### PR TITLE
docs: clarify public-only scope for DOCS lane workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ launch-video/
 # Demo build output
 examples/yc-demo/out/
 scripts/cleanup-auth-stubs.js
+
+# Private enterprise / customer commercial pack — LOCAL ONLY (never commit/push)
+docs/enterprise/
+web/local-enterprise-brief.html
+web/local-only/
+scripts/build_local_enterprise_brief.py
+scripts/serve_local_enterprise_brief.sh
+exports/

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Start here for API usage, deployment, integrations, and environmental impact met
 
 ## Company fleet (DOCS lane)
 
-This tree is **public product documentation only**. Enterprise quotes, customer packs, and control-plane runbooks belong in the private agent-bridge `docs/` tree — do not open SuperCompress feature branches for that material. Before `READY_FOR_PR`, confirm the branch diff matches the private-pack block at the bottom of the repo root `.gitignore` (see also agent-bridge `docs/ops/leak-checklist.md`).
+This tree is **public product documentation only**. Enterprise quotes, customer packs, order forms, and control-plane runbooks belong in the private agent-bridge `docs/` tree — do not open SuperCompress feature branches for that material. Before `READY_FOR_PR`, confirm the branch diff matches the private-pack block at the bottom of the repo root `.gitignore` (see also agent-bridge `docs/ops/leak-checklist.md`).
 
 ## Getting started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 Start here for API usage, deployment, integrations, and environmental impact methodology.
 
+## Company fleet (DOCS lane)
+
+This tree is **public product documentation only**. Enterprise quotes, customer packs, and control-plane runbooks belong in the private agent-bridge `docs/` tree — do not open SuperCompress feature branches for that material. Before `READY_FOR_PR`, confirm the branch diff matches the private-pack block at the bottom of the repo root `.gitignore` (see also agent-bridge `docs/ops/leak-checklist.md`).
+
 ## Getting started
 
 1. **[API.md](API.md)** — `compress_context`, `compress_for_turn`, `compare_policies`, plus Precision mode, domain preprocessors, and CCR


### PR DESCRIPTION
## Summary
78fe6e done

agent-bridge: ops readme + reviewer-qa.md (replaced the duplicate 05f15d stub), OWNERS tech routing table, leak-checklist points at reviewer-qa. local commits on docs/reviewer-secrets-oss-leak-qa-131d — not pushed

supercompress branch docs/cos-tech-coordinate-ops-reviewer-d2cb: enterprise gitignore block + docs/readme “company fleet” note so DOCS cards don’t open product branches for private packs. diff vs main is only .gitignore + docs/README — leak check passes

 was already queued on that sc branch. ping if you want agent-bridge pushed too

Commits:
• docs: clarify public-only scope for DOCS lane workers
• docs: steer DOCS lane away from OSS private packs
• chore: align gitignore with enterprise local-only block
• chore: remove control-plane GitHub workflows from OSS repo
• security: harden CCR tenant isolation and device-link pairing
• security: harden CCR tenant isolation and device-link pairing
• Merge pull request #6 from Supercompress/chore/control-plane-github-hooks
• Add GitHub Actions that route issues/PRs into the Ultron control plane.
• web: tokens_saved_pct naming; MIT + pre-inference clarity
• fix: prefer tokens_saved_pct in integrations/examples/proxy docs
• docs: prefer tokens_saved_pct; clarify pre-inference compression (not KV)
• Rename kv_savings_pct to tokens_saved_pct across the product surface.
• Relicense SuperCompress as MIT for commercial open-source use.
• Unify site header and footer to match the landing page.
• Relicense SuperCompress as MIT for commercial open-source use.
• Merge pull request #4 from Supercompress/fix/hero-video-assets
• Fix vercelignore so web/assets/video is not excluded.
• Merge pull request #3 from Supercompress/fix/hero-video
• Ignore models/ and other local media so Vercel can ship the hero mp4.
• Fix hero video: ship launch-post.mp4 and restore real poster.

## Commits
- docs: clarify public-only scope for DOCS lane workers
- docs: steer DOCS lane away from OSS private packs
- chore: align gitignore with enterprise local-only block
- chore: remove control-plane GitHub workflows from OSS repo
- security: harden CCR tenant isolation and device-link pairing
- security: harden CCR tenant isolation and device-link pairing
- Merge pull request #6 from Supercompress/chore/control-plane-github-hooks
- Add GitHub Actions that route issues/PRs into the Ultron control plane.
- web: tokens_saved_pct naming; MIT + pre-inference clarity
- fix: prefer tokens_saved_pct in integrations/examples/proxy docs
- docs: prefer tokens_saved_pct; clarify pre-inference compression (not KV)
- Rename kv_savings_pct to tokens_saved_pct across the product surface.
- Relicense SuperCompress as MIT for commercial open-source use.
- Unify site header and footer to match the landing page.
- Relicense SuperCompress as MIT for commercial open-source use.

## Test plan
- [ ] Diff reviewed against intent
- [ ] No drive-by unrelated changes
- [ ] Safe for feature branch → main (no force-push)

_Control plane task: `78fe6e` · branch `docs/cos-tech-coordinate-ops-reviewer-d2cb`_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR documents that DOCS-lane workers must keep enterprise and customer material in a private repository and adds ignore rules for local-only enterprise artifacts.

- Adds a Company fleet scope and leak-check reminder to the documentation index.
- Ignores private enterprise documents, local web briefs, helper scripts, and exports.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking documentation issue in how the intended leak check is specified.

The ignore additions do not conflict with current repository outputs, but the readiness instruction should define a concrete validation so workers do not mistake ignore patterns for confirmation that a branch contains no private material.

**Files Needing Attention:** docs/README.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/README.md | Adds the public-only documentation boundary, but describes the readiness leak check ambiguously rather than as a reproducible validation. |
| .gitignore | Adds local-only enterprise artifact patterns; no current tracked workflow conflicts with the new paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify public-only scope for DOCS..."](https://github.com/supercompress/supercompress/commit/50fcf9ebfbe8ea47cdbada4a1b94f5408353b1ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51417408)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->