### PR TITLE
fix(dashboard): credits modal + auto-recharge default on

### DIFF
--- a/web/assets/css/supercompress.css
+++ b/web/assets/css/supercompress.css
@@ -3299,6 +3299,99 @@ button.btn-link-muted {
   max-width: 560px;
 }
 
+.dash-modal-card--credits {
+  max-width: 420px;
+}
+
+.dash-credits-lead {
+  margin: -4px 0 18px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--text-body);
+}
+
+.dash-credits-presets {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.dash-credits-preset {
+  padding: 10px 6px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 8px;
+  background: #fff;
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 550;
+  color: #334155;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.dash-credits-preset:hover {
+  border-color: rgba(37, 99, 235, 0.35);
+  color: var(--brand);
+}
+
+.dash-credits-preset.active {
+  border-color: var(--brand);
+  background: var(--brand-soft);
+  color: var(--brand-dark);
+}
+
+.dash-credits-amount-row {
+  position: relative;
+}
+
+.dash-credits-currency {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #64748b;
+  font-size: 14px;
+  font-weight: 550;
+  pointer-events: none;
+}
+
+.dash-credits-amount {
+  padding-left: 28px !important;
+}
+
+.dash-credits-hint {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.dash-credits-auto {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 16px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #475569;
+  cursor: pointer;
+}
+
+.dash-credits-auto input {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.dash-credits-submit {
+  margin-top: 18px !important;
+}
+
+@media (max-width: 480px) {
+  .dash-credits-presets {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 .dash-profile {
   position: relative;
 }

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -1012,7 +1012,8 @@ function syncCreditsPresets(amount) {
 function openCreditsModal() {
   const modal = $("modal-credits");
   if (!modal) {
-    handleEnablePaygCheckout(lastBillingSub?.default_credit_limit_usd || 10, false);
+    // Modal missing: still default auto-recharge ON when jumping straight to checkout
+    handleEnablePaygCheckout(lastBillingSub?.default_credit_limit_usd || 10, true);
     return;
   }
   const { min, max, def, rate } = creditLimitsFromSub(lastBillingSub);
@@ -1040,7 +1041,11 @@ function openCreditsModal() {
     err.classList.add("hidden");
   }
   const auto = $("credits-auto-recharge");
-  if (auto) auto.checked = Boolean(lastBillingSub?.auto_recharge);
+  if (auto) {
+    // Default ON when adding / topping up credits (user can uncheck).
+    // If they previously enabled auto-recharge, keep it on; never open with it forced off.
+    auto.checked = true;
+  }
   syncCreditsPresets(Number(input?.value));
   syncCreditsHint();
   modal.classList.remove("hidden");
@@ -1112,7 +1117,7 @@ function handleEnablePayg() {
   openCreditsModal();
 }
 
-async function handleEnablePaygCheckout(creditUsd, autoRecharge = false) {
+async function handleEnablePaygCheckout(creditUsd, autoRecharge = true) {
   if (apiMode === "local") {
     alert("Stripe billing is not available in local/dev mode. Set up production with STRIPE_SECRET_KEY on Vercel.");
     return;

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -26,7 +26,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <meta name="theme-color" content="rgb(251,251,248)" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=108" />
+  <link rel="stylesheet" href="assets/css/supercompress.css?v=111" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=11" />
 <style>
     /* Dashboard: no dark bg layers, full light page */
@@ -1081,6 +1081,34 @@ npm exec supercompress setup</pre>
     </div>
   </div>
 
+  <!-- Credit top-up modal -->
+  <div class="dash-modal hidden" id="modal-credits">
+    <div class="dash-modal-card dash-modal-card--credits">
+      <h2 id="credits-modal-title">Add credits</h2>
+      <p class="dash-credits-lead" id="credits-modal-lead">$0.30 = 1M tokens after your free monthly allowance. Minimum load $10 (~33M tokens).</p>
+      <div class="dash-credits-presets" id="credits-presets" role="group" aria-label="Suggested amounts">
+        <button type="button" class="dash-credits-preset" data-amount="10">$10</button>
+        <button type="button" class="dash-credits-preset" data-amount="20">$20</button>
+        <button type="button" class="dash-credits-preset" data-amount="50">$50</button>
+        <button type="button" class="dash-credits-preset" data-amount="100">$100</button>
+        <button type="button" class="dash-credits-preset" data-amount="250">$250</button>
+      </div>
+      <label class="dash-field-label" for="credits-amount">Custom amount (USD)</label>
+      <div class="dash-credits-amount-row">
+        <span class="dash-credits-currency" aria-hidden="true">$</span>
+        <input class="dash-field-input dash-credits-amount" id="credits-amount" type="number" inputmode="decimal" min="10" max="1000" step="1" value="10" />
+      </div>
+      <p class="dash-credits-hint" id="credits-hint">About 33M tokens · $10 minimum</p>
+      <label class="dash-credits-auto">
+        <input type="checkbox" id="credits-auto-recharge" checked />
+        <span>Auto-recharge this amount when balance hits $0</span>
+      </label>
+      <button type="button" class="btn-brand dash-credits-submit" id="btn-confirm-credits">Continue to checkout</button>
+      <button type="button" class="btn-link-muted" id="btn-cancel-credits">Cancel</button>
+      <p class="dash-auth-error hidden" id="credits-error"></p>
+    </div>
+  </div>
+
   </div><!-- /.df-page-inner -->
 
 <footer class="df-footer">
@@ -1154,7 +1182,7 @@ npm exec supercompress setup</pre>
   <script src="assets/js/firebase-config.js?v=3"></script>
   <script src="assets/js/supercompress.js?v=1"></script>
   <script src="assets/js/dither-kit-lite.js?v=2"></script>
-  <script type="module" src="assets/js/dashboard-api.js?v=20"></script>
+  <script type="module" src="assets/js/dashboard-api.js?v=23"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
   <script src="/assets/js/site-chrome.js?v=11"></script>
 </body>


### PR DESCRIPTION
## Summary
- Restore missing `#modal-credits` markup (amount presets + auto-recharge checkbox)
- Default auto-recharge **checked** when adding/topping up credits
- Fix fallback checkout path that was hardcoding `auto_recharge: false`
- Add credits-modal CSS + cache-bust dashboard assets

## Test plan
- [ ] Open dashboard → Billing → Add credits → modal appears with auto-recharge ticked
- [ ] Uncheck works; Continue to checkout still opens Stripe
- [ ] Hard refresh clears old `dashboard-api.js?v=20` cache

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores the dashboard credit top-up modal and makes auto-recharge the default for credit checkout.
- Adds preset and custom credit amount controls with an auto-recharge checkbox.
- Adds responsive styling for the restored modal.
- Updates checkout defaults and cache-busts dashboard assets.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the top-up modal preserves an existing subscriber's auto-recharge opt-out.

The forced checked state is submitted and persisted before checkout completion, allowing a routine top-up to silently re-enable future off-session charges.

**Files Needing Attention:** web/assets/js/dashboard-api.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/assets/js/dashboard-api.js | Restores modal-based checkout and defaults auto-recharge on, but unconditionally overrides existing subscribers' disabled setting. |
| web/dashboard.html | Adds complete credit-modal markup and updates dashboard asset versions; its IDs and structure match the JavaScript bindings and modal conventions. |
| web/assets/css/supercompress.css | Adds focused responsive styling for the credit modal without an identified functional issue. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as Existing subscriber
  participant D as Dashboard modal
  participant B as Billing API
  participant S as Stripe
  U->>D: Open Add credits
  D->>D: Force auto-recharge checked
  U->>D: Continue to checkout
  D->>B: "auto_recharge=true"
  B->>B: Persist auto-recharge setting
  B->>S: Create checkout session
  S-->>U: Open Stripe Checkout
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): restore credits modal wi..."](https://github.com/supercompress/supercompress/commit/ed082f62069c45d6347bf6b3b40182363c0d4321) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51525925)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->