### PR TITLE
fix: gitignore enterprise pack paths for OSS leak gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ launch-video/
 # Demo build output
 examples/yc-demo/out/
 scripts/cleanup-auth-stubs.js
+
+# Private enterprise / customer commercial pack — LOCAL ONLY (never commit/push)
+docs/enterprise/
+web/local-enterprise-brief.html
+web/local-only/
+scripts/build_local_enterprise_brief.py
+scripts/serve_local_enterprise_brief.sh
+exports/


### PR DESCRIPTION
## Summary
05f15d done

qa pass on agent-bridge/docs: no live keys/stripe secrets. owners/boundary match enterprise + marketing + ops. product docs/ in the sc worktree is clean (placeholders only)

fixed the enterprise brief script — it was telling people to use supercompress web/local-* paths. stubbed local-web, added ops/leak-checklist, sign-off in ops/reviewer-qa-05f15d.md

commits on ~/agent-bridge branch docs/reviewer-secrets-oss-leak-qa-131d (not pushed). the cursor worktree is the sc repo — no sc doc changes needed there

 (agent-bridge private): closes oss-leak footguns in enterprise tooling docs and lands the ops leak checklist so reviewers have a concrete pre-sc-pr gate before cos closes 05f15d

Commits:
• fix: gitignore enterprise pack paths for OSS leak gate

## Commits
- fix: gitignore enterprise pack paths for OSS leak gate

## Test plan
- [ ] Diff reviewed against intent
- [ ] No drive-by unrelated changes
- [ ] Safe for feature branch → chore/remove-control-plane-workflows (no force-push)

_Control plane task: `05f15d` · branch `docs/reviewer-secrets-oss-leak-qa-131d`_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `.gitignore` rules intended to prevent private enterprise and customer-commercial-pack artifacts from being committed to the public repository.
- Ignores local enterprise documentation and web content.
- Ignores local enterprise brief build and serving scripts.
- Ignores locally generated exports.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defect identified.

The newly ignored paths are absent from both the base and head tracked trees, and no existing repository path or contract was found that conflicts with the added patterns.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds six ignore patterns for untracked private enterprise-pack paths; no actionable issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: gitignore enterprise pack paths for..."](https://github.com/supercompress/supercompress/commit/f71adf3a7b773313050edeb3d81ce1d83f6ffd6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51417332)</sub>

<!-- /greptile_comment -->