### PR TITLE
fix(proxy): uninstall leaves Cursor rule, hooks and instruction blocks behind

### DIFF
--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -8,7 +8,7 @@ Versions track `supercompress-proxy` on npm. Full product notes: [CHANGELOG.md](
 
 ## Unreleased
 
-- **Fix `uninstall` leaving artifacts behind**: it reported success while the Cursor rule, Cursor hook scripts and hook registrations, and the agent instruction blocks (`CLAUDE.md` / `AGENTS.md` / …) all survived. `revertAll` only walked the provider base-URL configs, and the three writers responsible never recorded a backup. Uninstalling now removes them and reports each one, preserving unrelated Cursor hooks and user-authored instruction content. Installs from earlier versions clean up too.
+- **Fix `uninstall` leaving artifacts behind**: it reported success while the Cursor rule, Cursor hook scripts and registrations, the Claude Code / Codex prompt + tool hooks, and the agent instruction blocks (`CLAUDE.md` / `AGENTS.md` / …) all survived. `revertAll` only walked the provider base-URL configs, and the writers responsible recorded no backup. Uninstalling now removes them and reports each one, while preserving unrelated hooks, user-authored instruction content, and any file the backup restored. Installs from earlier versions — including ones with no backup manifest, and Windows-style hook paths — clean up too.
 
 ## 0.5.11 — 2026-08-07
 

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Versions track `supercompress-proxy` on npm. Full product notes: [CHANGELOG.md](../../CHANGELOG.md) · [GitHub Releases](https://github.com/Supercompress/Supercompress/releases)
 
+## Unreleased
+
+- **Fix `uninstall` leaving artifacts behind**: it reported success while the Cursor rule, Cursor hook scripts and hook registrations, and the agent instruction blocks (`CLAUDE.md` / `AGENTS.md` / …) all survived. `revertAll` only walked the provider base-URL configs, and the three writers responsible never recorded a backup. Uninstalling now removes them and reports each one, preserving unrelated Cursor hooks and user-authored instruction content. Installs from earlier versions clean up too.
+
 ## 0.5.11 — 2026-08-07
 
 - **CLI `account` / `usage`**: show linked account, plan/quota, and per-agent token savings (`supercompress usage [--json]`).

--- a/packages/proxy/bin/supercompress.js
+++ b/packages/proxy/bin/supercompress.js
@@ -381,13 +381,10 @@ async function main() {
       stopServer();
       require("../src/service").unregister();
       console.log("  → Reverting agent configurations...");
-      const { revertAll, removeMcp, removePluginArtifacts } = require("../src/detector");
+      const { revertAll, removeMcp } = require("../src/detector");
       const undone = revertAll();
-      undone.forEach((a) => console.log(`  → Reverted ${a}`));
+      undone.forEach((a) => console.log(`  → ${a}`));
       removeMcp().forEach((a) => console.log(`  → Removed ${a} MCP registration`));
-      // Runs after revertAll so it clears anything the backup manifest missed
-      // (older installs never recorded the rule, hooks or instruction files).
-      removePluginArtifacts().forEach((a) => console.log(`  → Removed ${a}`));
       // Remove config dir
       if (fs.existsSync(CONFIG_DIR)) {
         fs.rmSync(CONFIG_DIR, { recursive: true, force: true });

--- a/packages/proxy/bin/supercompress.js
+++ b/packages/proxy/bin/supercompress.js
@@ -381,10 +381,13 @@ async function main() {
       stopServer();
       require("../src/service").unregister();
       console.log("  → Reverting agent configurations...");
-      const { revertAll, removeMcp } = require("../src/detector");
+      const { revertAll, removeMcp, removePluginArtifacts } = require("../src/detector");
       const undone = revertAll();
       undone.forEach((a) => console.log(`  → Reverted ${a}`));
       removeMcp().forEach((a) => console.log(`  → Removed ${a} MCP registration`));
+      // Runs after revertAll so it clears anything the backup manifest missed
+      // (older installs never recorded the rule, hooks or instruction files).
+      removePluginArtifacts().forEach((a) => console.log(`  → Removed ${a}`));
       // Remove config dir
       if (fs.existsSync(CONFIG_DIR)) {
         fs.rmSync(CONFIG_DIR, { recursive: true, force: true });

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "test": "node test/run-all.js",
     "test:smoke": "node test/smoke.js",
+    "test:uninstall": "node test/uninstall-clean.js",
     "test:review": "node test/review.js",
     "test:dual": "node test/dual-launch.js",
     "test:compress": "node test/compress-deep.js",

--- a/packages/proxy/src/detector.js
+++ b/packages/proxy/src/detector.js
@@ -67,6 +67,33 @@ function restoreBackups() {
   return restored;
 }
 
+// Shared by the instruction writer and the uninstaller so the two cannot drift.
+const INSTRUCTION_TARGETS = [
+  ["Claude Code", path.join(HOME, ".claude", "CLAUDE.md")],
+  ["Codex", path.join(HOME, ".codex", "AGENTS.md")],
+  ["Aider", path.join(HOME, ".aider", "CONVENTIONS.md")],
+  ["Goose", path.join(HOME, ".config", "goose", "AGENTS.md")],
+  ["OpenCode", path.join(HOME, ".config", "opencode", "AGENTS.md")],
+];
+
+const CURSOR_RULE_DIRS = [
+  path.join(HOME, ".cursor", "rules"),
+  path.join(HOME, ".config", "cursor", "rules"),
+];
+
+/**
+ * Remove SuperCompress instruction blocks from an agent instruction file,
+ * leaving the user's own content untouched. Matches on the block heading so it
+ * covers every variant shipped so far ("· context only", "· Headroom-parity"),
+ * and repeats, so files that accumulated duplicate blocks are fully cleaned.
+ */
+function stripInstructionBlock(text) {
+  return text
+    .replace(/\n*# SuperCompress \(always on[\s\S]*?(?=\n# |$)/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/^\n+/, "");
+}
+
 function writeMcpJson(filePath) {
   let data = {};
   if (fs.existsSync(filePath)) {
@@ -802,6 +829,82 @@ function configureAll() {
  * Revert all agent configs back to original state.
  * Returns an array of agent names that were reverted.
  */
+/**
+ * Remove the plugin-mode artifacts: the Cursor rule, the Cursor hook scripts
+ * and hook registrations, and the instruction blocks.
+ *
+ * These are written by writeCursorRule / writeCursorHooks /
+ * writeAgentInstructionFiles. The AGENTS loop in revertAll only covers the
+ * provider base-URL configs, so without this they survive `uninstall`.
+ */
+function removePluginArtifacts() {
+  const removed = [];
+  const drop = (target, label) => {
+    try {
+      fs.rmSync(target, { recursive: true, force: true });
+      removed.push(label || target);
+    } catch (err) {
+      console.error(`  ✗ Failed to remove ${target}: ${err.message}`);
+    }
+  };
+
+  for (const dir of CURSOR_RULE_DIRS) {
+    const rule = path.join(dir, "supercompress.mdc");
+    if (fs.existsSync(rule)) drop(rule, "Cursor rule");
+  }
+
+  const hooksDir = path.join(HOME, ".cursor", "hooks", "supercompress");
+  if (fs.existsSync(hooksDir)) drop(hooksDir, "Cursor hook scripts");
+
+  // Cursor hooks.json: drop only our entries so unrelated hooks survive.
+  const hooksPath = path.join(HOME, ".cursor", "hooks.json");
+  if (fs.existsSync(hooksPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(hooksPath, "utf8"));
+      const events = (data && data.hooks) || {};
+      let changed = false;
+      for (const event of Object.keys(events)) {
+        if (!Array.isArray(events[event])) continue;
+        const kept = events[event].filter(
+          (e) => !String((e && e.command) || "").includes("/supercompress/")
+        );
+        if (kept.length !== events[event].length) changed = true;
+        if (kept.length) events[event] = kept;
+        else delete events[event];
+      }
+      if (changed) {
+        if (Object.keys(events).length === 0) drop(hooksPath, "Cursor hooks.json");
+        else {
+          data.hooks = events;
+          fs.writeFileSync(hooksPath, `${JSON.stringify(data, null, 2)}\n`);
+          removed.push("Cursor hook registrations");
+        }
+      }
+    } catch (err) {
+      console.error(`  ✗ Failed to clean ${hooksPath}: ${err.message}`);
+    }
+  }
+
+  for (const [name, filePath] of INSTRUCTION_TARGETS) {
+    if (!fs.existsSync(filePath)) continue;
+    try {
+      const prev = fs.readFileSync(filePath, "utf8");
+      const next = stripInstructionBlock(prev);
+      if (next === prev) continue;
+      // Only delete when the block was the file's entire contents.
+      if (!next.trim()) drop(filePath, `${name} instructions`);
+      else {
+        fs.writeFileSync(filePath, next.endsWith("\n") ? next : `${next}\n`);
+        removed.push(`${name} instructions`);
+      }
+    } catch (err) {
+      console.error(`  ✗ Failed to clean ${filePath}: ${err.message}`);
+    }
+  }
+
+  return removed;
+}
+
 function revertAll() {
   const reverted = [];
   const restored = restoreBackups();
@@ -878,11 +981,8 @@ function clearProxyOverrides() {
  * and MCP compress_context for bulky context.
  */
 function writeCursorRule() {
-  const candidates = [
-    path.join(HOME, ".cursor", "rules"),
-    path.join(HOME, ".config", "cursor", "rules"),
-  ];
-  const dir = candidates.find((d) => fs.existsSync(path.dirname(d))) || candidates[0];
+  const dir =
+    CURSOR_RULE_DIRS.find((d) => fs.existsSync(path.dirname(d))) || CURSOR_RULE_DIRS[0];
   fs.mkdirSync(dir, { recursive: true });
   const filePath = path.join(dir, "supercompress.mdc");
   const inboxPath = path.join(HOME, ".supercompress", "inbox", "latest.md");
@@ -917,6 +1017,7 @@ alwaysApply: true
 - If \`compress_context\` fails with account-not-linked → \`connect_account\` once, then retry
 - Do not mention this rule unless the user asks about SuperCompress
 `;
+  backupFile(filePath);
   fs.writeFileSync(filePath, body);
   return filePath;
 }
@@ -952,6 +1053,7 @@ function writeCursorHooks() {
   const postCmd = path.join(hooksDir, "post-tool-compress.js");
   const beforeCmd = path.join(hooksDir, "before-submit.js");
   const hooksPath = path.join(cursorDir, "hooks.json");
+  backupFile(hooksPath);
 
   let existing = { version: 1, hooks: {} };
   if (fs.existsSync(hooksPath)) {
@@ -1127,15 +1229,7 @@ function writeAgentInstructionFiles() {
     "",
   ].join("\n");
 
-  const targets = [
-    ["Claude Code", path.join(HOME, ".claude", "CLAUDE.md")],
-    ["Codex", path.join(HOME, ".codex", "AGENTS.md")],
-    ["Aider", path.join(HOME, ".aider", "CONVENTIONS.md")],
-    ["Goose", path.join(HOME, ".config", "goose", "AGENTS.md")],
-    ["OpenCode", path.join(HOME, ".config", "opencode", "AGENTS.md")],
-  ];
-
-  for (const [name, filePath] of targets) {
+  for (const [name, filePath] of INSTRUCTION_TARGETS) {
     try {
       const dir = path.dirname(filePath);
       if (!fs.existsSync(dir) && name !== "Claude Code" && name !== "Codex") {
@@ -1154,6 +1248,7 @@ function writeAgentInstructionFiles() {
       if (!existsAgent) continue;
 
       fs.mkdirSync(dir, { recursive: true });
+      backupFile(filePath);
       let next = body;
       if (fs.existsSync(filePath)) {
         const prev = fs.readFileSync(filePath, "utf8");
@@ -1204,6 +1299,8 @@ module.exports = {
   configureMcp,
   removeMcp,
   revertAll,
+  removePluginArtifacts,
+  stripInstructionBlock,
   clearProxyOverrides,
   AGENTS,
   AGENT_CATALOG,

--- a/packages/proxy/src/detector.js
+++ b/packages/proxy/src/detector.js
@@ -81,6 +81,22 @@ const CURSOR_RULE_DIRS = [
   path.join(HOME, ".config", "cursor", "rules"),
 ];
 
+// Claude-style hook configs written by writeAgentPromptHooks.
+const AGENT_HOOK_TARGETS = [
+  ["Claude Code", path.join(HOME, ".claude", "settings.json"), false],
+  ["Codex", path.join(HOME, ".codex", "hooks.json"), true],
+];
+
+/**
+ * True when a hook command belongs to SuperCompress. Accepts both path
+ * separators so Windows registrations are matched too, and the env-prefixed
+ * form (`SUPERCOMPRESS_AGENT_NAME=… /path/to/hook.js`).
+ */
+function isSuperCompressCommand(command) {
+  const cmd = String(command || "");
+  return /[\\/]supercompress[\\/]/i.test(cmd) || /\bSUPERCOMPRESS_[A-Z_]+=/.test(cmd);
+}
+
 /**
  * Remove SuperCompress instruction blocks from an agent instruction file,
  * leaving the user's own content untouched. Matches on the block heading so it
@@ -88,8 +104,10 @@ const CURSOR_RULE_DIRS = [
  * and repeats, so files that accumulated duplicate blocks are fully cleaned.
  */
 function stripInstructionBlock(text) {
+  // Stop at the next heading of any level — a user section starting with "##"
+  // must not be swallowed along with the block.
   return text
-    .replace(/\n*# SuperCompress \(always on[\s\S]*?(?=\n# |$)/g, "\n")
+    .replace(/\n*# SuperCompress \(always on[\s\S]*?(?=\n#{1,6} |$)/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .replace(/^\n+/, "");
 }
@@ -826,18 +844,21 @@ function configureAll() {
 }
 
 /**
- * Revert all agent configs back to original state.
- * Returns an array of agent names that were reverted.
- */
-/**
  * Remove the plugin-mode artifacts: the Cursor rule, the Cursor hook scripts
- * and hook registrations, and the instruction blocks.
+ * and hook registrations, the Claude/Codex/Gemini hook entries, and the
+ * instruction blocks.
  *
  * These are written by writeCursorRule / writeCursorHooks /
- * writeAgentInstructionFiles. The AGENTS loop in revertAll only covers the
- * provider base-URL configs, so without this they survive `uninstall`.
+ * writeAgentPromptHooks / writeAgentInstructionFiles. The AGENTS loop in
+ * revertAll only covers the provider base-URL configs, so without this they
+ * survive `uninstall` — including installs old enough to have recorded no
+ * backup at all.
+ *
+ * @param {Set<string>} skip paths restoreBackups already returned to their
+ *   pre-install contents. Deleting those would defeat the backup.
+ * @returns {string[]} human-readable labels for what was removed
  */
-function removePluginArtifacts() {
+function removePluginArtifacts(skip = new Set()) {
   const removed = [];
   const drop = (target, label) => {
     try {
@@ -848,9 +869,26 @@ function removePluginArtifacts() {
     }
   };
 
+  /** Drop our entries from a Claude-style {hooks:{event:[{hooks:[…]}]}} map. */
+  const pruneHookMap = (events) => {
+    let changed = false;
+    for (const event of Object.keys(events)) {
+      if (!Array.isArray(events[event])) continue;
+      const kept = events[event].filter((group) => {
+        if (isSuperCompressCommand(group && group.command)) return false;
+        const inner = (group && group.hooks) || [];
+        return !inner.some((h) => isSuperCompressCommand(h && h.command));
+      });
+      if (kept.length !== events[event].length) changed = true;
+      if (kept.length) events[event] = kept;
+      else delete events[event];
+    }
+    return changed;
+  };
+
   for (const dir of CURSOR_RULE_DIRS) {
     const rule = path.join(dir, "supercompress.mdc");
-    if (fs.existsSync(rule)) drop(rule, "Cursor rule");
+    if (fs.existsSync(rule) && !skip.has(rule)) drop(rule, "Cursor rule");
   }
 
   const hooksDir = path.join(HOME, ".cursor", "hooks", "supercompress");
@@ -858,21 +896,11 @@ function removePluginArtifacts() {
 
   // Cursor hooks.json: drop only our entries so unrelated hooks survive.
   const hooksPath = path.join(HOME, ".cursor", "hooks.json");
-  if (fs.existsSync(hooksPath)) {
+  if (fs.existsSync(hooksPath) && !skip.has(hooksPath)) {
     try {
       const data = JSON.parse(fs.readFileSync(hooksPath, "utf8"));
       const events = (data && data.hooks) || {};
-      let changed = false;
-      for (const event of Object.keys(events)) {
-        if (!Array.isArray(events[event])) continue;
-        const kept = events[event].filter(
-          (e) => !String((e && e.command) || "").includes("/supercompress/")
-        );
-        if (kept.length !== events[event].length) changed = true;
-        if (kept.length) events[event] = kept;
-        else delete events[event];
-      }
-      if (changed) {
+      if (pruneHookMap(events)) {
         if (Object.keys(events).length === 0) drop(hooksPath, "Cursor hooks.json");
         else {
           data.hooks = events;
@@ -885,8 +913,48 @@ function removePluginArtifacts() {
     }
   }
 
+  // Claude Code / Codex prompt + tool hooks. Backed up since this change, but
+  // installs from earlier releases have no manifest to restore from.
+  for (const [name, filePath, deleteWhenEmpty] of AGENT_HOOK_TARGETS) {
+    if (!fs.existsSync(filePath) || skip.has(filePath)) continue;
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      const events = (data && data.hooks) || {};
+      if (!pruneHookMap(events)) continue;
+      if (Object.keys(events).length === 0) {
+        delete data.hooks;
+        // hooks.json exists only for hooks; settings.json holds user config.
+        if (deleteWhenEmpty && Object.keys(data).length === 0) {
+          drop(filePath, `${name} hooks`);
+          continue;
+        }
+      } else {
+        data.hooks = events;
+      }
+      fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+      removed.push(`${name} hooks`);
+    } catch (err) {
+      console.error(`  ✗ Failed to clean ${filePath}: ${err.message}`);
+    }
+  }
+
+  // Gemini CLI carries a flag rather than hooks.
+  const geminiPath = path.join(HOME, ".gemini", "settings.json");
+  if (fs.existsSync(geminiPath) && !skip.has(geminiPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(geminiPath, "utf8"));
+      if (data && data.supercompress) {
+        delete data.supercompress;
+        fs.writeFileSync(geminiPath, `${JSON.stringify(data, null, 2)}\n`);
+        removed.push("Gemini CLI flag");
+      }
+    } catch (err) {
+      console.error(`  ✗ Failed to clean ${geminiPath}: ${err.message}`);
+    }
+  }
+
   for (const [name, filePath] of INSTRUCTION_TARGETS) {
-    if (!fs.existsSync(filePath)) continue;
+    if (!fs.existsSync(filePath) || skip.has(filePath)) continue;
     try {
       const prev = fs.readFileSync(filePath, "utf8");
       const next = stripInstructionBlock(prev);
@@ -905,6 +973,10 @@ function removePluginArtifacts() {
   return removed;
 }
 
+/**
+ * Revert all agent configs back to original state.
+ * Returns an array of agent names that were reverted.
+ */
 function revertAll() {
   const reverted = [];
   const restored = restoreBackups();
@@ -912,7 +984,7 @@ function revertAll() {
   for (const agent of AGENTS) {
     const filePath = agent.detect();
     if (filePath && restored.has(filePath)) {
-      reverted.push(agent.name);
+      reverted.push(`Reverted ${agent.name}`);
       continue;
     }
     if (filePath) {
@@ -921,7 +993,7 @@ function revertAll() {
         const updated = agent.configure(config, true);
         if (updated) {
           agent.write(filePath, updated);
-          reverted.push(agent.name);
+          reverted.push(`Reverted ${agent.name}`);
         }
       } catch {}
     }
@@ -933,7 +1005,10 @@ function revertAll() {
     removeFromShellProfile("OPENAI_API_BASE");
   }
 
-  return reverted;
+  // Runs last, and skips whatever restoreBackups already returned to its
+  // pre-install contents — otherwise a user's own file at one of these paths
+  // would be restored and then deleted.
+  return reverted.concat(removePluginArtifacts(restored).map((a) => `Removed ${a}`));
 }
 
 /**
@@ -1073,10 +1148,9 @@ function writeCursorHooks() {
   if (!existing.hooks || typeof existing.hooks !== "object") existing.hooks = {};
   if (!existing.version) existing.version = 1;
 
-  const isOurs = (entry) => {
-    const cmd = String((entry && entry.command) || "");
-    return cmd.includes("hooks/supercompress/") || cmd.includes("/supercompress/");
-  };
+  // Shared with the uninstaller so install-time dedupe and uninstall-time
+  // cleanup agree — notably on Windows, where the command holds backslashes.
+  const isOurs = (entry) => isSuperCompressCommand(entry && entry.command);
 
   const ensureHook = (event, entry) => {
     const list = Array.isArray(existing.hooks[event])

--- a/packages/proxy/test/run-all.js
+++ b/packages/proxy/test/run-all.js
@@ -8,6 +8,7 @@ const path = require("path");
 const ROOT = path.join(__dirname, "..");
 const suites = [
   ["smoke", "test/smoke.js"],
+  ["uninstall-clean", "test/uninstall-clean.js"],
   ["dual-launch", "test/dual-launch.js"],
   ["compress-deep", "test/compress-deep.js"],
   ["bug-hunt", "test/bug-hunt.js"],

--- a/packages/proxy/test/uninstall-clean.js
+++ b/packages/proxy/test/uninstall-clean.js
@@ -137,4 +137,90 @@ let passed = 0;
   passed++;
 }
 
+// 3. A user's own file at one of our paths is backed up and restored — the
+//    artifact sweep must not then delete what the restore just put back.
+{
+  const home = newHome();
+  const rulePath = path.join(home, ".cursor", "rules", "supercompress.mdc");
+  const mine = "MY OWN CURSOR RULE - not supercompress\n";
+  fs.mkdirSync(path.dirname(rulePath), { recursive: true });
+  fs.writeFileSync(rulePath, mine);
+
+  run(home, "plugin");
+  run(home, "uninstall");
+
+  assert.ok(fs.existsSync(rulePath), "a pre-existing user file must survive uninstall");
+  assert.strictEqual(
+    fs.readFileSync(rulePath, "utf8"),
+    mine,
+    "a pre-existing user file must be restored to its original contents"
+  );
+  fs.rmSync(home, { recursive: true, force: true });
+  console.log("✔ a user's own file at one of our paths is restored, not deleted");
+  passed++;
+}
+
+// 4. Stripping the instruction block must stop at the next heading of any
+//    level, or a user section starting with "##" is swallowed with it.
+{
+  const { stripInstructionBlock } = require(path.join(ROOT, "src", "detector.js"));
+  const input = [
+    "# My notes", "", "Keep this.", "",
+    "# SuperCompress (always on · context only)", "", "Compress bulky context.", "",
+    "## My own subsection", "", "This must survive.", "",
+  ].join("\n");
+  const out = stripInstructionBlock(input);
+  assert.ok(out.includes("Keep this."), "content before the block must survive");
+  assert.ok(out.includes("## My own subsection"), "a following h2 section must survive");
+  assert.ok(out.includes("This must survive."), "content under a following h2 must survive");
+  assert.ok(!out.includes("SuperCompress (always on"), "the block itself must be removed");
+  console.log("✔ block stripping stops at the next heading of any level");
+  passed++;
+}
+
+// 5. Claude/Codex hook registrations from an install that recorded no backup
+//    must still be removed — including Windows-style backslash paths.
+{
+  const home = newHome();
+  const settings = path.join(home, ".claude", "settings.json");
+  const codexHooks = path.join(home, ".codex", "hooks.json");
+  fs.writeFileSync(
+    settings,
+    JSON.stringify({
+      model: "opus",
+      hooks: {
+        PostToolUse: [
+          { hooks: [{ type: "command", command: "C:\\Users\\me\\.cursor\\hooks\\supercompress\\post-tool-compress.js" }], matcher: ".*" },
+        ],
+        UserPromptSubmit: [{ hooks: [{ type: "command", command: "/usr/bin/mine" }] }],
+      },
+    })
+  );
+  fs.writeFileSync(
+    codexHooks,
+    JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "SUPERCOMPRESS_AGENT_NAME=Codex /home/u/.cursor/hooks/supercompress/user-prompt-submit.js" }] },
+        ],
+      },
+    })
+  );
+
+  run(home, "uninstall");
+
+  const after = JSON.parse(fs.readFileSync(settings, "utf8"));
+  assert.strictEqual(
+    after.hooks && after.hooks.PostToolUse,
+    undefined,
+    "Windows-path SuperCompress hook must be removed from settings.json"
+  );
+  assert.ok(after.hooks && after.hooks.UserPromptSubmit, "the user's own hook must survive");
+  assert.strictEqual(after.model, "opus", "unrelated settings must survive");
+  assert.ok(!fs.existsSync(codexHooks), "a Codex hooks.json holding only our entries must be removed");
+  fs.rmSync(home, { recursive: true, force: true });
+  console.log("✔ Claude/Codex hook registrations are removed, Windows paths included");
+  passed++;
+}
+
 console.log(`\nuninstall-clean: ${passed} checks passed`);

--- a/packages/proxy/test/uninstall-clean.js
+++ b/packages/proxy/test/uninstall-clean.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * `supercompress uninstall` must leave nothing behind.
+ *
+ * uninstall reported success while leaving the Cursor rule, the Cursor hook
+ * scripts and registrations, and the agent instruction blocks in place:
+ * revertAll only ever walked the provider base-URL configs, and the writers
+ * responsible recorded no backup for the uninstaller to restore from.
+ *
+ * Every command runs against a throwaway HOME, so the suite never touches the
+ * developer's real agent configuration.
+ */
+
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const ROOT = path.join(__dirname, "..");
+const CLI = path.join(ROOT, "bin", "supercompress.js");
+
+function run(home, ...args) {
+  const res = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 60000,
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+  });
+  assert.strictEqual(res.status, 0, `${args.join(" ")} exited ${res.status}: ${res.stderr}`);
+  return res.stdout;
+}
+
+function newHome() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "sc-uninstall-"));
+  fs.mkdirSync(path.join(home, ".claude"), { recursive: true });
+  fs.mkdirSync(path.join(home, ".codex"), { recursive: true });
+  return home;
+}
+
+/** Every file under `dir` that still mentions SuperCompress. */
+function residue(dir) {
+  const hits = [];
+  const walk = (d) => {
+    let entries = [];
+    try { entries = fs.readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) { walk(full); continue; }
+      if (/supercompress/i.test(e.name)) { hits.push(full); continue; }
+      try {
+        if (/supercompress/i.test(fs.readFileSync(full, "utf8"))) hits.push(full);
+      } catch { /* binary or unreadable */ }
+    }
+  };
+  walk(dir);
+  return hits;
+}
+
+const USER_NOTES = "# My personal notes\n\nKeep this.\n";
+let passed = 0;
+
+// 1. Install then uninstall must restore the starting state exactly.
+{
+  const home = newHome();
+  const claudeMd = path.join(home, ".claude", "CLAUDE.md");
+  const settings = path.join(home, ".claude", "settings.json");
+  const settingsBefore = '{"model":"opus","theme":"dark"}\n';
+  fs.writeFileSync(claudeMd, USER_NOTES);
+  fs.writeFileSync(settings, settingsBefore);
+
+  run(home, "plugin");
+  assert.ok(
+    fs.readFileSync(settings, "utf8").includes("supercompress"),
+    "precondition: plugin should have installed hooks into settings.json"
+  );
+
+  run(home, "uninstall");
+
+  assert.strictEqual(
+    fs.readFileSync(claudeMd, "utf8"),
+    USER_NOTES,
+    "uninstall must restore CLAUDE.md to its pre-install content"
+  );
+  assert.strictEqual(
+    JSON.parse(fs.readFileSync(settings, "utf8")).hooks,
+    undefined,
+    "uninstall must remove the hooks it added to settings.json"
+  );
+  const left = residue(home);
+  assert.deepStrictEqual(left, [], `uninstall left artifacts behind:\n  ${left.join("\n  ")}`);
+  fs.rmSync(home, { recursive: true, force: true });
+  console.log("✔ uninstall removes every artifact and restores user content");
+  passed++;
+}
+
+// 2. Installs from releases that recorded no backups must still uninstall
+//    cleanly, and unrelated Cursor hooks must survive.
+{
+  const home = newHome();
+  const claudeMd = path.join(home, ".claude", "CLAUDE.md");
+  const hooksJson = path.join(home, ".cursor", "hooks.json");
+  const scHooks = path.join(home, ".cursor", "hooks", "supercompress");
+  fs.mkdirSync(scHooks, { recursive: true });
+  fs.mkdirSync(path.join(home, ".cursor", "rules"), { recursive: true });
+
+  fs.writeFileSync(
+    claudeMd,
+    `${USER_NOTES}\n# SuperCompress (always on · context only)\n\nCompress bulky **context**.\n\n1. Read the digest.\n`
+  );
+  fs.writeFileSync(path.join(home, ".cursor", "rules", "supercompress.mdc"), "legacy rule\n");
+  fs.writeFileSync(path.join(scHooks, "session-start.js"), "// legacy\n");
+  fs.writeFileSync(
+    hooksJson,
+    JSON.stringify({
+      version: 1,
+      hooks: {
+        sessionStart: [{ command: path.join(scHooks, "session-start.js") }],
+        myOwnHook: [{ command: "/usr/bin/true" }],
+      },
+    })
+  );
+
+  run(home, "uninstall");
+
+  assert.strictEqual(
+    fs.readFileSync(claudeMd, "utf8"),
+    USER_NOTES,
+    "uninstall must strip the instruction block without eating user content"
+  );
+  const hooks = JSON.parse(fs.readFileSync(hooksJson, "utf8")).hooks;
+  assert.ok(hooks.myOwnHook, "unrelated Cursor hooks must survive uninstall");
+  assert.strictEqual(hooks.sessionStart, undefined, "SuperCompress hook entry must be removed");
+  const left = residue(home);
+  assert.deepStrictEqual(left, [], `legacy uninstall left artifacts behind:\n  ${left.join("\n  ")}`);
+  fs.rmSync(home, { recursive: true, force: true });
+  console.log("✔ legacy installs uninstall cleanly and spare unrelated hooks");
+  passed++;
+}
+
+console.log(`\nuninstall-clean: ${passed} checks passed`);


### PR DESCRIPTION
## Problem

`supercompress uninstall` reports success while leaving most of what `plugin` installed in place.

```
→ Reverting agent configurations...
→ Reverted Claude Code
✓ SuperCompress uninstalled.
```

Still present afterwards:

| Artifact | Status |
|---|---|
| `~/.cursor/rules/supercompress.mdc` | left behind |
| `~/.cursor/hooks/supercompress/*.js` (5 scripts) | left behind |
| `~/.cursor/hooks.json` registrations | left behind |
| `~/.claude/CLAUDE.md` instruction block | left behind |
| `~/.codex/AGENTS.md` instruction block | left behind |

The user-visible consequence: someone who wants SuperCompress off their machine runs the documented command, is told it worked, and still has a `PostToolUse` hook with matcher `.*` spawning a subprocess on every tool call, plus instruction files steering their agent.

I checked this against the published `supercompress-proxy@0.5.12` as well, not just this repo — `removePluginArtifacts` is absent there too, `revertAll` is unchanged, and the same three writers record no backup. So this affects installs in the wild today.

## Root cause

`revertAll()` knows two things: `restoreBackups()`, and iterating `AGENTS` — the provider base-URL configs from the API-key-proxy design. The plugin-mode artifacts are written by `writeCursorRule()`, `writeCursorHooks()` and `writeAgentInstructionFiles()`, and none of those has a counterpart in the revert path.

Compounding it, those same three writers never called `backupFile()`, so the backup manifest couldn't cover for them either:

```
configureMcp()               → backupFile ×3
configureAll()               → backupFile ×2
writeAgentPromptHooks()      → backupFile ×3
writeCursorRule()            → none
writeCursorHooks()           → none
writeAgentInstructionFiles() → none
```

`→ Reverted Claude Code` isn't wrong, exactly — `settings.json` really was restored from the manifest. It's just silent about the five files nothing ever considered.

## Fix

- `removePluginArtifacts(skip)` removes the Cursor rule, hook scripts and registrations, the Claude Code / Codex hook entries, the Gemini flag, and the instruction blocks. It prunes hook maps entry-by-entry so unrelated hooks survive, and only deletes an instruction file when the block was its entire contents — otherwise it rewrites the file with the user's own content intact.
- It takes the set of paths `restoreBackups()` already returned to their pre-install state and skips them, so a user's own file at one of our paths is never restored and then deleted.
- `isSuperCompressCommand()` matches both path separators and the env-prefixed form, so Windows registrations are cleaned too.
- `stripInstructionBlock()` matches on the block heading — covering every variant shipped so far (`· context only`, `· Headroom-parity`) — and stops at the next heading of any level, so a following `##` section is not swallowed.
- `backupFile()` added to the three writers that lacked it, so future uninstalls restore rather than reconstruct.
- `INSTRUCTION_TARGETS`, `CURSOR_RULE_DIRS` and `AGENT_HOOK_TARGETS` hoisted to module scope so the installer and uninstaller cannot drift apart.
- `uninstall` reports each artifact it removed rather than one blanket success line.

After:

```
→ Reverted Claude Code
→ Removed Cursor rule
→ Removed Cursor hook scripts
→ Removed Cursor hook registrations
→ Removed Claude Code hooks
→ Removed Claude Code instructions
✓ SuperCompress uninstalled.
```

## Tests

New `test/uninstall-clean.js`, five checks:

1. Install → uninstall restores `CLAUDE.md` and `settings.json` to their pre-install bytes, and a recursive scan finds no remaining reference to SuperCompress anywhere under `$HOME`.
2. An install that recorded no backup manifest still uninstalls cleanly, and an unrelated user-authored Cursor hook survives.
3. A user's own file sitting at one of our paths is restored to its original contents, not deleted by the sweep.
4. Stripping stops at the next heading of any level — a following `##` section and its content survive.
5. Claude/Codex hook registrations are removed even with no backup manifest and with Windows-style backslash paths, while the user's own hooks and unrelated settings keys survive.

Each was verified to fail against the current code and pass after, neutralised in turn so none is riding on another's failure.

Every command in the suite runs against a `mkdtemp` `$HOME`, so the tests never touch the developer's real agent configuration.

## Notes

Three things I ran into that are deliberately **not** in this PR, happy to send any of them separately:

1. **Instruction blocks stack on repeated `plugin` runs.** In this repo the idempotency probe tests `prev.includes("SuperCompress (always on)")` while the writer emits `SuperCompress (always on · context only)`, so the block is appended again every run — three runs, three copies. Published 0.5.12 already solves this via `agent-plugins.stripSupercompressInstructionBlocks()`, which this repo doesn't have, so it looked better to leave it to your next sync than to fix it a second, different way here. The uninstall path above cleans up already-duplicated blocks regardless.

2. **`test/bug-hunt.js:124` spawns the real installer with no `HOME` override**, so `npm test` installs SuperCompress into the contributor's live Claude/Cursor/Codex configs. That's how I found this bug. One-line fix: pass a temp `HOME` in the `spawnSync` env.

3. **`src/forwarder.js:12` requires `node-fetch`, which `package.json` no longer declares** (dropped in 0.5.9). The published package doesn't have this — it uses global fetch with a Node 18+ guard — so it looks like this repo is behind the published build. Running the proxy from a fresh clone fails.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The uninstall path now restores backed-up files before removing legacy plugin artifacts and avoids deleting paths that restoration returned to their pre-install state.
- Adds cleanup for Cursor rules, scripts, hook registrations, agent hooks, Gemini configuration, and instruction blocks.
- Adds backups to plugin artifact writers and regression coverage for restoring pre-existing user files.
- Improves uninstall status output and includes the new cleanup suite in the test matrix.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/detector.js | Adds backup-aware plugin artifact cleanup; the restored Cursor rule is preserved because restoration and cleanup use the same path and restored-path set. |
| packages/proxy/bin/supercompress.js | Updates uninstall output to print the detailed actions returned by the expanded revert path. |
| packages/proxy/test/uninstall-clean.js | Adds isolated uninstall regressions, including direct coverage that a pre-existing Cursor rule is restored rather than deleted. |
| packages/proxy/test/run-all.js | Adds the uninstall cleanup regression suite to the full test matrix. |
| packages/proxy/package.json | Exposes the uninstall cleanup test through a dedicated package script. |
| packages/proxy/CHANGELOG.md | Documents the expanded artifact cleanup and preservation behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Run uninstall] --> B[Restore backup manifest]
  B --> C[Collect restored paths]
  C --> D[Revert provider configuration]
  D --> E[Remove plugin artifacts]
  E --> F{Path was restored?}
  F -- Yes --> G[Preserve restored user file]
  F -- No --> H[Remove SuperCompress artifact]
  G --> I[Remove MCP registrations]
  H --> I
  I --> J[Delete SuperCompress config directory]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(proxy): address review — restore-saf..."](https://github.com/supercompress/supercompress/commit/b2ab53d1185378918b7889faa354acff91477cc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51426916)</sub>

<!-- /greptile_comment -->