### PR TITLE
Unblock hero launch video assets on Vercel

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -37,5 +37,3 @@ web/assets/video/supercompress-lovable.mp4
 models
 models/**
 launch-video/**
-video
-video/**

--- a/web/index.html
+++ b/web/index.html
@@ -35,10 +35,10 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
-  <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=4" as="image" fetchpriority="high" />
-  <link rel="preload" href="/assets/video/launch-post.mp4?v=4" as="video" type="video/mp4" />
-  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=3" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=3" />
+  <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=5" as="image" fetchpriority="high" />
+  <link rel="preload" href="/assets/video/launch-post.mp4?v=5" as="video" type="video/mp4" />
+  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=5" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=5" />
 
 
 <!-- Preconnect hints for faster external resource loading -->
@@ -146,10 +146,10 @@
     "@type": "VideoObject",
     "name": "SuperCompress Launch Video — LLM Token Compression",
     "description": "SuperCompress reduces input tokens before LLM inference for chatbots, AI search, support agents, copilots, RAG, and agent workflows.",
-    "thumbnailUrl": "https://supercompress.dev/assets/video/launch-post-poster.jpg?v=4",
+    "thumbnailUrl": "https://supercompress.dev/assets/video/launch-post-poster.jpg?v=5",
     "uploadDate": "2026-07-24",
     "duration": "PT46S",
-    "contentUrl": "https://supercompress.dev/assets/video/launch-post.mp4?v=4",
+    "contentUrl": "https://supercompress.dev/assets/video/launch-post.mp4?v=5",
     "publisher": {
       "@type": "Organization",
       "name": "SuperCompress"
@@ -289,8 +289,8 @@
           <div class="hero-frame is-live" id="launch-video-frame">
             <canvas class="dither-canvas micro-dither hero-dither" data-dither="compress" aria-hidden="true"></canvas>
             <div class="hero-frame-embed">
-              <img class="hero-frame-poster" src="/assets/video/launch-post-poster.jpg?v=4" alt="SuperCompress launch video preview" width="1280" height="720" loading="eager" fetchpriority="high" />
-              <video class="hero-frame-video" src="/assets/video/launch-post.mp4?v=4" autoplay muted loop playsinline preload="auto" poster="/assets/video/launch-post-poster.jpg?v=4"></video>
+              <img class="hero-frame-poster" src="/assets/video/launch-post-poster.jpg?v=5" alt="SuperCompress launch video preview" width="1280" height="720" loading="eager" fetchpriority="high" />
+              <video class="hero-frame-video" src="/assets/video/launch-post.mp4?v=5" autoplay muted loop playsinline preload="auto" poster="/assets/video/launch-post-poster.jpg?v=5"></video>
             </div>
             <div class="launch-video-unmute">
               <button type="button" class="launch-video-sound" id="launch-video-sound" aria-label="Unmute launch video">Unmute</button>
@@ -743,7 +743,7 @@
 
   <script src="/assets/js/vendor/gsap/gsap.min.js"></script>
   <script src="/assets/js/vendor/gsap/ScrollTrigger.min.js"></script>
-<script src="/assets/js/landing-app.js?v=3"></script>
+<script src="/assets/js/landing-app.js?v=5"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove overly broad `video` ignore that matched `web/assets/video`
- Keep shipping `launch-post.mp4` + real poster for the homepage hero

## Test plan
- [ ] `https://www.supercompress.dev/assets/video/launch-post.mp4` returns 200
- [ ] Hero plays the launch video instead of the hands still


Made with [Cursor](https://cursor.com)