### PR TITLE
chore: gitignore private enterprise / customer docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,14 @@ web/ab-compare.html
 web/ab-comparison.html
 web/assets/css/pitch.css
 
+# Private enterprise / customer commercial pack — LOCAL ONLY (never commit/push)
+docs/enterprise/
+web/local-enterprise-brief.html
+web/local-only/
+scripts/build_local_enterprise_brief.py
+scripts/serve_local_enterprise_brief.sh
+exports/
+
 # Ops / outreach / SEO generator scripts
 scripts/send_batch_*.py
 scripts/generate_seo_batch*.py


### PR DESCRIPTION
## Summary
- Ignore `docs/enterprise/`, local enterprise brief HTML, and related private ops paths
- Prevents customer commercial docs (e.g. Saurabh order forms) from being committed to the public OSS repo again

## Context
Closed/deleted accidental PRs/branches that briefly exposed private enterprise paths. `main` was never contaminated.

## Test plan
- [x] `git check-ignore` covers `docs/enterprise/**`
- [x] No `docs/enterprise` paths remain on any `github/*` branch

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds ignore rules intended to keep private enterprise, customer-commercial, and local operational artifacts out of the public repository.
- Ignores the `docs/enterprise/` documentation tree and local-only web assets.
- Ignores local enterprise brief build and serving scripts.
- Ignores export output, although the generic rule also applies to nested directories.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking concern that the generic `exports/` rule can hide unrelated nested directories.

The private enterprise paths are narrowly scoped and intentional, but anchoring the export directory would avoid silently excluding future source or asset directories elsewhere in the repository.

**Files Needing Attention:** .gitignore

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds private enterprise and local-output exclusions; the unanchored `exports/` rule has broader repository-wide matching semantics than the other path-specific additions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: gitignore private enterprise and ..."](https://github.com/supercompress/supercompress/commit/a751ba92ddb62da3de62d9e266a86706bbf2ef41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51414864)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->