### PR TITLE
fix: gitignore enterprise pack paths for OSS leak gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ launch-video/
 # Demo build output
 examples/yc-demo/out/
 scripts/cleanup-auth-stubs.js
+
+# Private enterprise / customer commercial pack — LOCAL ONLY (never commit/push)
+docs/enterprise/
+web/local-enterprise-brief.html
+web/local-only/
+scripts/build_local_enterprise_brief.py
+scripts/serve_local_enterprise_brief.sh
+exports/


### PR DESCRIPTION
## Summary
05f15d wrapped.

agent-bridge/docs: no live keys, boundary/owners/client-lanes match folders, no “PR enterprise to SC” drift. qa log at docs/ops/reviewer-qa-05f15d.md

supercompress worktree (docs/reviewer-secrets-oss-leak-qa-131d): added enterprise/local-brief block to .gitignore so it matches leak-checklist + enterprise-git-status

 (SC worktree): gitignore enterprise paths so OSS branches can’t accidentally stage commercial packs — complements the private docs QA.

 (agent-bridge branch docs/reviewer-secrets-oss-leak-qa-131d): reviewer QA record + ops index row for card close. private repo, not product OSS.

no push on either branch. pinged you on imessage.

Commits:
• fix: gitignore enterprise pack paths for OSS leak gate
• chore: remove control-plane GitHub workflows from OSS repo
• security: harden CCR tenant isolation and device-link pairing
• security: harden CCR tenant isolation and device-link pairing
• Merge pull request #6 from Supercompress/chore/control-plane-github-hooks
• Add GitHub Actions that route issues/PRs into the Ultron control plane.
• web: tokens_saved_pct naming; MIT + pre-inference clarity
• fix: prefer tokens_saved_pct in integrations/examples/proxy docs
• docs: prefer tokens_saved_pct; clarify pre-inference compression (not KV)
• Rename kv_savings_pct to tokens_saved_pct across the product surface.
• Relicense SuperCompress as MIT for commercial open-source use.
• Unify site header and footer to match the landing page.
• Relicense SuperCompress as MIT for commercial open-source use.
• Merge pull request #4 from Supercompress/fix/hero-video-assets
• Fix vercelignore so web/assets/video is not excluded.
• Merge pull request #3 from Supercompress/fix/hero-video
• Ignore models/ and other local media so Vercel can ship the hero mp4.
• Fix hero video: ship launch-post.mp4 and restore real poster.

## Commits
- fix: gitignore enterprise pack paths for OSS leak gate
- chore: remove control-plane GitHub workflows from OSS repo
- security: harden CCR tenant isolation and device-link pairing
- security: harden CCR tenant isolation and device-link pairing
- Merge pull request #6 from Supercompress/chore/control-plane-github-hooks
- Add GitHub Actions that route issues/PRs into the Ultron control plane.
- web: tokens_saved_pct naming; MIT + pre-inference clarity
- fix: prefer tokens_saved_pct in integrations/examples/proxy docs
- docs: prefer tokens_saved_pct; clarify pre-inference compression (not KV)
- Rename kv_savings_pct to tokens_saved_pct across the product surface.
- Relicense SuperCompress as MIT for commercial open-source use.
- Unify site header and footer to match the landing page.
- Relicense SuperCompress as MIT for commercial open-source use.
- Merge pull request #4 from Supercompress/fix/hero-video-assets
- Fix vercelignore so web/assets/video is not excluded.

## Test plan
- [ ] Diff reviewed against intent
- [ ] No drive-by unrelated changes
- [ ] Safe for feature branch → main (no force-push)

_Control plane task: `05f15d` · branch `docs/reviewer-secrets-oss-leak-qa-131d`_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `.gitignore` rules intended to keep local enterprise and customer-pack material out of the public repository.
- Ignores private enterprise documentation, local web briefs, helper scripts, and export content.
- One export-directory rule is broader than the otherwise path-specific enterprise boundaries.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking recommendation to root-anchor the broad export-directory exclusion.

The new enterprise paths are isolated ignore rules and no current repository workflow uses them, but `exports/` applies at every directory depth and can silently hide future unrelated files.

**Files Needing Attention:** .gitignore

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds enterprise-pack exclusions; the unanchored `exports/` rule also matches unrelated nested directories. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: gitignore enterprise pack paths for..."](https://github.com/supercompress/supercompress/commit/f71adf3a7b773313050edeb3d81ce1d83f6ffd6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51417321)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->