### PR TITLE
Security: stop leaking affiliate PII from public list endpoint

### DIFF
--- a/api/affiliates.js
+++ b/api/affiliates.js
@@ -390,9 +390,6 @@ async function handleList(req, res) {
     const list = Object.values(affiliates).map((a) => ({
       id: a.id,
       name: a.name,
-      email: a.email,
-      website: a.website,
-      audience: a.audience,
       referral_slug: a.referral_slug,
       referral_link: a.referral_link,
       status: a.status,


### PR DESCRIPTION
**What this does**

`GET /api/affiliates` (the default list view) is unauthenticated and was returning every affiliate's `email`, `website`, and `audience`. Anyone could dump the full affiliate roster with email addresses. This removes those fields from the public response, leaving only non-sensitive display data.

**Files touched**

- `api/affiliates.js` — `handleList` no longer includes `email`, `website`, or `audience`. It now returns `id`, `name`, `referral_slug`, `referral_link`, `status`, `created_at`.

**Breaking changes**

- Any UI that read affiliate emails (or website/audience) from this public endpoint will now get blank values. Those consumers should use the founder-gated `view=admin` endpoint instead.

**Verification**

- `curl` the list endpoint and confirm no `email` field appears in the response.

**Known follow-ups (separate PRs)**

- Cross-tenant reads on `/api/retrieve` (missing owner check).
- Persistent, single-fetch-only failure on the `/api/connect-device` pairing secret.