### PR TITLE
Security: make device pairing secret single-use and time-limited

### DIFF
--- a/api/account.js
+++ b/api/account.js
@@ -91,9 +91,23 @@ async function handleConnectDevice(req, res) {
   if (!code || code.length < 6) return json(res, 422, { detail: "Valid code required" });
 
   if (req.method === "GET") {
-    const status = await linkedStatus(code);
-    if (!status) return json(res, 404, { detail: "Connection code not found" });
-    return json(res, 200, status);
+    const claimed = await mutateStore((store) => {
+      const rec = store.connections?.[code];
+      if (!rec) return { notFound: true };
+      const ageMs = Date.now() - new Date(rec.linked_at || rec.created_at || 0).getTime();
+      if (rec.secret && ageMs > 10 * 60 * 1000) {
+        delete store.connections[code];
+        return { expired: true };
+      }
+      if (!rec.secret) return { status: "pending", owner_uid: rec.owner_uid || null };
+      const secret = rec.secret;
+      const owner_uid = rec.owner_uid || null;
+      delete store.connections[code];
+      return { status: "linked", owner_uid, secret };
+    });
+    if (claimed?.notFound) return json(res, 404, { detail: "Connection code not found" });
+    if (claimed?.expired) return json(res, 410, { detail: "Connection code expired" });
+    return json(res, 200, { code, ...claimed });
   }
 
   if (req.method !== "POST") return json(res, 405, { detail: "Method not allowed" });


### PR DESCRIPTION
**What this does**

`GET /api/connect-device` was returning the plaintext API key for any code, with no expiry and no single-use limit. A leaked or guessed pairing code (and the code travelled in a browser URL) exposed a live key indefinitely. Now the secret is returned at most once, the connection record is deleted after read, and records older than 10 minutes return 410.

**Files touched**

- `api/account.js`:  the connect-device GET path now consumes the record inside `mutateStore`: it returns the secret at most once then deletes it, rejects records older than 10 minutes with 410, and returns 404 for unknown codes.

**Breaking changes**

- The pairing secret is single-use now. The CLI reads it once during its poll window, so the normal flow is unaffected, but a repeat poll of the same code returns pending or expired.
- The GET response no longer includes `linked_at` / `created_at`. Any consumer that read those fields will now get undefined.

**Verification**

- Link a device, poll the code once (secret returned), poll again (no secret); confirm a record older than 10 minutes returns 410 and an unknown code returns 404.

**Follow-ups (separate PRs) for the maintainer to consider**

- Raise pairing code entropy in `packages/proxy/src/setup.js` from 4 to 16 random bytes.
- Cross-tenant reads on `/api/retrieve` (missing owner check).