### PR TITLE
docs: tighten saurabh two-option order form to one page

### DIFF
--- a/docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.html
+++ b/docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>SuperCompress — Org Flat Order Form</title>
+  <style>
+    @page { size: letter; margin: 0.5in 0.55in; }
+    * { box-sizing: border-box; }
+    body {
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-size: 9.25pt;
+      line-height: 1.32;
+      color: #111;
+      max-width: 7.5in;
+      margin: 0 auto;
+      padding: 0;
+    }
+    h1 { font-size: 13pt; font-weight: 600; margin: 0 0 0.15rem; letter-spacing: -0.02em; }
+    .meta { font-size: 8pt; color: #444; margin-bottom: 0.65rem; }
+    h2 { font-size: 9.5pt; font-weight: 600; margin: 0.55rem 0 0.25rem; text-transform: uppercase; letter-spacing: 0.04em; color: #222; }
+    table { width: 100%; border-collapse: collapse; margin: 0.35rem 0; font-size: 8.75pt; }
+    th, td { border: 1px solid #999; padding: 0.28rem 0.35rem; vertical-align: top; text-align: left; }
+    th { background: #f2f2f2; font-weight: 600; }
+    .parties td { border: none; padding: 0.12rem 0; vertical-align: bottom; }
+    .parties { margin-bottom: 0.35rem; }
+    .parties .lbl { width: 11rem; color: #333; }
+    .line { border-bottom: 1px solid #666; display: inline-block; min-width: 14rem; height: 1.1em; }
+    ul { margin: 0.2rem 0 0.35rem; padding-left: 1rem; }
+    li { margin: 0.12rem 0; }
+    p { margin: 0.25rem 0; }
+    .checks { font-size: 9pt; margin: 0.35rem 0; }
+    .legal { font-size: 8.5pt; color: #222; }
+    .sig { width: 100%; margin-top: 0.45rem; font-size: 8.75pt; }
+    .sig td { border: none; width: 50%; vertical-align: top; padding: 0.15rem 0.5rem 0 0; }
+    .sig .line { min-width: 10rem; width: 90%; }
+    footer { margin-top: 0.5rem; font-size: 7.5pt; color: #666; border-top: 1px solid #ddd; padding-top: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h1>SuperCompress — Org Flat Order Form (70 seats)</h1>
+  <p class="meta">SC-OF-2026-0808-SP-B v1.1 · Draft — not active until countersigned and paid</p>
+
+  <table class="parties">
+    <tr><td class="lbl">Customer (legal entity)</td><td><span class="line"></span></td></tr>
+    <tr><td class="lbl">Billing contact</td><td><span class="line"></span></td></tr>
+    <tr><td class="lbl">Start date</td><td><span class="line"></span></td></tr>
+    <tr><td class="lbl">Provider</td><td>SuperCompress — Arjun Shah, Founder — supercompress.dev</td></tr>
+  </table>
+  <p class="legal">This Order Form plus published Terms of Service and Privacy Policy at supercompress.dev is the Agreement. This form controls commercial terms in Sections 1–4 if there is a conflict.</p>
+
+  <h2>1. Plan — select one</h2>
+  <p>PAYG list: <strong>$0.30 / 1M</strong> <code>tokens_in</code>. Both: <strong>70 seats</strong>, one invoice, <strong>shared org pool</strong>.</p>
+  <table>
+    <thead><tr><th></th><th>Option A</th><th>Option B</th></tr></thead>
+    <tbody>
+      <tr><th>Monthly fee</th><td><strong>$700</strong> ($10×70)</td><td><strong>$1,400</strong> ($20×70)</td></tr>
+      <tr><th>Monthly pool</th><td><strong>3.5B</strong> (70×50M)</td><td><strong>10.5B</strong> (70×150M)</td></tr>
+      <tr><th>Pool at PAYG list</th><td>~$1,050/mo</td><td>~$3,150/mo</td></tr>
+      <tr><th>vs PAYG (tokens)</th><td>~33% below</td><td>~56% below</td></tr>
+    </tbody>
+  </table>
+  <p class="checks">☐ Option A &nbsp; ☐ Option B &nbsp;|&nbsp; Billing: ☐ Card ☐ Invoice &nbsp;|&nbsp; Term: ☐ Monthly ☐ Annual prepay</p>
+
+  <h2>2. Access, seats, usage</h2>
+  <ul>
+    <li><strong>Go-live:</strong> Signed form + first payment → org live within <strong>5 business days</strong>; billing contact gets <strong>org admin</strong> link.</li>
+    <li><strong>Seats:</strong> Up to <strong>70</strong> active users. Admin invites by email; removing a user frees a seat. More seats or pool = written add-on.</li>
+    <li><strong>Pool:</strong> Org-wide monthly allowance; resets each billing period. At <strong>100%</strong>, compression pauses until next period or add-on (no surprise PAYG on this plan unless agreed in writing).</li>
+    <li><strong>Support:</strong> Email billing contact — org, billing, usage (US Pacific business hours).</li>
+  </ul>
+
+  <h2>3. Payment</h2>
+  <p>USD in advance each period; Customer pays applicable taxes. Late undisputed amounts (15+ days) may suspend service after notice. Month-to-month auto-renews unless either party gives <strong>30 days’</strong> written notice before period end.</p>
+
+  <h2>4. Legal (summary)</h2>
+  <p class="legal">Customer owns submitted content. Mutual confidentiality for non-public business info. Service substantially per docs under normal use; otherwise “as is.” Liability capped at fees paid in the prior <strong>12 months</strong>; no indirect/consequential damages. <strong>California</strong> law. Notices by email to billing contacts. Access ends at period end on termination.</p>
+
+  <h2>5. Signatures</h2>
+  <table class="sig">
+    <tr>
+      <td><strong>Customer</strong><br/>Signature <span class="line"></span><br/>Name / title <span class="line"></span><br/>Date <span class="line"></span></td>
+      <td><strong>SuperCompress</strong><br/>Signature <span class="line"></span><br/>Arjun Shah, Founder<br/>Date <span class="line"></span></td>
+    </tr>
+  </table>
+
+  <footer>SuperCompress · Org flat order form · draft · not executed until countersigned</footer>
+</body>
+</html>

--- a/docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.md
+++ b/docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.md
@@ -1,0 +1,66 @@
+# SuperCompress — Org Flat Order Form (70 seats)
+
+**Document ID:** SC-OF-2026-0808-SP-B · **Version:** 1.1 · Draft — not active until countersigned and paid.
+
+| **Customer** | |
+|--|--|
+| Legal entity | _________________________________________________ |
+| Billing contact (name, email) | _________________________________________________ |
+| Effective / start date | _________________________________________________ |
+
+**Provider:** SuperCompress (https://www.supercompress.dev), Arjun Shah, Founder.
+
+This Order Form, together with the SuperCompress Terms of Service and Privacy Policy at https://www.supercompress.dev (the “Agreement”), governs the org subscription below. If commercial terms conflict, this form controls Sections 1–4.
+
+---
+
+## 1. Plan (select one)
+
+Public pay-as-you-go is **$0.30 / 1M** compression input tokens (`tokens_in`). Both options include **70 seats** on one organization, **one monthly invoice**, and a **shared org token pool** (not per-user wallets).
+
+| | **Option A** | **Option B** |
+|--|--|--|
+| **Monthly fee** | **$700** ($10/seat × 70) | **$1,400** ($20/seat × 70) |
+| **Monthly pool** | **3.5B** `tokens_in` (70 × 50M) | **10.5B** `tokens_in` (70 × 150M) |
+| **Same pool at PAYG list** | ~$1,050/mo | ~$3,150/mo |
+| **vs PAYG (tokens only)** | ~33% below list | ~56% below list |
+
+**Selection:** ☐ Option A ☐ Option B · **Billing:** ☐ Credit card ☐ Invoice (terms: _______) · **Term:** ☐ Month-to-month ☐ Annual prepay (per written quote)
+
+---
+
+## 2. Access, seats, and usage
+
+**After you sign.** Return a signed copy with start date and billing contact. When the first period is paid (or card authorized), Provider provisions your organization within **five (5) business days** and emails the billing contact an **org admin** setup link.
+
+**Seats (70 max).** Each seat is one active user on Customer’s org. The org admin invites members by email from the dashboard (or approved admin flow). Removing a user **frees** the seat for someone else. Seats above 70 or pool changes require a **written add-on** (email confirmation from both parties is enough).
+
+**Shared pool.** All org compression (API, MCP, proxy, dashboard-integrated flows) draws from the selected monthly pool. The pool **resets** at each billing period. When the pool reaches **100%** for the period, compression **pauses** until the next period or an approved add-on. Provider does not charge PAYG overage on this plan unless Customer separately enables it in writing.
+
+**Support.** Email the billing contact for org admin, billing, and usage questions (U.S. Pacific business hours, best effort).
+
+---
+
+## 3. Fees and payment
+
+Fees are **USD**, billed **in advance** each period, plus applicable taxes (Customer’s responsibility except tax on Provider’s income). Undisputed amounts unpaid **fifteen (15) days** after due date may lead to suspension after notice. Month-to-month renews automatically unless either party gives **thirty (30) days’** written notice before period end.
+
+---
+
+## 4. Legal (summary)
+
+Customer retains ownership of content submitted for compression. Each party protects the other’s non-public business information. Provider warrants the service will perform substantially per public documentation under normal use; otherwise the service is **“as is.”** Neither party’s total liability for claims under this Order Form exceeds **fees paid in the twelve (12) months** before the claim; neither party is liable for indirect or consequential damages. **Governing law:** California, USA. **Notices:** email to the billing contacts above. On termination, org access ends at period end.
+
+---
+
+## 5. Signatures
+
+| **Customer** | **SuperCompress** |
+|--|--|
+| Signature: _________________________ | Signature: _________________________ |
+| Name / title: _________________________ | Arjun Shah, Founder |
+| Date: _________________________ | Date: _________________________ |
+
+---
+
+*Internal: UNSENT — Arjun approval before send. Task 3931c0.*

--- a/docs/enterprise/flat-rate/customers/saurabh-parashar/quote-email-two-options.md
+++ b/docs/enterprise/flat-rate/customers/saurabh-parashar/quote-email-two-options.md
@@ -1,0 +1,32 @@
+# Quote email — two org options (UNSENT)
+
+**Attach:** `order-form-org-flat-70seats-two-options.pdf` (or the `.md` export)
+
+**To:** Saurabh (sub15@parashars.com)  
+**Do not send from agents.**
+
+---
+
+**Subject:** SuperCompress org plan — two options for ~70 seats
+
+Hi Saurabh,
+
+For your team (~70 seats), here are two simple org plans — one invoice, shared token pool, hard monthly cap:
+
+**Option A — $700/month** ($10/seat × 70)  
+**3.5B compression tokens/month** (70 × 50M shared across the org).  
+At public pay-as-you-go ($0.30/1M), that pool is about **$1,050/mo** in tokens alone — this flat rate is roughly **one-third below** that retail line.
+
+**Option B — $1,400/month** ($20/seat × 70)  
+**10.5B compression tokens/month** (70 × 150M shared).  
+Same retail math is about **$3,150/mo** — this flat rate is roughly **half off** that PAYG number.
+
+Both include the 70 seats and predictable billing (not per-person wallets). Pick whichever fits your rollout; we can adjust after you see real team usage.
+
+**Attached:** order form with the same terms — review, fill the customer block, sign, and send back with your start date and billing contact. Once it’s executed and the first period is paid, we’ll stand up your org within about five business days and email you an org admin link to invite your team (up to 70 seats, shared pool).
+
+Best regards,
+
+Arjun Shah  
+Founder, SuperCompress  
+https://www.supercompress.dev


### PR DESCRIPTION
## Summary
contract’s one page now — pdf refreshed at ~/.agent-bridge/briefs/saurabh-org-flat-70seats-two-options.pdf (should’ve popped open)

added real legal summary + clear go-live/seats/pool stuff (5 biz days, admin invites, 70 cap, pause at 100%). email draft matches

committed on feat/contract-two-pages-long-one-60c9, no push. 

Commits:
• docs: tighten saurabh two-option order form to one page

## Commits
- docs: tighten saurabh two-option order form to one page

## Test plan
- [ ] Diff reviewed against intent
- [ ] No drive-by unrelated changes
- [ ] Safe for feature branch → chore/remove-control-plane-workflows (no force-push)

_Control plane task: `3931c0` · branch `feat/contract-two-pages-long-one-60c9`_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds condensed HTML and Markdown versions of a two-option, 70-seat order form plus its customer email draft.
- Defines monthly pricing, shared token pools, seat limits, provisioning, payment, and legal terms.
- Adds a letter-sized HTML representation intended for a one-page printed attachment.
- Leaves annual-prepay terms undefined and allows the printable form to select invoice billing without recording invoice terms.

<h3>Confidence Score: 3/5</h3>

The PR should not be merged until the annual-prepay contract terms and the printable form’s missing invoice-terms field are resolved.

Customers can currently execute an annual selection without defined annual commercial terms, or execute the printable invoice option without a due-date basis for late-payment enforcement.

**Files Needing Attention:** docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.md and docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.html

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.html | Adds the print-oriented order form, but its annual-prepay option is undefined and its invoice selection omits the payment-terms field. |
| docs/enterprise/flat-rate/customers/saurabh-parashar/order-form-org-flat-70seats-two-options.md | Adds the detailed order form while exposing annual prepay without an annual price, duration, or renewal provision. |
| docs/enterprise/flat-rate/customers/saurabh-parashar/quote-email-two-options.md | Adds the matching monthly quote email, but it does not supply the annual terms referenced by the order form. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: tighten saurabh two-option order f..."](https://github.com/supercompress/supercompress/commit/f964e575ea0f027b794f43acf93d79c8948e68d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51413418)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->