### PR TITLE
Unify header and footer chrome sitewide from landing

### DIFF
--- a/scripts/sync_site_chrome.py
+++ b/scripts/sync_site_chrome.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Apply landing-page header/footer chrome to every public HTML page."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WEB = ROOT / "web"
+HEADER = (WEB / "assets/partials/site-header.html").read_text()
+FOOTER = (WEB / "assets/partials/site-footer.html").read_text()
+# Strip comment markers for injection body
+HEADER_HTML = re.sub(r"<!-- SITE_HEADER_(?:START|END) -->\n?", "", HEADER).strip() + "\n"
+FOOTER_HTML = re.sub(r"<!-- SITE_FOOTER_(?:START|END) -->\n?", "", FOOTER).strip() + "\n"
+
+SKIP = {
+    "web/assets/partials/site-header.html",
+    "web/assets/partials/site-footer.html",
+    "web/logo-dots.html",
+}
+
+CHROME_CSS = '<link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />'
+CHROME_JS = '<script src="/assets/js/site-chrome.js?v=6"></script>'
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def ensure_chrome_css(html: str) -> str:
+    if "landing-chrome.css" in html:
+        return re.sub(
+            r'<link rel="stylesheet" href="/assets/css/landing-chrome\.css\?v=\d+"\s*/?>',
+            CHROME_CSS,
+            html,
+            count=1,
+        )
+    # Insert after last stylesheet link in head, else before </head>
+    links = list(re.finditer(r'<link[^>]+rel="stylesheet"[^>]*>', html, re.I))
+    if links:
+        last = links[-1]
+        return html[: last.end()] + "\n  " + CHROME_CSS + html[last.end() :]
+    return html.replace("</head>", f"  {CHROME_CSS}\n</head>", 1)
+
+
+def ensure_chrome_js(html: str) -> str:
+    if "site-chrome.js" in html:
+        return re.sub(
+            r'<script src="/assets/js/site-chrome\.js\?v=\d+"></script>',
+            CHROME_JS,
+            html,
+        )
+    if "</body>" in html:
+        return html.replace("</body>", f"  {CHROME_JS}\n</body>", 1)
+    return html + "\n" + CHROME_JS + "\n"
+
+
+def page_hrefs(page: Path) -> set[str]:
+    path = "/" + str(page.relative_to(WEB)).replace("\\", "/")
+    if path.endswith("/index.html"):
+        path = path[: -len("index.html")]
+    elif path.endswith(".html"):
+        path = path[: -len(".html")]
+    path = path.rstrip("/") or "/"
+    hrefs = {path, path + "/"}
+    if path == "/index":
+        hrefs.update({"/", "/index", "/index/"})
+    return hrefs
+
+
+def mark_current(html: str, page: Path) -> str:
+    """Add aria-current to matching nav links for this page."""
+    targets = page_hrefs(page)
+
+    def repl(m: re.Match) -> str:
+        href = m.group(1)
+        tag = m.group(0)
+        if "aria-current" in tag:
+            return tag
+        if href.startswith("http") or href.startswith("/#"):
+            return tag
+        norm = href.rstrip("/") or "/"
+        if norm in {t.rstrip("/") or "/" for t in targets}:
+            return tag[:-1] + ' aria-current="page">'
+        return tag
+
+    return re.sub(r'<a href="([^"]+)"[^>]*>', repl, html)
+
+
+def replace_header(html: str) -> str:
+    # Remove existing df-header (+ spacer)
+    html2, n = re.subn(
+        r'<header class="df-header">.*?</header>\s*(?:<div class="df-header-spacer"[^>]*></div>\s*)?',
+        HEADER_HTML,
+        html,
+        count=1,
+        flags=re.S,
+    )
+    if n:
+        return html2
+
+    # Remove sc-nav
+    html2, n = re.subn(
+        r'<nav class="sc-nav">.*?</nav>\s*',
+        HEADER_HTML,
+        html,
+        count=1,
+        flags=re.S,
+    )
+    if n:
+        return html2
+
+    # Playground-style bare header
+    html2, n = re.subn(
+        r"<header>\s*<h1>[\s\S]*?</header>\s*",
+        HEADER_HTML,
+        html,
+        count=1,
+    )
+    if n:
+        return html2
+
+    # Docs top nav — keep layout but inject site header before docs-layout
+    if 'class="docs-layout"' in html and 'class="df-header"' not in html:
+        html = html.replace(
+            '<div class="docs-layout">',
+            HEADER_HTML + '<div class="docs-layout">',
+            1,
+        )
+        # Replace docs pill links with landing set
+        html = re.sub(
+            r'<nav class="docs-nav-pill"[^>]*>.*?</nav>',
+            """<nav class="docs-nav-pill" aria-label="Main">
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
+              <a href="/blog">Blog</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
+            </nav>""",
+            html,
+            count=1,
+            flags=re.S,
+        )
+        return html
+
+    # SEO / pages with no header — insert after <body...>
+    if 'class="df-header"' not in html:
+        html = re.sub(
+            r"(<body[^>]*>)",
+            r"\1\n" + HEADER_HTML,
+            html,
+            count=1,
+            flags=re.I,
+        )
+    return html
+
+
+def replace_footer(html: str) -> str:
+    html2, n = re.subn(
+        r"<footer class=\"df-footer\">.*?</footer>",
+        FOOTER_HTML.rstrip(),
+        html,
+        count=1,
+        flags=re.S,
+    )
+    if n:
+        return html2
+
+    # Generic footer tags
+    html2, n = re.subn(
+        r"<footer\b[^>]*>.*?</footer>",
+        FOOTER_HTML.rstrip(),
+        html,
+        count=1,
+        flags=re.S,
+    )
+    if n:
+        return html2
+
+    # Insert before chrome js / body end
+    if 'class="df-footer"' not in html:
+        if CHROME_JS in html:
+            return html.replace(CHROME_JS, FOOTER_HTML + "  " + CHROME_JS, 1)
+        if "</body>" in html:
+            return html.replace("</body>", FOOTER_HTML + "</body>", 1)
+    return html
+
+
+def strip_seo_chrome_nav(html: str) -> str:
+    """Remove in-page seo-nav that duplicates site header links."""
+    return re.sub(
+        r'\s*<nav class="seo-nav"[^>]*>.*?</nav>\s*',
+        "\n",
+        html,
+        count=1,
+        flags=re.S,
+    )
+
+
+def process(path: Path) -> bool:
+    rel_path = rel(path)
+    if rel_path in SKIP:
+        return False
+    original = path.read_text(encoding="utf-8", errors="ignore")
+    html = original
+    html = ensure_chrome_css(html)
+    html = replace_header(html)
+    html = strip_seo_chrome_nav(html)
+    html = replace_footer(html)
+    html = ensure_chrome_js(html)
+    # Index: keep in-page #agents as /#agents already in partial; sync index header too
+    if path.name == "index.html" and path.parent == WEB:
+        html = html.replace('href="#agents"', 'href="/#agents"')
+    html = mark_current(html, path)
+    if html != original:
+        path.write_text(html, encoding="utf-8")
+        return True
+    return False
+
+
+def main() -> None:
+    changed = []
+    for path in sorted(WEB.rglob("*.html")):
+        if "partials" in path.parts:
+            continue
+        if process(path):
+            changed.append(rel(path))
+    print(f"updated {len(changed)} pages")
+    for c in changed:
+        print(" ", c)
+
+
+if __name__ == "__main__":
+    main()

--- a/web/404.html
+++ b/web/404.html
@@ -20,6 +20,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=118" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .nf-page {
       position: relative;
@@ -242,6 +243,49 @@
   <script defer src="/_vercel/insights/script.js"></script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <div class="nf-page">
     <div class="nf-hands" aria-hidden="true">
       <img src="/assets/img/hero-stipple-hands.jpg?v=1" alt="" width="1920" height="1080" decoding="async" />
@@ -305,5 +349,68 @@
       if (cut) cut.textContent = "100% · " + path + " not found";
     })();
   </script>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/affiliates.html
+++ b/web/affiliates.html
@@ -23,6 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <meta name="theme-color" content="rgb(251,251,248)" />
   <link rel="stylesheet" href="assets/css/supercompress.css?v=110" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     /* ── Affiliate self-serve page ── */
     .aff-hero {
@@ -465,39 +466,41 @@
         <span class="df-logo-word">Super<em>Compress</em></span>
       </a>
       <div class="df-header-end">
-        <nav class="df-nav-pill" aria-label="Affiliates">
-          <a href="#how-it-works">How it works</a>
-          <a href="#commissions">Commissions</a>
-          <a href="/affiliate-creator-kit">Creator kit</a>
-          <a href="#signup">Join now</a>
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
         </nav>
         <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M23.6004 9.5927l-.0337-.0862L20.3.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412l-3.935 8.604H8.924L4.989.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412L.434 9.5065l-.032.0862c-.468 1.228-.148 2.628.804 3.55l.008.008.022.02 6.044 4.533-.032.024 5.735 4.36 5.735-4.36-.033-.024 6.045-4.533.022-.02.008-.008c.95-.922 1.27-2.322.803-3.55z"/>
-          </svg>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
       </div>
       <div class="df-mobile-bar">
         <a href="/" class="df-logo-mobile">
-          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="22" height="22" />
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
           <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
         </a>
-        <button type="button" class="df-menu-btn" id="df-menu-btn" aria-label="Toggle menu" aria-expanded="false">
-          <span></span><span></span>
-        </button>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
       </div>
     </div>
-    <div class="df-mobile-nav hidden" id="df-mobile-nav">
-      <a href="#how-it-works">How it works</a>
-      <a href="#commissions">Commissions</a>
-      <a href="/affiliate-creator-kit">Creator kit</a>
-      <a href="#signup">Join now</a>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
     </div>
   </header>
-
   <div class="df-header-spacer" aria-hidden="true"></div>
-
-  <!-- Hero -->
+<!-- Hero -->
   <section class="aff-hero">
     <div class="aff-hero-inner">
       <p class="aff-hero-label">Affiliate Program</p>
@@ -790,5 +793,68 @@
       });
     })();
   </script>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/agent-memory-compression.html
+++ b/web/agent-memory-compression.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,18 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Agent patterns</p>
     <h1>Agent memory compression</h1>
     <p class="seo-lead">Agent memory stores facts about users, tasks, and previous interactions. Over time, this memory grows beyond any context window. Compression keeps the most relevant memories for each new interaction.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Memory is unbounded</h2>
         <p>An agent serving customers might accumulate 100+ facts per customer: preferences, account details, issue history, resolved tickets. Sending all 100 facts with every new query is expensive and dilutes focus. Compression keeps only the facts relevant to the current query.</p>
       </section>
@@ -108,5 +146,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/ai-search.html
+++ b/web/ai-search.html
@@ -23,6 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="assets/css/content-shell.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .ai-search-page { font-family: var(--shell-sans); }
     .ai-search-hero h2 { margin: 0 0 8px; font-size: 1.25rem; line-height: 1.25; }
@@ -93,6 +94,49 @@
   </script>
 </head>
 <body class="sc-shell-page">
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <header class="sc-topbar">
     <h1>Super<em>Compress</em> AI search facts</h1>
     <nav>
@@ -186,5 +230,68 @@
       </ul>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/aiscore.html
+++ b/web/aiscore.html
@@ -12,8 +12,52 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/aiscore.css?v=3" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <div class="score-noise" aria-hidden="true"></div>
   <header class="score-header">
     <a class="score-logo" href="/" aria-label="SuperCompress home">
@@ -67,7 +111,69 @@
     </section>
 
   </main>
-  <footer class="score-footer"><span>Super<em>Compress</em></span><span>AI Score is a private assessment tool.</span><a href="/">Back to supercompress.dev ↗</a></footer>
+  <footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
   <script src="/assets/js/aiscore.js?v=3"></script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/assets/css/landing-chrome.css
+++ b/web/assets/css/landing-chrome.css
@@ -1,5 +1,23 @@
+@import url("https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap");
+@font-face {
+  font-family: "Geist";
+  src: url("https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/Geist-Regular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Geist";
+  src: url("https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/Geist-Medium.woff2") format("woff2");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
 /* Header + footer chrome from this site, mapped to local tokens */
 :root {
+  --max-w: 1400px;
+  --serif: "Platypi", "EB Garamond", Georgia, serif;
+  --sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --frame-buffer: clamp(16px, 4vw, 40px);
   --nav-h: 72px;
   --text-primary: #171717;

--- a/web/assets/js/site-chrome.js
+++ b/web/assets/js/site-chrome.js
@@ -1,0 +1,32 @@
+(() => {
+  const header = document.querySelector(".df-header");
+  if (header) {
+    const sync = () => header.classList.toggle("is-scrolled", window.scrollY > 12);
+    window.addEventListener("scroll", sync, { passive: true });
+    sync();
+  }
+
+  const btn = document.querySelector(".df-menu-btn");
+  const nav = document.getElementById("df-mobile-nav");
+  if (!btn || !nav) return;
+
+  const close = () => {
+    nav.classList.remove("is-open");
+    nav.classList.add("hidden");
+    btn.setAttribute("aria-expanded", "false");
+  };
+  const open = () => {
+    nav.classList.add("is-open");
+    nav.classList.remove("hidden");
+    btn.setAttribute("aria-expanded", "true");
+  };
+
+  btn.addEventListener("click", () => {
+    if (nav.classList.contains("is-open")) close();
+    else open();
+  });
+  nav.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") close();
+  });
+})();

--- a/web/assets/partials/site-footer.html
+++ b/web/assets/partials/site-footer.html
@@ -1,64 +1,64 @@
 <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->

--- a/web/assets/partials/site-header.html
+++ b/web/assets/partials/site-header.html
@@ -1,0 +1,44 @@
+<!-- SITE_HEADER_START -->
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<!-- SITE_HEADER_END -->

--- a/web/benchmarks.html
+++ b/web/benchmarks.html
@@ -27,6 +27,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .bench-head { text-align: center; padding: 60px 20px 20px; max-width: 860px; margin: 0 auto; }
     .bench-head h1 { font-family: var(--serif); font-weight: 300; font-size: 2.6rem; line-height: 1.15; }
@@ -197,27 +198,48 @@
 
   <div class="df-page">
     <header class="df-header">
-      <div class="df-header-blur" aria-hidden="true"></div>
-      <div class="df-header-inner">
-        <a href="/" class="df-logo-desktop">
-          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-          <span class="df-logo-word">Super<em>Compress</em></span>
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks" aria-current="page">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
-        <div class="df-header-end">
-          <nav class="df-nav-pill" aria-label="Main">
-            <a href="/">Home</a>
-            <a href="/playground">Playground</a>
-          </nav>
-          <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
-            <a href="/dashboard">Dashboard</a>
-          </nav>
-        </div>
       </div>
-    </header>
-
-    <div class="df-header-spacer" aria-hidden="true"></div>
-
-    <main>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks" aria-current="page">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<main>
       <div class="bench-head">
         <div class="bench-kicker"><strong>Updated 2026-07-29</strong> · held-out answer containment · live compiler workloads</div>
         <h1>Keep the answer. Drop the noise.</h1>
@@ -595,67 +617,67 @@
 
     <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks" aria-current="page">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks" aria-current="page">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -675,5 +697,6 @@
       <span style="background: rgba(255,255,255,0.08); padding: 2px 8px; border-radius: 20px; font-size: 12px;">★</span>
     </a>
   </div>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/blog.html
+++ b/web/blog.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     /* ── Blog-specific overrides ── */
 
@@ -284,48 +285,48 @@
   <div class="df-page">
     <!-- Header -->
     <header class="df-header">
-      <div class="df-header-blur" aria-hidden="true"></div>
-      <div class="df-header-inner">
-        <a href="/" class="df-logo-desktop">
-          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-          <span class="df-logo-word">Super<em>Compress</em></span>
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog" aria-current="page">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
-        <div class="df-header-end">
-          <nav class="df-nav-pill" aria-label="Main">
-            <a href="/">Home</a>
-            <a href="/token-compression">Guide</a>
-            <a href="/dashboard">Dashboard</a>
-            <a href="/docs/" target="_blank" rel="noopener">Docs</a>
-            <a href="/playground">Playground</a>
-          </nav>
-          <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M23.6004 9.5927l-.0337-.0862L20.3.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412l-3.935 8.604H8.924L4.989.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412L.434 9.5065l-.032.0862c-.468 1.228-.148 2.628.804 3.55l.008.008.022.02 6.044 4.533-.032.024 5.735 4.36 5.735-4.36-.033-.024 6.045-4.533.022-.02.008-.008c.95-.922 1.27-2.322.803-3.55z"/>
-            </svg>
-          </a>
-        </div>
-        <div class="df-mobile-bar">
-          <a href="/" class="df-logo-mobile">
-            <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="22" height="22" />
-            <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
-          </a>
-          <button type="button" class="df-menu-btn" id="df-menu-btn" aria-label="Toggle menu" aria-expanded="false">
-            <span></span><span></span>
-          </button>
-        </div>
       </div>
-      <div class="df-mobile-nav hidden" id="df-mobile-nav">
-        <a href="/">Home</a>
-        <a href="/token-compression">Guide</a>
-        <a href="/dashboard">Dashboard</a>
-        <a href="/docs/" target="_blank" rel="noopener">Docs</a>
-        <a href="/playground">Playground</a>
-        <a href="https://github.com/Supercompress/Supercompress">GitHub</a>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
       </div>
-    </header>
-    <div class="df-header-spacer" aria-hidden="true"></div>
-
-    <div class="df-main-wrap">
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog" aria-current="page">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="df-main-wrap">
       <main class="df-main">
 
         <!-- Hero -->
@@ -1335,67 +1336,67 @@
       <!-- Footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog" aria-current="page">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
 
     </div>
@@ -1458,5 +1459,6 @@
       });
     }
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/cache-aligner-prefix-stabilization.html
+++ b/web/cache-aligner-prefix-stabilization.html
@@ -23,6 +23,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=106" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; background: #fbfbf8; color: #141412; line-height: 1.7; }
     .post-header { max-width: 760px; margin: 0 auto; padding: 48px 24px 24px; }
@@ -61,6 +62,49 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <nav class="nav-bar">
     <a href="/" class="brand">Super<em>Compress</em></a>
     <a href="/blog">Blog</a>
@@ -220,5 +264,68 @@ console.log(wrapped);         // Fully wrapped output, ready to send to any LLM<
       <li>Cache hit rate reporting through the API response</li>
     </ul>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -22,6 +22,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=116" />
   <link rel="stylesheet" href="/assets/css/sc-sm.css?v=4" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     /* Changelog uses sc-nav chrome from sc-sm + df-footer from supercompress.css */
     body { background: var(--bg, #fff); }
@@ -159,31 +160,49 @@
   </style>
 </head>
 <body>
-  <nav class="sc-nav">
-    <div class="sc-nav-inner">
-      <a class="sc-brand" href="/">
-        <img src="/assets/img/logo-chevrons.png" alt="" width="22" height="22" />
-        <span>supercompress</span>
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
       </a>
-      <div class="sc-nav-links">
-        <a href="/#coding-agents">Agents</a>
-        <a href="/benchmarks">Benchmarks</a>
-        <a href="/docs/">Docs</a>
-        <a href="/changelog" aria-current="page">Changelog</a>
-      </div>
-      <div class="sc-nav-end">
-        <a class="sc-login" href="/dashboard">Login</a>
-        <a class="btn-primary btn-primary-sm" href="/playground">
-          <span class="btn-primary-label">Try playground</span>
-          <span class="btn-primary-arrow" aria-hidden="true">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M3 7h8m0 0L7.5 3.5M11 7l-3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          </span>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog" aria-current="page">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
       </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
     </div>
-  </nav>
-
-  <main class="cl-page">
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog" aria-current="page">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<main class="cl-page">
     <header class="cl-hero">
       <p class="cl-kicker">Releases</p>
       <h1>What’s <em>new</em>.</h1>
@@ -333,67 +352,68 @@
 
   <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog" aria-current="page">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog" aria-current="page">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/coding-agent-proxy.html
+++ b/web/coding-agent-proxy.html
@@ -21,6 +21,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/style.css?v=110" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     /* ── Blog article styles ── */
     .article-page {
@@ -272,42 +273,48 @@
   <div class="df-page">
     <!-- Header -->
     <header class="df-header">
-      <div class="df-header-blur" aria-hidden="true"></div>
-      <div class="df-header-inner">
-        <a href="/" class="df-logo-desktop">
-          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-          <span class="df-logo-word">Super<em>Compress</em></span>
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
-        <div class="df-header-end">
-          <nav class="df-nav-pill" aria-label="Main">
-            <a href="/">Home</a>
-            <a href="/token-compression">Guide</a>
-            <a href="/dashboard">Dashboard</a>
-            <a href="/docs/" target="_blank" rel="noopener">Docs</a>
-            <a href="/playground">Playground</a>
-          </nav>
-        </div>
-        <div class="df-mobile-bar">
-          <a href="/" class="df-logo-mobile">
-            <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="22" height="22" />
-            <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
-          </a>
-          <button type="button" class="df-menu-btn" id="df-menu-btn" aria-label="Toggle menu" aria-expanded="false">
-            <span></span><span></span>
-          </button>
-        </div>
       </div>
-      <div class="df-mobile-nav hidden" id="df-mobile-nav">
-        <a href="/">Home</a>
-        <a href="/token-compression">Guide</a>
-        <a href="/dashboard">Dashboard</a>
-        <a href="/docs/" target="_blank" rel="noopener">Docs</a>
-        <a href="/playground">Playground</a>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
       </div>
-    </header>
-    <div class="df-header-spacer" aria-hidden="true"></div>
-
-    <div class="df-main-wrap">
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="df-main-wrap">
       <main class="df-main article-page">
 
         <!-- Hero -->
@@ -497,67 +504,67 @@
       <!-- Footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
 
     </div>
@@ -575,5 +582,6 @@
     }
   </script>
   <script src="/assets/js/supercompress.js?v=12"></script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/compare.html
+++ b/web/compare.html
@@ -322,8 +322,52 @@
     "license": "https://opensource.org/licenses/MIT"
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <div class="header" style="padding-top:40px;">
   <div style="text-align:center;background:linear-gradient(135deg,rgba(37,99,235,0.08),rgba(124,58,237,0.08));border-bottom:1px solid #1a1a1a;padding:8px 20px;font-size:13px;color:#94a3b8;">
     <span style="color:#60a5fa;font-weight:600;">pip install supercompress</span>
@@ -626,5 +670,68 @@ Response Format:
     // Load default preset
     loadPreset('rag');
   </script>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/context-compression.html
+++ b/web/context-compression.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,20 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Context compression guide</p>
     <h1>Context compression for agents and RAG</h1>
     <p class="seo-lead">Context compression turns oversized agent memory, retrieved documents, and logs into a smaller context that still answers the user&#x27;s question.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Why agents need context compression</h2>
         <p>AI agents accumulate context with every turn: conversation history, tool call results, code outputs. After 5-10 turns, a typical agent prompt can exceed 10,000 tokens.</p>
 <p>Without context compression, cost balloons, latency increases, and quality degrades as the model sifts through noise.</p>
@@ -122,5 +158,68 @@ def rag_with_compression(query, retriever, llm):
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression" aria-current="page">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -27,6 +27,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <meta name="theme-color" content="rgb(251,251,248)" />
   <link rel="stylesheet" href="assets/css/supercompress.css?v=102" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     /* Dashboard: no dark bg layers, full light page */
     html, body.dash-page {
@@ -401,57 +402,48 @@
 
   <div class="df-page-inner">
     <header class="df-header">
-      <div class="df-header-blur" aria-hidden="true"></div>
-      <div class="df-header-inner">
-        <a href="/" class="df-logo-desktop">
-          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-          <span class="df-logo-word">Super<em>Compress</em></span>
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard" aria-current="page">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
-
-        <div class="df-header-end">
-          <nav class="df-nav-pill" aria-label="Dashboard">
-            <a href="/">Home</a>
-            <a href="/docs/" target="_blank" rel="noopener">Docs</a>
-            <a href="/docs/api-reference" target="_blank" rel="noopener">API reference</a>
-          </nav>
-          <div class="dash-profile hidden" id="dash-profile">
-            <button type="button" class="dash-profile-btn" id="dash-profile-btn" aria-label="Account menu">
-              <span class="dash-profile-initial" id="dash-profile-initial">?</span>
-            </button>
-            <div class="dash-profile-dropdown">
-              <div class="dash-profile-dropdown-name" id="dash-profile-name">—</div>
-              <div class="dash-profile-dropdown-email" id="dash-profile-email">—</div>
-              <button type="button" class="dash-profile-signout" id="dash-signout">Sign out</button>
-            </div>
-          </div>
-          <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M23.6004 9.5927l-.0337-.0862L20.3.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412l-3.935 8.604H8.924L4.989.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412L.434 9.5065l-.032.0862c-.468 1.228-.148 2.628.804 3.55l.008.008.022.02 6.044 4.533-.032.024 5.735 4.36 5.735-4.36-.033-.024 6.045-4.533.022-.02.008-.008c.95-.922 1.27-2.322.803-3.55z"/>
-            </svg>
-          </a>
-        </div>
-
-        <div class="df-mobile-bar">
-          <a href="/" class="df-logo-mobile">
-            <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="22" height="22" />
-            <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
-          </a>
-          <button type="button" class="df-menu-btn" id="df-menu-btn" aria-label="Toggle menu" aria-expanded="false">
-            <span></span><span></span>
-          </button>
-        </div>
       </div>
-      <div class="df-mobile-nav hidden" id="df-mobile-nav">
-        <a href="/">Home</a>
-        <a href="/docs/" target="_blank" rel="noopener">Docs</a>
-        <a href="/docs/api-reference" target="_blank" rel="noopener">API reference</a>
-        <a href="https://github.com/Supercompress/Supercompress">GitHub</a>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
       </div>
-    </header>
-
-    <div class="df-header-spacer" aria-hidden="true"></div>
-
-    <!-- Auth -->
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard" aria-current="page">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<!-- Auth -->
     <section class="dash-auth" id="view-auth">
       <div class="dash-auth-card">
         <p class="dash-section-label">API Dashboard</p>
@@ -762,5 +754,68 @@ npm exec supercompress setup</pre>
   <script src="assets/js/supercompress.js?v=1"></script>
   <script type="module" src="assets/js/dashboard-api.js?v=14"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard" aria-current="page">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/api-reference.html
+++ b/web/docs/api-reference.html
@@ -18,9 +18,52 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <aside class="docs-sidebar" id="docs-sidebar">
       <a href="/docs/" class="docs-sidebar-logo">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="18" height="18" />
@@ -30,7 +73,7 @@
       <a href="/docs/" class="docs-sidebar-link">Overview</a>
       <a href="/docs/quickstart" class="docs-sidebar-link">Quickstart</a>
       <div class="docs-sidebar-section">Reference</div>
-      <a href="/docs/api-reference" class="docs-sidebar-link active">API Reference</a>
+      <a href="/docs/api-reference" class="docs-sidebar-link active" aria-current="page">API Reference</a>
       <a href="/docs/integrations" class="docs-sidebar-link">Integrations</a>
       <a href="/docs/coding-agents" class="docs-sidebar-link">Coding Agents</a>
       <a href="/docs/usage" class="docs-sidebar-link">Usage</a>
@@ -46,12 +89,11 @@
           <button class="docs-mobile-toggle" id="mobile-toggle" aria-label="Toggle sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/></svg><span>Docs</span></button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -312,67 +354,67 @@ impact = sustainability_from_tokens_saved(saved)
       <!-- Full SuperCompress footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference" aria-current="page">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -406,5 +448,6 @@ impact = sustainability_from_tokens_saved(saved)
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/architecture.html
+++ b/web/docs/architecture.html
@@ -18,9 +18,52 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <aside class="docs-sidebar" id="docs-sidebar">
       <a href="/docs/" class="docs-sidebar-logo">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="18" height="18" />
@@ -35,7 +78,7 @@
       <a href="/docs/coding-agents" class="docs-sidebar-link">Coding Agents</a>
       <a href="/docs/usage" class="docs-sidebar-link">Usage</a>
       <div class="docs-sidebar-section">Deep dives</div>
-      <a href="/docs/architecture" class="docs-sidebar-link active">Architecture</a>
+      <a href="/docs/architecture" class="docs-sidebar-link active" aria-current="page">Architecture</a>
       <a href="/docs/environment" class="docs-sidebar-link">Environment & CO₂</a>
     </aside>
     <div class="docs-sidebar-overlay" id="sidebar-overlay"></div>
@@ -46,12 +89,11 @@
           <button class="docs-mobile-toggle" id="mobile-toggle" aria-label="Toggle sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/></svg><span>Docs</span></button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -197,67 +239,67 @@
       <!-- Full SuperCompress footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -291,5 +333,6 @@
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/coding-agents.html
+++ b/web/docs/coding-agents.html
@@ -18,9 +18,52 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <aside class="docs-sidebar" id="docs-sidebar">
       <a href="/docs/" class="docs-sidebar-logo">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="18" height="18" />
@@ -32,7 +75,7 @@
       <div class="docs-sidebar-section">Reference</div>
       <a href="/docs/api-reference" class="docs-sidebar-link">API Reference</a>
       <a href="/docs/integrations" class="docs-sidebar-link">Integrations</a>
-      <a href="/docs/coding-agents" class="docs-sidebar-link active">Coding Agents</a>
+      <a href="/docs/coding-agents" class="docs-sidebar-link active" aria-current="page">Coding Agents</a>
       <a href="/docs/usage" class="docs-sidebar-link">Usage</a>
       <a href="/changelog" class="docs-sidebar-link">Changelog</a>
       <div class="docs-sidebar-section">Deep dives</div>
@@ -50,12 +93,11 @@
           </button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -197,67 +239,67 @@
 
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents" aria-current="page">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents" aria-current="page">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
     </div>
   </div>
@@ -293,5 +335,6 @@
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/environment.html
+++ b/web/docs/environment.html
@@ -18,9 +18,52 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <aside class="docs-sidebar" id="docs-sidebar">
       <a href="/docs/" class="docs-sidebar-logo">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="18" height="18" />
@@ -36,7 +79,7 @@
       <a href="/docs/usage" class="docs-sidebar-link">Usage</a>
       <div class="docs-sidebar-section">Deep dives</div>
       <a href="/docs/architecture" class="docs-sidebar-link">Architecture</a>
-      <a href="/docs/environment" class="docs-sidebar-link active">Environment & CO2</a>
+      <a href="/docs/environment" class="docs-sidebar-link active" aria-current="page">Environment & CO2</a>
     </aside>
     <div class="docs-sidebar-overlay" id="sidebar-overlay"></div>
 
@@ -46,12 +89,11 @@
           <button class="docs-mobile-toggle" id="mobile-toggle" aria-label="Toggle sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/></svg><span>Docs</span></button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -171,67 +213,67 @@ impact = sustainability_from_tokens_saved(saved)
       <!-- Full SuperCompress footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -265,5 +307,6 @@ impact = sustainability_from_tokens_saved(saved)
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -22,18 +22,61 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/" aria-current="page">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/" aria-current="page">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <!-- Sidebar -->
     <aside class="docs-sidebar" id="docs-sidebar">
-      <a href="/docs/" class="docs-sidebar-logo">
+      <a href="/docs/" class="docs-sidebar-logo" aria-current="page">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="18" height="18" />
         <span class="docs-sidebar-logo-word">Super<em>Compress</em></span>
       </a>
 
       <div class="docs-sidebar-section">Getting started</div>
-      <a href="/docs/" class="docs-sidebar-link active">
+      <a href="/docs/" class="docs-sidebar-link active" aria-current="page">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 4l6-3 6 3v9l-6 3-6-3z"/><path d="M2 4l6 3"/><path d="M14 4l-6 3"/><path d="M8 7v9"/></svg>
         Overview
       </a>
@@ -84,12 +127,11 @@
           </button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/" aria-current="page">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -197,67 +239,67 @@
       <!-- Full SuperCompress footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/" aria-current="page">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/" aria-current="page">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
     </div>
   </div>
@@ -313,5 +355,6 @@
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/integrations.html
+++ b/web/docs/integrations.html
@@ -18,9 +18,52 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <aside class="docs-sidebar" id="docs-sidebar">
       <a href="/docs/" class="docs-sidebar-logo">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="18" height="18" />
@@ -31,7 +74,7 @@
       <a href="/docs/quickstart" class="docs-sidebar-link">Quickstart</a>
       <div class="docs-sidebar-section">Reference</div>
       <a href="/docs/api-reference" class="docs-sidebar-link">API Reference</a>
-      <a href="/docs/integrations" class="docs-sidebar-link active">Integrations</a>
+      <a href="/docs/integrations" class="docs-sidebar-link active" aria-current="page">Integrations</a>
       <a href="/docs/coding-agents" class="docs-sidebar-link">Coding Agents</a>
       <a href="/docs/usage" class="docs-sidebar-link">Usage</a>
       <div class="docs-sidebar-section">Deep dives</div>
@@ -46,12 +89,11 @@
           <button class="docs-mobile-toggle" id="mobile-toggle" aria-label="Toggle sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/></svg><span>Docs</span></button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -273,67 +315,67 @@ app.post(<span class="str">"/api/chat"</span>, sc.handler, <span class="kw">asyn
       <!-- Full SuperCompress footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -367,5 +409,6 @@ app.post(<span class="str">"/api/chat"</span>, sc.handler, <span class="kw">asyn
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/quickstart.html
+++ b/web/docs/quickstart.html
@@ -20,9 +20,52 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <!-- Sidebar (same as index) -->
     <aside class="docs-sidebar" id="docs-sidebar">
       <a href="/docs/" class="docs-sidebar-logo">
@@ -31,7 +74,7 @@
       </a>
       <div class="docs-sidebar-section">Getting started</div>
       <a href="/docs/" class="docs-sidebar-link">Overview</a>
-      <a href="/docs/quickstart" class="docs-sidebar-link active">Quickstart</a>
+      <a href="/docs/quickstart" class="docs-sidebar-link active" aria-current="page">Quickstart</a>
       <div class="docs-sidebar-section">Reference</div>
       <a href="/docs/api-reference" class="docs-sidebar-link">API Reference</a>
       <a href="/docs/integrations" class="docs-sidebar-link">Integrations</a>
@@ -52,12 +95,11 @@
           </button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -204,67 +246,67 @@ out = sc.compress(context, question)
       <!-- Full SuperCompress footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart" aria-current="page">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -301,5 +343,6 @@ out = sc.compress(context, question)
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/docs/usage.html
+++ b/web/docs/usage.html
@@ -18,9 +18,52 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css" />
   <link rel="stylesheet" href="/assets/css/docs.css" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <div class="docs-layout">
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<div class="docs-layout">
     <aside class="docs-sidebar" id="docs-sidebar">
       <a href="/docs/" class="docs-sidebar-logo">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="18" height="18" />
@@ -33,7 +76,7 @@
       <a href="/docs/api-reference" class="docs-sidebar-link">API Reference</a>
       <a href="/docs/integrations" class="docs-sidebar-link">Integrations</a>
       <a href="/docs/coding-agents" class="docs-sidebar-link">Coding Agents</a>
-      <a href="/docs/usage" class="docs-sidebar-link active">Usage</a>
+      <a href="/docs/usage" class="docs-sidebar-link active" aria-current="page">Usage</a>
       <div class="docs-sidebar-section">Deep dives</div>
       <a href="/docs/architecture" class="docs-sidebar-link">Architecture</a>
       <a href="/docs/environment" class="docs-sidebar-link">Environment & CO₂</a>
@@ -46,12 +89,11 @@
           <button class="docs-mobile-toggle" id="mobile-toggle" aria-label="Toggle sidebar"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6h18"/><path d="M3 12h18"/><path d="M3 18h18"/></svg><span>Docs</span></button>
           <div class="docs-nav-end">
             <nav class="docs-nav-pill" aria-label="Main">
-              <a href="/">Home</a>
-              <a href="/token-compression">Guide</a>
+              <a href="/benchmarks">Benchmarks</a>
+              <a href="/#agents">Agents</a>
               <a href="/blog">Blog</a>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/playground">Playground</a>
-              <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+              <a href="/changelog">Changelog</a>
+              <a href="/docs/">Docs</a>
             </nav>
             <a href="/dashboard" class="docs-nav-cta">Get API key</a>
           </div>
@@ -163,67 +205,67 @@ from supercompress import compress_context</code></pre>
       <!-- Full SuperCompress footer -->
       <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -257,5 +299,6 @@ from supercompress import compress_context</code></pre>
       });
     })();
   </script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/domain-preprocessors.html
+++ b/web/domain-preprocessors.html
@@ -23,6 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="assets/css/content-shell.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .article-page { font-family: var(--shell-sans); }
     .article-hero { padding: 40px 0 24px; }
@@ -62,6 +63,49 @@
   </script>
 </head>
 <body class="sc-shell-page">
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <header class="sc-topbar">
     <h1>Super<em>Compress</em> blog</h1>
     <nav>
@@ -282,5 +326,68 @@ console.log(`Preprocessor: ${result.preprocessor}`); // "json", "code", "log", o
       <p><em>Domain preprocessors are available in SuperCompress v0.6+. <a href="/dashboard">Get your API key</a> or <a href="/playground">try the playground</a> — paste JSON, code, or logs and see the preprocessor in action.</em></p>
     </article>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/firecrawl-context-compression.html
+++ b/web/firecrawl-context-compression.html
@@ -19,6 +19,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=110" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -61,19 +62,54 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Integration guide</p>
     <h1>Compress Firecrawl results before they hit your LLM.</h1>
     <p class="seo-lead">Firecrawl is useful because it turns pages into model-ready content. The problem is that model-ready content can still be huge. SuperCompress runs between Firecrawl and the model, keeping query-relevant evidence while removing scraped noise.</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/dashboard?signup=1">Free API key</a>
-      <a href="/rag-token-optimization">RAG token optimization</a>
-      <a href="/langchain-prompt-compression">LangChain</a>
-      <a href="/benchmarks">Benchmarks</a>
-    </nav>
-
-    <section class="seo-section">
+<section class="seo-section">
       <h2>Where it fits</h2>
       <table class="seo-table">
         <thead><tr><th>Step</th><th>Without compression</th><th>With SuperCompress</th></tr></thead>
@@ -136,5 +172,68 @@ print(compressed.stats)</code></pre>
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard?signup=1&utm_source=seo&utm_medium=firecrawl_page&utm_campaign=gtm_execution">Get a free API key</a><a class="btn-link-muted" href="/#demo">Try the demo</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/how-prompt-compression-works.html
+++ b/web/how-prompt-compression-works.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,18 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Technical guide</p>
     <h1>How prompt compression works</h1>
     <p class="seo-lead">SuperCompress uses a learned policy of approximately 5,000 parameters — tiny compared to the LLMs it optimizes for. Here is how it works under the hood.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>The scoring policy</h2>
         <p>The compressor breaks your context into blocks and scores each block against the query. Blocks containing information likely to help answer the question get high scores. Blocks containing irrelevant information get low scores and are removed.</p>
 <p>The policy was trained on thousands of question-answering examples to learn what types of content matter for answering different kinds of questions.</p>
@@ -121,5 +159,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -38,7 +38,7 @@
   <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=5" as="image" fetchpriority="high" />
   <link rel="preload" href="/assets/video/launch-post.mp4?v=5" as="video" type="video/mp4" />
   <link rel="stylesheet" href="/assets/css/landing-motion.css?v=5" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=5" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 
 
 <!-- Preconnect hints for faster external resource loading -->
@@ -223,14 +223,14 @@
       <header class="df-header">
     <div class="df-header-blur" aria-hidden="true"></div>
     <div class="df-header-inner">
-      <a href="/" class="df-logo-desktop">
+      <a href="/" class="df-logo-desktop" aria-current="page">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
         <span class="df-logo-word">Super<em>Compress</em></span>
       </a>
       <div class="df-header-end">
         <nav class="df-nav-pill" aria-label="Main">
           <a href="/benchmarks">Benchmarks</a>
-          <a href="#agents">Agents</a>
+          <a href="/#agents">Agents</a>
           <a href="/blog">Blog</a>
           <a href="/changelog">Changelog</a>
           <a href="/docs/">Docs</a>
@@ -243,7 +243,7 @@
         </a>
       </div>
       <div class="df-mobile-bar">
-        <a href="/" class="df-logo-mobile">
+        <a href="/" class="df-logo-mobile" aria-current="page">
           <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
           <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
         </a>
@@ -252,7 +252,7 @@
     </div>
     <div class="df-mobile-nav" id="df-mobile-nav">
       <a href="/benchmarks">Benchmarks</a>
-      <a href="#agents">Agents</a>
+      <a href="/#agents">Agents</a>
       <a href="/blog">Blog</a>
       <a href="/changelog">Changelog</a>
       <a href="/docs/">Docs</a>
@@ -675,7 +675,7 @@
     <div class="df-footer-inner">
       <div class="df-footer-grid">
         <div class="df-footer-brand">
-          <a href="/" class="df-footer-lockup">
+          <a href="/" class="df-footer-lockup" aria-current="page">
             <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
             <p class="df-footer-heading">Super<em>Compress</em></p>
           </a>
@@ -745,5 +745,6 @@
   <script src="/assets/js/vendor/gsap/ScrollTrigger.min.js"></script>
 <script src="/assets/js/landing-app.js?v=5"></script>
 
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/live-demo.html
+++ b/web/live-demo.html
@@ -27,6 +27,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=106" />
   <link rel="stylesheet" href="assets/css/live-demo.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <!-- Preconnect hints for faster external resource loading -->
   <link rel="preconnect" href="https://github.com" />
   <link rel="dns-prefetch" href="https://github.com" />
@@ -79,6 +80,49 @@
   </script>
 </head>
 <body class="live-demo-body">
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <header class="demo-topbar">
     <a href="/" class="demo-brand" aria-label="SuperCompress home">
       <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="22" height="22" />
@@ -254,5 +298,68 @@
       Share on HN
     </a>
   </div>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/llm-cost-optimization.html
+++ b/web/llm-cost-optimization.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,21 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Cost optimization guide</p>
     <h1>LLM cost optimization without wrecking quality</h1>
     <p class="seo-lead">The best LLM cost optimization stack combines prompt compression, caching, model routing, and measurement.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/reduce-llm-costs">Reduce LLM costs</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>The LLM cost optimization stack</h2>
         <ol>
 <li><strong>Prompt compression</strong> (highest impact) - Remove 60-85% of input tokens</li>
@@ -115,5 +150,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/reduce-llm-costs">Reduce LLM costs</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization" aria-current="page">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/llm-token-compression.html
+++ b/web/llm-token-compression.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,20 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Token compression guide</p>
     <h1>LLM token compression before inference</h1>
     <p class="seo-lead">LLM token compression removes waste before the model spends compute on it. The goal is to preserve the evidence needed for the answer while cutting everything else.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>What is LLM token compression?</h2>
         <p><strong>LLM token compression</strong> reduces the number of tokens sent to a language model during inference while preserving the information needed to answer the current query.</p>
 <p>In a typical RAG query, 60-80% of retrieved context may be irrelevant to the specific question. Those tokens still cost money and add latency.</p>
@@ -124,5 +160,68 @@ result = comp.compress(context, query)</code></pre>
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/mcp-integration.html
+++ b/web/mcp-integration.html
@@ -23,6 +23,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=106" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     body { font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; background: #fbfbf8; color: #141412; line-height: 1.7; }
     .post-header { max-width: 760px; margin: 0 auto; padding: 48px 24px 24px; }
@@ -61,6 +62,49 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <nav class="nav-bar">
     <a href="/" class="brand">Super<em>Compress</em></a>
     <a href="/blog">Blog</a>
@@ -208,5 +252,68 @@ Agent: Here are the exact error messages from the log...</pre>
       <li><strong>Streaming compression</strong> — Progressive compression for real-time agent contexts</li>
     </ul>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/open-source-token-compression.html
+++ b/web/open-source-token-compression.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,20 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Open source guide</p>
     <h1>Open-source token compression</h1>
     <p class="seo-lead">SuperCompress is an open-source (MIT) token compression engine for teams that want transparent preprocessing.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Why open source matters</h2>
         <ul>
 <li><strong>Transparency</strong> - Inspect exactly how compression works</li>
@@ -120,5 +156,68 @@ result = comp.compress(context, query)</code></pre>
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/playground.html
+++ b/web/playground.html
@@ -203,17 +203,52 @@
     "license": "https://opensource.org/licenses/MIT"
   }
   </script>
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
-  <header>
-    <h1>Super<em>Compress</em> playground</h1>
-    <nav>
-      <a href="/">Landing page</a>
+  <header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground" aria-current="page">Playground</a>
       <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
-    </nav>
+    </div>
   </header>
-
-  <main>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<main>
     <section class="panel">
       <label for="api-key">API key (optional — uses hosted API when set)</label>
       <div class="key-row">
@@ -480,5 +515,68 @@
       Share on HN
     </a>
   </div>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground" aria-current="page">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/precision-mode-compression.html
+++ b/web/precision-mode-compression.html
@@ -23,6 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="assets/css/content-shell.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .article-page { font-family: var(--shell-sans); }
     .article-hero { padding: 40px 0 24px; }
@@ -62,6 +63,49 @@
   </script>
 </head>
 <body class="sc-shell-page">
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <header class="sc-topbar">
     <h1>Super<em>Compress</em> blog</h1>
     <nav>
@@ -243,5 +287,68 @@ console.log(`Confidence: ${result.confidence}, Budget: ${result.budget_ratio}`);
       <p><em>Precision Mode is available in SuperCompress v0.6+. <a href="/dashboard">Get your API key</a> to try it on your own context. Or <a href="/playground">open the playground</a> to test it in-browser.</em></p>
     </article>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/prompt-compression-guide.html
+++ b/web/prompt-compression-guide.html
@@ -106,8 +106,52 @@
     .btn-outline { background: transparent; border: 1px solid #2d2d44; color: #b0b0c8; }
     .btn-outline:hover { border-color: #7c3aed; color: #c4b5fd; background: rgba(124,58,237,0.08); text-decoration: none; }
   </style>
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <div class="container">
     <h1>Prompt Compression Guide</h1>
     <p class="meta">Last updated July 3, 2026 &middot; 15 min read</p>
@@ -344,5 +388,68 @@
       <a href="/dashboard" class="btn btn-outline">Get an API key</a>
     </div>
   </div>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/prompt-compression.html
+++ b/web/prompt-compression.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -83,20 +84,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Prompt compression guide</p>
     <h1>Prompt compression that keeps the answer</h1>
     <p class="seo-lead">Prompt compression is the practical way to reduce oversized LLM requests before they hit an expensive model. SuperCompress scores context against the current question and keeps the lines most likely to matter.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Why prompt compression matters</h2>
         <p>Every LLM call processes your full prompt including context that may be irrelevant to the question. In agent loops, RAG pipelines, and coding assistants, context accumulates rapidly.</p>
 <p>Without prompt compression, you pay for every token regardless of relevance. A typical RAG query sending 4,000 tokens may only need 400 of them to answer the question.</p>
@@ -142,5 +178,68 @@ print(f"Removed {result.tokens_removed} tokens")</code></pre>
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression" aria-current="page">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/reduce-llm-costs.html
+++ b/web/reduce-llm-costs.html
@@ -25,6 +25,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <link rel="stylesheet" href="assets/css/supercompress.css?v=115" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -116,20 +117,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Reduce LLM costs · Reduce token costs</p>
     <h1>How to reduce LLM costs and token costs in 2026</h1>
     <p class="seo-lead">If your AI bill is climbing, you do not need a cheaper model first. You need fewer tokens in the prompt. This guide shows how to reduce LLM costs and reduce token costs with query-aware prompt compression — before OpenAI, Claude, Gemini, or coding agents ever see the dump.</p>
     <p class="seo-author">By <strong><a href="https://arjunshah.xyz" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> · Creator of SuperCompress · Updated 2026-07-28</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Try it</a>
-      <a href="/docs/coding-agents">Coding agents</a>
-      <a href="/dashboard?signup=1">Get API key</a>
-    </nav>
-
-    <nav class="seo-toc" aria-label="On this page">
+<nav class="seo-toc" aria-label="On this page">
       <p>On this page</p>
       <ol>
         <li><a href="#why">Why LLM and token costs explode</a></li>
@@ -269,5 +305,68 @@ print(result.compressed_text, result.kv_savings_pct)</pre>
       </p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/reduce-openai-costs.html
+++ b/web/reduce-openai-costs.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,21 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">OpenAI cost reduction guide</p>
     <h1>Reduce OpenAI costs before the API call</h1>
     <p class="seo-lead">The fastest way to reduce OpenAI spend is to stop sending tokens the model does not need. SuperCompress compiles long context around the current question before the API call.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/reduce-llm-costs">Reduce LLM costs</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Where your OpenAI costs come from</h2>
         <p>With GPT-4o at $2.50/1M input tokens, a typical agent making 1,000 calls/day with 4,000-token prompts spends ~$10/day on input tokens. Compressing by 65% drops that to ~$3.50/day.</p>
       </section>    <section class="seo-section">
@@ -117,5 +152,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/reduce-llm-costs">Reduce LLM costs</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/research.html
+++ b/web/research.html
@@ -27,6 +27,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <!-- Preconnect hints for faster external resource loading -->
   <link rel="preconnect" href="https://github.com" />
   <link rel="dns-prefetch" href="https://github.com" />
@@ -274,49 +275,48 @@
 
   <div class="df-page">
     <header class="df-header">
-      <div class="df-header-blur" aria-hidden="true"></div>
-      <div class="df-header-inner">
-        <a href="/" class="df-logo-desktop">
-          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-          <span class="df-logo-word">Super<em>Compress</em></span>
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
-        <div class="df-header-end">
-          <nav class="df-nav-pill" aria-label="Main">
-            <a href="/">Home</a>
-            <a href="/benchmarks">Benchmarks</a>
-            <a href="/token-compression">Guide</a>
-          </nav>
-          <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
-            <a href="/dashboard">Dashboard</a>
-          </nav>
-          <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M23.6004 9.5927l-.0337-.0862L20.3.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412l-3.935 8.604H8.924L4.989.9814c-.093-.246-.38-.412-.646-.412-.266 0-.552.166-.646.412L.434 9.5065l-.032.0862c-.468 1.228-.148 2.628.804 3.55l.008.008.022.02 6.044 4.533-.032.024 5.735 4.36 5.735-4.36-.033-.024 6.045-4.533.022-.02.008-.008c.95-.922 1.27-2.322.803-3.55z"/>
-            </svg>
-          </a>
-        </div>
-
-        <div class="df-mobile-bar">
-          <a href="/" class="df-logo-mobile">
-            <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="22" height="22" />
-            <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
-          </a>
-          <button type="button" class="df-menu-btn" id="df-menu-btn" aria-label="Toggle menu" aria-expanded="false">
-            <span></span><span></span>
-          </button>
-        </div>
       </div>
-      <div class="df-mobile-nav hidden" id="df-mobile-nav">
-        <a href="/">Home</a>
-        <a href="/benchmarks">Benchmarks</a>
-        <a href="/token-compression">Token Compression Guide</a>
-        <a href="/dashboard">Dashboard</a>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
       </div>
-    </header>
-
-    <div class="df-header-spacer" aria-hidden="true"></div>
-
-    <!-- Research Header -->
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<!-- Research Header -->
     <header class="research-head">
       <p class="kicker">Academic Citation & Technical Details</p>
       <h1>SuperCompress: Efficient LLM Context Compression</h1>
@@ -471,67 +471,67 @@
     <!-- Footer -->
     <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -565,5 +565,6 @@
       Share on HN
     </a>
   </div>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/reversible-compression-ccr.html
+++ b/web/reversible-compression-ccr.html
@@ -23,6 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="assets/css/content-shell.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .article-page { font-family: var(--shell-sans); }
     .article-hero { padding: 40px 0 24px; }
@@ -62,6 +63,49 @@
   </script>
 </head>
 <body class="sc-shell-page">
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <header class="sc-topbar">
     <h1>Super<em>Compress</em> blog</h1>
     <nav>
@@ -267,5 +311,68 @@ console.log(`Cache: ${stats.entries} entries, ${stats.bytes} bytes`);</pre>
       <p><em>CCR is available in SuperCompress v0.6+. <a href="/dashboard">Get your API key</a> to try it on production traffic. Combine with <a href="/precision-mode-compression">Precision Mode</a> for guaranteed-quality, reversible compression.</em></p>
     </article>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/supercompress-architecture.html
+++ b/web/supercompress-architecture.html
@@ -77,8 +77,52 @@
     .flow-diagram { background: #0d0d16; border: 1px solid #1c1c2e; border-radius: 10px; padding: 20px; margin: 20px 0; font-family: 'SF Mono', monospace; font-size: 0.82rem; color: #888; line-height: 2; text-align: center; }
     .flow-diagram .arrow { color: #a78bfa; }
   </style>
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <div class="container">
     <h1>SuperCompress Architecture</h1>
     <p class="meta">Last updated July 3, 2026 · 10 min read</p>
@@ -335,5 +379,68 @@
       <a href="/dashboard" class="btn btn-outline">Get an API key</a>
     </div>
   </div>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/supercompress-vs-alternatives.html
+++ b/web/supercompress-vs-alternatives.html
@@ -103,8 +103,52 @@
     .faq summary { font-weight: 500; color: #c8c8d8; font-size: 0.9rem; }
     .faq details p { margin-top: 10px; font-size: 0.85rem; color: #777; }
   </style>
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <div class="container">
     <h1>SuperCompress vs Alternatives</h1>
     <p class="subtitle">A side-by-side comparison of every major prompt compression method — from lightweight scoring to full-model approaches — with benchmarks, trade-offs, and deployment guidance.</p>
@@ -274,5 +318,68 @@
       <a href="https://github.com/Supercompress/Supercompress" class="btn btn-outline" target="_blank">GitHub</a>
     </div>
   </div>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/supercompress-vs-headroom.html
+++ b/web/supercompress-vs-headroom.html
@@ -22,6 +22,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -61,18 +62,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Comparison guide</p>
     <h1>SuperCompress vs Headroom</h1>
     <p class="seo-lead">Both compress context before LLM inference. But the architecture, query-awareness, and deployment story are radically different. Here is the real comparison — not marketing claims, but architecture-level differences that matter for your stack.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> — Creator of SuperCompress — Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related pages">
-      <a href="/">Home</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-    <section class="seo-section">
+<section class="seo-section">
       <h2>The fundamental difference: architecture</h2>
       <p>The most important difference between SuperCompress and Headroom is at the architecture level. SuperCompress uses a learned policy of approximately <strong>5,000 parameters</strong> — small enough to load and run in microseconds. Headroom uses a <strong>ModernBERT-based model</strong> (165M+ parameters) with ONNX Runtime for efficient local execution.</p>
       <p>This difference in architecture cascades into every aspect of the two tools: installation complexity, deployment options, latency, query-awareness, and cold start behavior.</p>
@@ -202,5 +240,68 @@ result = compress(messages, model="auto")
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/supercompress-vs-summarization.html
+++ b/web/supercompress-vs-summarization.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,20 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Comparison guide</p>
     <h1>SuperCompress vs summarization</h1>
     <p class="seo-lead">Summarization rewrites context with another LLM call, risking fact changes. Query-aware selection keeps original text intact.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>The summarization problem</h2>
         <ol>
 <li><strong>Extra LLM call</strong> - Paying for summarization AND the final response</li>
@@ -114,5 +150,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/supercompress-vs-truncation.html
+++ b/web/supercompress-vs-truncation.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,20 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Comparison guide</p>
     <h1>SuperCompress vs truncation</h1>
     <p class="seo-lead">Truncation keeps the beginning and end, drops the middle. If answer evidence sits in the middle, truncation removes it.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/token-compression">Guide</a>
-      <a href="/benchmarks">Benchmarks</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Why truncation is risky</h2>
         <p>Truncation achieves only ~25% oracle recall at a 65% compression budget. That means 75% of the time, the line containing the answer gets dropped.</p>
       </section>    <section class="seo-section">
@@ -116,5 +152,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/token-compression.html
+++ b/web/token-compression.html
@@ -35,6 +35,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .guide-head {
       max-width: 800px;
@@ -301,43 +302,48 @@
 
   <div class="df-page">
     <header class="df-header">
-      <div class="df-header-blur" aria-hidden="true"></div>
-      <div class="df-header-inner">
-        <a href="/" class="df-logo-desktop">
-          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-          <span class="df-logo-word">Super<em>Compress</em></span>
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
         </a>
-        <div class="df-header-end">
-          <nav class="df-nav-pill" aria-label="Main">
-            <a href="/">Home</a>
-            <a href="/playground">Playground</a>
-            <a href="/benchmarks">Benchmarks</a>
-          </nav>
-          <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
-            <a href="/dashboard">Dashboard</a>
-          </nav>
-        </div>
-        <div class="df-mobile-bar">
-          <a href="/" class="df-logo-mobile">
-            <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="22" height="22" />
-            <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
-          </a>
-          <button type="button" class="df-menu-btn" id="df-menu-btn" aria-label="Toggle menu" aria-expanded="false">
-            <span></span><span></span>
-          </button>
-        </div>
       </div>
-      <div class="df-mobile-nav hidden" id="df-mobile-nav">
-        <a href="/">Home</a>
-        <a href="/playground">Playground</a>
-        <a href="/benchmarks">Benchmarks</a>
-        <a href="/dashboard">Dashboard</a>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
       </div>
-    </header>
-
-    <div class="df-header-spacer" aria-hidden="true"></div>
-
-    <!-- Guide Header -->
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<!-- Guide Header -->
     <header class="guide-head">
       <p class="kicker">Definitive Resource · Updated 2026</p>
       <h1>Token Compression for LLMs:<br />The Complete Guide</h1>
@@ -665,67 +671,67 @@ class CompressionCallback(BaseCallbackHandler):
     <!-- Footer -->
     <!-- SITE_FOOTER_START -->
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · coding agent plugin.</p>
-        <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression" aria-current="page">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression" aria-current="page">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Navigation</p>
-          <ul>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/#agents">Agents</a></li>
-            <li><a href="/blog">Blog</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/dashboard">Dashboard</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Resources</p>
-          <ul>
-            <li><a href="/playground">Playground</a></li>
-            <li><a href="/changelog">Changelog</a></li>
-            <li><a href="/token-compression">Token compression guide</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">SEO Guides</p>
-          <ul>
-            <li><a href="/prompt-compression">Prompt compression</a></li>
-            <li><a href="/token-compression">LLM token compression</a></li>
-            <li><a href="/context-compression">Context compression</a></li>
-            <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Documentation</p>
-          <ul>
-            <li><a href="/docs/">Documentation</a></li>
-            <li><a href="/docs/quickstart">Quickstart</a></li>
-            <li><a href="/docs/api-reference">API reference</a></li>
-            <li><a href="/docs/coding-agents">Coding agents</a></li>
-          </ul>
-        </div>
-        <div>
-          <p class="df-footer-heading">Social</p>
-          <ul>
-            <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
-          </ul>
-        </div>
-      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · Non-commercial license</p>
-  </div>
-</footer>
+  </footer>
 <!-- SITE_FOOTER_END -->
   </div>
 
@@ -792,5 +798,6 @@ class CompressionCallback(BaseCallbackHandler):
   </script>
   <script src="assets/js/supercompress.js?v=6"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/what-is-prompt-compression.html
+++ b/web/what-is-prompt-compression.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,18 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Beginner&#x27;s guide</p>
     <h1>What is prompt compression?</h1>
     <p class="seo-lead">Prompt compression is the practice of reducing the size of an LLM prompt before sending it to the model, while preserving the information needed to answer the user&#x27;s question correctly.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Understanding prompt compression</h2>
         <p>Every time you send a prompt to an LLM, you pay for every token — including tokens that are irrelevant to your question. Prompt compression removes those irrelevant tokens before the API call, saving money without sacrificing answer quality.</p>
 <p>Think of it like editing a report before sending it to your manager: you keep the important data and remove the filler. SuperCompress does this automatically, scoring each line of your prompt against your question and keeping only the lines most likely to contain the answer.</p>
@@ -118,5 +156,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>

--- a/web/when-to-use-compression.html
+++ b/web/when-to-use-compression.html
@@ -24,6 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=6" />
   <style>
     .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
     .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
@@ -78,18 +79,55 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="/docs/">Docs</a>
+        </nav>
+        <nav class="df-nav-pill df-nav-pill--solo" aria-label="Dashboard">
+          <a href="/dashboard">Dashboard</a>
+        </nav>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="/docs/">Docs</a>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+
   <main class="seo-page">
     <p class="seo-kicker">Best practices</p>
     <h1>When to use prompt compression</h1>
     <p class="seo-lead">Prompt compression is not always the right answer. Here is a decision framework to help you determine when to compress and when to skip.</p>
     <p class="seo-author">By <strong><a href="https://www.linkedin.com/in/arjunkshah" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-underline-offset:3px;">Arjun Shah</a></strong> - Creator of SuperCompress - Updated 2026-07-03</p>
-    <nav class="seo-nav" aria-label="Related SuperCompress pages">
-      <a href="/">Home</a>
-      <a href="/playground">Playground</a>
-      <a href="/dashboard">API Key</a>
-    </nav>
-
-        <section class="seo-section">
+<section class="seo-section">
         <h2>Compress when:</h2>
         <ul>
 <li><strong>Context exceeds 1,000 tokens</strong> — Below this, the savings may not justify the overhead</li>
@@ -121,5 +159,68 @@
       <p class="seo-cta-actions"><a class="btn-brand" href="/dashboard">Get an API key</a><a class="btn-link-muted" href="/token-compression">Read the guide</a></p>
     </section>
   </main>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/docs/">Docs</a></li>
+              <li><a href="/dashboard">Dashboard</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">SEO Guides</p>
+            <ul>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/token-compression">LLM token compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/llm-cost-optimization">Reduce LLM costs</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="/docs/">Documentation</a></li>
+              <li><a href="/docs/quickstart">Quickstart</a></li>
+              <li><a href="/docs/api-reference">API reference</a></li>
+              <li><a href="/docs/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=6"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Landing page is now the source of truth for logo, header links, Dashboard bubble, and footer
- Applied across blog, changelog, docs, playground, dashboard, benchmarks, and SEO/guide pages
- Adds `landing-chrome.css` + `site-chrome.js` everywhere; sync script at `scripts/sync_site_chrome.py`

## Test plan
- [ ] `/blog` header matches `/` (Benchmarks · Agents · Blog · Changelog · Docs + Dashboard)
- [ ] `/changelog` no longer uses the old `sc-nav` bar
- [ ] Footer links match landing on blog/changelog/docs
- [ ] Mobile menu opens/closes on a non-landing page
- [ ] Docs still usable with sidebar + new top chrome


Made with [Cursor](https://cursor.com)