### PR TITLE
docs: saurabh org flat order form and quote email (500M pool)

### DIFF
--- a/docs/enterprise/README.md
+++ b/docs/enterprise/README.md
@@ -1,0 +1,5 @@
+# Enterprise (internal)
+
+Planning and customer commercial documents. Not public product docs until Arjun approves push.
+
+See `flat-rate/customers/saurabh-parashar/` for active quote artifacts.

--- a/docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-500m-70seats.md
+++ b/docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-500m-70seats.md
@@ -1,0 +1,137 @@
+# SuperCompress — Org Flat Subscription Order Form
+
+**Document ID:** SC-OF-2026-0808-SP  
+**Version:** 1.0  
+**Status:** Draft for customer signature — not executed until countersigned and paid.
+
+---
+
+## 1. Parties
+
+| | |
+|--|--|
+| **Provider** | SuperCompress (`https://www.supercompress.dev`), operated by Arjun Shah, Founder |
+| **Customer** | _________________________________________________ (“Customer”) |
+| **Billing contact** | Name: _________________ Email: _________________ |
+| **Effective date** | _________________ (subscription start; “Effective Date”) |
+
+This Order Form, together with the SuperCompress Terms of Service and Privacy Policy published at `https://www.supercompress.dev` (collectively, the “Agreement”), governs Customer’s subscription to the Org Flat plan described below. If there is a conflict, this Order Form controls for commercial terms in Sections 2–5.
+
+---
+
+## 2. Subscription summary
+
+| Term | Value |
+|------|--------|
+| **Plan** | Org Flat |
+| **Licensed seats** | **70** named users on one Customer organization |
+| **Included usage** | **500,000,000** compression input tokens (`tokens_in`) per calendar month, **org-wide shared pool** (not per-user wallets) |
+| **Monthly fee** | **USD $699.00** per month, billed in advance |
+| **Annual prepay (optional)** | **USD $7,130.00** per year (approximately 15% discount vs. twelve monthly payments), billed in advance |
+| **Billing method** | ☐ Credit card via Stripe ☐ Company invoice (Net terms as agreed in writing: _______) |
+| **Initial term** | ☐ Month-to-month, renews automatically ☐ Annual prepay for twelve (12) months from Effective Date |
+| **Renewal** | Auto-renews for successive periods equal to the Initial term unless either party gives **thirty (30) days’** written notice before period end |
+
+---
+
+## 3. Usage, alerts, and overage
+
+3.1 **Measurement.** Usage counts toward the monthly pool when members of Customer’s organization invoke SuperCompress compression (API, MCP, proxy, or dashboard-integrated flows) and `tokens_in` is metered to the org pool.
+
+3.2 **Usage alerts.** Provider will notify the billing contact when org pool consumption reaches approximately **eighty percent (80%)** of the monthly allowance.
+
+3.3 **Hard cap (default).** When the org pool reaches **one hundred percent (100%)** of the monthly allowance, compression for the org **stops until** (a) the next monthly period begins, or (b) Customer purchases an approved **capacity add-on** or plan upgrade per Section 4. Provider will not charge PAYG overage beyond the flat fee unless Customer separately enables prepaid PAYG or signs an add-on covering overage.
+
+3.4 **Fair use.** The included pool is sized for team rollout. If sustained usage materially exceeds this Order Form for multiple months, parties will meet in good faith to adjust pool, seats, or tier (including Enterprise custom pricing).
+
+3.5 **Seats.** Customer may assign seats up to the licensed count. Additional seats require a written add-on (standard list: +USD $8/seat/month unless otherwise agreed).
+
+---
+
+## 4. Add-ons and changes
+
+| Add-on (standard list) | Price |
+|------------------------|-------|
+| Extra seats | +USD $8 / seat / month |
+| Extra pool capacity | +USD $40 / 100M `tokens_in` / month |
+
+Changes to seats, pool, or price require **written agreement** (email from Customer billing contact + Provider confirmation suffices). Provider will issue an updated Order Form or addendum for material changes.
+
+---
+
+## 5. Fees and payment
+
+5.1 Customer pays fees on the billing cycle selected above. All amounts are in **USD**, exclusive of applicable taxes.
+
+5.2 **Taxes.** Customer is responsible for sales, VAT, GST, or similar taxes except taxes on Provider’s net income.
+
+5.3 **Late payment.** Undisputed amounts unpaid **fifteen (15) days** after due date may result in suspension of org access after notice.
+
+5.4 **Eval transition.** If Customer completed a separate evaluation period, this subscription may begin on the Effective Date above to avoid a service gap; eval-specific caps do not carry over unless stated in writing.
+
+---
+
+## 6. Service and support
+
+6.1 Provider delivers the production SuperCompress service (compression engine, account dashboard, org administration as available on Effective Date).
+
+6.2 **Support:** Email support to the billing contact for org administration, billing, and usage questions; response targets best-effort business hours (U.S. Pacific).
+
+6.3 Provider may update the service for security, performance, and feature improvements without materially reducing core compression functionality for the subscribed plan.
+
+---
+
+## 7. Confidentiality and data
+
+Each party will protect the other’s non-public business information received in connection with this Agreement. Customer data processed through SuperCompress is handled per the published Privacy Policy. Customer retains ownership of Customer content submitted for compression.
+
+---
+
+## 8. Warranties and limitation of liability
+
+8.1 Provider warrants the service will perform substantially in accordance with public documentation under normal use.
+
+8.2 **Disclaimer.** Except as stated in 8.1, the service is provided **“as is.”** Provider disclaims implied warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+8.3 **Limitation.** Neither party’s aggregate liability arising from this Order Form exceeds **fees paid by Customer in the twelve (12) months** before the claim. Neither party is liable for indirect, incidental, special, or consequential damages.
+
+---
+
+## 9. Termination
+
+Either party may terminate month-to-month subscriptions with **thirty (30) days’** written notice. Annual prepay is non-refundable except where required by law. On termination, org access ends at period end; Customer export of usage data available on request within **thirty (30) days**.
+
+---
+
+## 10. General
+
+**Governing law:** State of California, USA, excluding conflict-of-law rules.  
+**Notices:** Email to billing contacts above constitutes written notice.  
+**Entire agreement:** This Order Form + published Terms/Privacy + any signed addenda.
+
+---
+
+## 11. Signatures
+
+By signing below, each party agrees to the Agreement.
+
+**Customer**
+
+| | |
+|--|--|
+| Legal entity name | _________________________________________________ |
+| Authorized signature | _________________________________________________ |
+| Name / title | _________________________________________________ |
+| Date | _________________________________________________ |
+
+**Provider — SuperCompress**
+
+| | |
+|--|--|
+| Signature | _________________________________________________ |
+| Arjun Shah, Founder | |
+| Date | _________________________________________________ |
+
+---
+
+*Internal: Arjun approval required before send. Task 8ac413. Pool 500M / 70 seats / $699 aligns with Aug 2026 quote thread.*

--- a/docs/enterprise/flat-rate/customers/saurabh-parashar/quote-email-org-flat-500m.md
+++ b/docs/enterprise/flat-rate/customers/saurabh-parashar/quote-email-org-flat-500m.md
@@ -1,0 +1,31 @@
+# Quote email — Org Flat 500M (UNSENT)
+
+**Attach:** `order-form-org-flat-500m-70seats.md` (export to PDF before send if preferred)
+
+**From:** arjunkshah21@gmail.com  
+**To:** Saurabh (sub15@parashars.com)  
+**Do not send from agents.**
+
+---
+
+**Subject:** SuperCompress org plan — order form attached (70 seats, 500M/mo)
+
+Hi Saurabh,
+
+Following up on sizing for your team (~70 reports): attached is an **Org Flat subscription order form** with one monthly invoice, a shared org token pool, and a defined cap so usage stays predictable.
+
+**Summary**
+
+- **USD $699/month** (optional **USD $7,130/year** prepay, ~15% vs monthly)
+- **70 seats** on one organization
+- **500M compression tokens/month** — shared org pool (not individual wallets)
+- Usage alert at ~80% of pool; service pauses at 100% unless we agree an add-on in advance
+- Billing: credit card or company invoice — your choice
+
+Please review the order form, complete the Customer block, and return a signed copy with your preferred start date and billing contact. I will provision the org once executed.
+
+Best regards,
+
+Arjun Shah  
+Founder, SuperCompress  
+https://www.supercompress.dev


### PR DESCRIPTION
## Summary
done — swapped the sloppy email for a real order form (signatures, terms, 500m/70/$699) plus a short cover email with no “reply with” or rollout fluff

files in docs/enterprise/.../saurabh-parashar/ on the worktree, committed. paste copy in ~/.agent-bridge/briefs/saurabh-org-flat-quote.txt — pdf the order form before you attach

 on chore/little-ai-sloppy-professional-real-d86c — internal commercial docs only, no product code. so saurabh gets something you’d actually attach, not bullet-point ai quote paste

Commits:
• docs: saurabh org flat order form and quote email (500M pool)

## Commits
- docs: saurabh org flat order form and quote email (500M pool)

## Test plan
- [ ] Diff reviewed against intent
- [ ] No drive-by unrelated changes
- [ ] Safe for feature branch → chore/remove-control-plane-workflows (no force-push)

_Control plane task: `8ac413` · branch `chore/little-ai-sloppy-professional-real-d86c`_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds internal customer-facing commercial documents for a 70-seat, 500-million-token Org Flat subscription and an accompanying cover email.

- Adds a signature-ready order form with pricing, renewal, quota, support, data, and legal terms.
- Adds a concise quote email summarizing the offer.
- Adds an enterprise-documentation index.
- The offered plan, billing paths, organization quota, alerts, and hard cap are not supported by the current implementation.

<h3>Confidence Score: 3/5</h3>

This PR should not be merged for customer use until the quoted subscription can be provisioned and its organization-wide quota, alert, and hard-cap commitments can be enforced.

The new documents invite a customer to execute terms for a recurring Org Flat product and shared quota behavior that the current billing, provisioning, metering, and enforcement paths do not support.

**Files Needing Attention:** docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-500m-70seats.md and docs/enterprise/flat-rate/customers/saurabh-parashar/quote-email-org-flat-500m.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/enterprise/README.md | Adds a clear internal-only index pointing to the active customer quote artifacts. |
| docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-500m-70seats.md | Adds a signable commercial agreement whose recurring plan and organization-level usage controls are not currently provisionable or enforceable. |
| docs/enterprise/flat-rate/customers/saurabh-parashar/quote-email-org-flat-500m.md | Accurately mirrors the order form but repeats unsupported provisioning, shared-pool, alert, and hard-cap commitments. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: saurabh org flat order form and qu..."](https://github.com/supercompress/supercompress/commit/cee1f924240f370e594dce4d35a14bd24a889961) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51412038)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->