### PR TITLE
docs: steer DOCS lane away from OSS private packs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ launch-video/
 # Demo build output
 examples/yc-demo/out/
 scripts/cleanup-auth-stubs.js
+
+# Private enterprise / customer commercial pack — LOCAL ONLY (never commit/push)
+docs/enterprise/
+web/local-enterprise-brief.html
+web/local-only/
+scripts/build_local_enterprise_brief.py
+scripts/serve_local_enterprise_brief.sh
+exports/

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Start here for API usage, deployment, integrations, and environmental impact met
 
 ## Company fleet (DOCS lane)
 
-This tree is **public product documentation only**. Enterprise quotes, customer packs, and control-plane runbooks belong in the private agent-bridge `docs/` tree — do not open SuperCompress feature branches for that material. Before `READY_FOR_PR`, confirm the branch diff matches the private-pack block at the bottom of the repo root `.gitignore` (see also agent-bridge `docs/ops/leak-checklist.md`).
+This tree is **public product documentation only**. Enterprise quotes, customer packs, order forms, and control-plane runbooks belong in the private agent-bridge `docs/` tree — do not open SuperCompress feature branches for that material. Before `READY_FOR_PR`, confirm the branch diff matches the private-pack block at the bottom of the repo root `.gitignore` (see also agent-bridge `docs/ops/leak-checklist.md`).
 
 ## Getting started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 Start here for API usage, deployment, integrations, and environmental impact methodology.
 
+## Company fleet (DOCS lane)
+
+This tree is **public product documentation only**. Enterprise quotes, customer packs, and control-plane runbooks belong in the private agent-bridge `docs/` tree — do not open SuperCompress feature branches for that material. Before `READY_FOR_PR`, confirm the branch diff matches the private-pack block at the bottom of the repo root `.gitignore` (see also agent-bridge `docs/ops/leak-checklist.md`).
+
 ## Getting started
 
 1. **[API.md](API.md)** — `compress_context`, `compress_for_turn`, `compare_policies`, plus Precision mode, domain preprocessors, and CCR


### PR DESCRIPTION
## Summary
task 78fe6e done

pulled ops gitignore onto your cos-tech sc branch + readme note so DOCS workers stop opening product branches for private packs

agent-bridge side: ops leak checklist + reviewer qa (05f15d) already landed. i added CoS tech routing to OWNERS on the reviewer docs branch (local commit, not pushed)

 on docs/cos-tech-coordinate-ops-reviewer-d2cb — cherry-picked enterprise .gitignore block from ops lane and documented the fleet boundary in product docs/README so ops checklist + reviewer QA stay aligned with what actually ships on github

Commits:
• docs: steer DOCS lane away from OSS private packs
• chore: align gitignore with enterprise local-only block

## Commits
- docs: steer DOCS lane away from OSS private packs
- chore: align gitignore with enterprise local-only block

## Test plan
- [ ] Diff reviewed against intent
- [ ] No drive-by unrelated changes
- [ ] Safe for feature branch → chore/remove-control-plane-workflows (no force-push)

_Control plane task: `78fe6e` · branch `docs/cos-tech-coordinate-ops-reviewer-d2cb`_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reinforces the boundary between public product documentation and private enterprise/customer materials.
- Adds ignore rules for local-only enterprise documents, scripts, briefs, and exports.
- Directs documentation workers to keep private commercial and control-plane material in the private agent-bridge tree.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The ignore rules and documentation guidance consistently route private enterprise material away from the public repository, and no existing tracked path, build workflow, or documentation destination conflicts with the new patterns.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitignore | Adds a coherent local-only ignore block for private enterprise artifacts; no current repository paths or workflows are adversely affected. |
| docs/README.md | Documents the public/private content boundary and aligns contributor routing with the new ignore rules. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify public-only scope for DOCS..."](https://github.com/supercompress/supercompress/commit/50fcf9ebfbe8ea47cdbada4a1b94f5408353b1ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51417374)</sub>

<!-- /greptile_comment -->