### PR TITLE
fix(proxy): preserve tool protocol and harden local runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Public page: https://www.supercompress.dev/changelog
 - Fix demo CO₂ grams over-count (`×1000` bug)
 
 ### Coding agent plugin
+- Protocol/runtime safety: native `fetch` (drop `node-fetch`), owned-PID-only stop, buffered SSE that preserves `tool_calls`, skip compression for structured tool/Responses items, inject digests as user (not system), fail-open on compress timeout/5xx, block browser `Origin` on local proxy, zstd size caps, spawn via `process.execPath`
 - See **[0.5.17](#0517--2026-08-10)** / **[0.5.16](#0516--2026-08-09)** below
 
 ### Repository hygiene

--- a/packages/proxy/bin/supercompress.js
+++ b/packages/proxy/bin/supercompress.js
@@ -408,18 +408,41 @@ async function main() {
   }
 }
 
-function isRunning() {
+function readPidFile() {
   try {
-    if (fs.existsSync(PID_PATH)) {
-      const pid = parseInt(fs.readFileSync(PID_PATH, "utf8").trim(), 10);
-      // A PID alone is not enough: stale PID files can point at another process.
-      process.kill(pid, 0);
-      return true;
-    }
+    if (!fs.existsSync(PID_PATH)) return null;
+    const pid = parseInt(fs.readFileSync(PID_PATH, "utf8").trim(), 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
   } catch {
-    // stale PID
-    try { fs.unlinkSync(PID_PATH); } catch {}
+    return null;
   }
+}
+
+/** True only if pid looks like our proxy server.js (not a reused PID). */
+function isOurProxyProcess(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return false;
+  }
+  try {
+    const out = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return /supercompress|packages[\\/]+proxy[\\/]+src[\\/]+server\.js|proxy[\\/]+src[\\/]+server\.js/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+function isRunning() {
+  const pid = readPidFile();
+  if (!pid) return false;
+  if (isOurProxyProcess(pid)) return true;
+  // Stale or reused PID — drop the file so we never SIGTERM a stranger.
+  try { fs.unlinkSync(PID_PATH); } catch {}
   return false;
 }
 
@@ -478,6 +501,8 @@ function killListenerOnPort(port) {
     for (const line of out.split("\n")) {
       const pid = parseInt(line.trim(), 10);
       if (!pid || pid === process.pid) continue;
+      // Never SIGTERM an unrelated listener (dev servers, Docker, etc.).
+      if (!isOurProxyProcess(pid)) continue;
       try {
         process.kill(pid, "SIGTERM");
         killed = true;
@@ -495,7 +520,7 @@ async function startServer(config) {
   const logPath = path.join(CONFIG_DIR, "proxy.log");
   fs.mkdirSync(CONFIG_DIR, { recursive: true });
   const logFd = fs.openSync(logPath, "a");
-  const child = spawn("node", [serverPath, String(port)], {
+  const child = spawn(process.execPath, [serverPath, String(port)], {
     detached: true,
     stdio: ["ignore", logFd, logFd],
     env: {
@@ -528,16 +553,16 @@ async function startServer(config) {
 function stopServer(port) {
   let stopped = false;
   try {
-    if (fs.existsSync(PID_PATH)) {
-      const pid = parseInt(fs.readFileSync(PID_PATH, "utf8").trim(), 10);
+    const pid = readPidFile();
+    if (pid && isOurProxyProcess(pid)) {
       try {
         process.kill(pid, "SIGTERM");
         stopped = true;
       } catch {}
-      try { fs.unlinkSync(PID_PATH); } catch {}
     }
+    try { fs.unlinkSync(PID_PATH); } catch {}
   } catch {}
-  // Also clear orphaned listeners (stale PID / launchd / older installs).
+  // Also clear orphaned SuperCompress listeners only (never foreign processes).
   const targetPort = port || loadConfig()?.port || 8080;
   if (killListenerOnPort(targetPort)) stopped = true;
   if (stopped) console.log("  ✓ Proxy stopped.");

--- a/packages/proxy/src/compressor.js
+++ b/packages/proxy/src/compressor.js
@@ -1,177 +1,202 @@
 /**
- * Compressor — calls the SuperCompress hosted API to compress message context.
+ * Compressor — calls SuperCompress API to compress conversation context.
  *
- * Every call uses the user's SuperCompress API key (from config),
- * which authenticates against their plan and counts toward their
- * monthly token quota. This is the monetization hook.
- *
- * The hosted API endpoint: POST https://supercompress.dev/api/v1/compress
+ * Protocol safety:
+ * - Structured tool / multimodal messages pass through uncompressed.
+ * - Compressed history is injected as a user digest (never elevated to system).
+ * - All system messages are preserved (joined), not overwritten.
+ * - Network / 5xx failures fail open (return original messages).
  */
 
-// Native fetch handles the hosted API's compressed responses reliably on the
-// Node versions supported by the CLI. node-fetch can report premature closes
-// for larger gzip responses even when the server returned a valid body.
-const fetch = globalThis.fetch;
-const path = require("path");
 const fs = require("fs");
+const path = require("path");
 const os = require("os");
 
-// Use the canonical host directly. The apex domain redirects to www, and
-// node-fetch can fail while replaying a compressed request across that 308.
-const SUPERCOMPRESS_API = "https://www.supercompress.dev/api/v1/compress";
+const SUPERCOMPRESS_API =
+  process.env.SUPERCOMPRESS_API_URL || "https://www.supercompress.dev/api/v1/compress";
+const COMPRESS_TIMEOUT_MS = Number(process.env.SUPERCOMPRESS_COMPRESS_TIMEOUT_MS || 12_000);
 
-/**
- * Load the user's API key from config.
- * Falls back to SUPERCOMPRESS_API_KEY env var.
- */
 function getApiKey() {
-  const envKey = String(process.env.SUPERCOMPRESS_API_KEY || "").trim();
-  // Ignore unresolved placeholders / non-sc_ values (Cursor used to inject
-  // the literal "${SUPERCOMPRESS_API_KEY}" into MCP/proxy env).
-  if (envKey && !envKey.includes("${") && envKey.startsWith("sc_")) {
-    return envKey;
-  }
-  const configPath = path.join(
-    process.env.SUPERCOMPRESS_CONFIG_DIR || path.join(os.homedir(), ".supercompress"),
-    "config.json"
-  );
+  if (process.env.SUPERCOMPRESS_API_KEY) return process.env.SUPERCOMPRESS_API_KEY;
   try {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-    const key = String(config.api_key || "").trim();
-    return key || null;
-  } catch {
-    return null;
+    const configPath = path.join(
+      process.env.SUPERCOMPRESS_CONFIG_DIR || path.join(os.homedir(), ".supercompress"),
+      "config.json"
+    );
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+      return config.api_key || null;
+    }
+  } catch {}
+  return null;
+}
+
+function messageText(content) {
+  if (typeof content === "string") return content;
+  if (content == null) return "";
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (!part || typeof part !== "object") return "";
+        return part.text || part.content || part.input_text || part.output_text || "";
+      })
+      .filter(Boolean)
+      .join("\n");
   }
+  if (typeof content === "object") {
+    return content.text || content.content || JSON.stringify(content);
+  }
+  return String(content);
+}
+
+/** True when history contains tool protocol that must not be flattened. */
+function hasStructuredProtocol(messages) {
+  if (!Array.isArray(messages)) return false;
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") continue;
+    const role = String(msg.role || "");
+    if (role === "tool" || role === "function") return true;
+    if (msg.tool_calls || msg.function_call || msg.tool_call_id || msg.name) return true;
+    if (Array.isArray(msg.content)) {
+      for (const part of msg.content) {
+        if (!part || typeof part !== "object") continue;
+        const t = String(part.type || "");
+        if (
+          t &&
+          t !== "text" &&
+          t !== "input_text" &&
+          t !== "output_text"
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }
 
 /**
- * Assemble the messages into a context + query pair for compression.
- *
- * Strategy:
- * - The last user message becomes the "query"
- * - All previous messages (system + assistant + user history) become the "context"
- * - If there's only one message, return it uncompressed
+ * Assemble compressible text context while preserving all system messages.
+ * Last user message = query; prior non-system turns = context (text only).
  */
 function assembleMessages(messages) {
   if (!messages || messages.length === 0) {
-    return { context: "", query: "", systemMsg: null };
+    return { context: "", query: "", systemMsgs: [] };
   }
 
-  let systemMsg = null;
+  const systemMsgs = [];
   const nonSystem = [];
 
   for (const msg of messages) {
-    if (msg.role === "system") {
-      systemMsg = msg;
+    if (msg.role === "system" || msg.role === "developer") {
+      systemMsgs.push(msg);
     } else {
       nonSystem.push(msg);
     }
   }
 
   if (nonSystem.length === 0) {
-    return { context: "", query: "", systemMsg };
+    return { context: "", query: "", systemMsgs };
   }
 
-  // The last user message becomes the query
   let query = "";
-  let contextParts = [];
-
+  const contextParts = [];
   const lastIdx = nonSystem.length - 1;
   const last = nonSystem[lastIdx];
 
   if (last.role === "user") {
-    query = typeof last.content === "string" ? last.content : JSON.stringify(last.content);
-    // Everything before the last user message is context
+    query = messageText(last.content);
     for (let i = 0; i < lastIdx; i++) {
       const msg = nonSystem[i];
-      const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
-      contextParts.push(`[${msg.role}]: ${content}`);
+      contextParts.push(`[${msg.role}]: ${messageText(msg.content)}`);
     }
   } else {
-    // Last message is not user — compress everything
     for (const msg of nonSystem) {
-      const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
-      contextParts.push(`[${msg.role}]: ${content}`);
+      contextParts.push(`[${msg.role}]: ${messageText(msg.content)}`);
     }
     query = "Continue the conversation.";
   }
 
-  const context = contextParts.join("\n\n");
-
-  return { context, query, systemMsg };
+  return { context: contextParts.join("\n\n"), query, systemMsgs };
 }
 
-/**
- * Detect the coding agent name from environment variables or config.
- * Used to tag compress API calls for per-agent usage tracking.
- */
 function detectAgentName() {
-  // Prefer explicit env (proxy / hooks set this per agent).
   if (process.env.SUPERCOMPRESS_AGENT_NAME) {
     return process.env.SUPERCOMPRESS_AGENT_NAME;
   }
-  // Never use configured_agents[0] — setup lists every detected agent, so the
-  // first entry (often Claude Code) would mis-attribute Cursor traffic.
   return "coding-agent";
+}
+
+function passThrough(messages, wordCount, skipReason) {
+  return {
+    messages,
+    original_tokens: wordCount,
+    compressed_tokens: wordCount,
+    tokens_saved: 0,
+    savings_pct: 0,
+    skip_reason: skipReason,
+  };
 }
 
 /**
  * Compress a list of messages via the SuperCompress API.
- *
- * @param {Array} messages - The conversation messages to compress
- * @param {string} [agentName] - Optional coding agent name for usage tracking
- * Returns the compressed messages array (replacing context messages
- * with a compressed version) plus compression stats.
  */
 async function compress(messages, agentName) {
+  if (hasStructuredProtocol(messages)) {
+    const words = messageText(JSON.stringify(messages)).split(/\s+/).length;
+    return passThrough(messages, words, "structured_protocol");
+  }
+
+  const { context, query, systemMsgs } = assembleMessages(messages);
+  const wordCount = context.split(/\s+/).filter(Boolean).length;
+  if (wordCount < 100) {
+    return passThrough(messages, wordCount, "context_too_small");
+  }
+
   const apiKey = getApiKey();
   if (!apiKey) {
     throw new Error(
       "SuperCompress API key not found. Run `supercompress setup` first " +
-      "or set SUPERCOMPRESS_API_KEY environment variable."
+        "or set SUPERCOMPRESS_API_KEY environment variable."
     );
   }
 
-  const { context, query, systemMsg } = assembleMessages(messages);
-
-  // Skip compression for very small contexts
-  const wordCount = context.split(/\s+/).length;
-  if (wordCount < 100) {
-    // Too small to compress meaningfully — pass through
-    return {
-      messages,
-      original_tokens: wordCount,
-      compressed_tokens: wordCount,
-      tokens_saved: 0,
-      savings_pct: 0,
-      skip_reason: "context_too_small",
-    };
-  }
-
-  // Determine the coding agent name for usage tracking
   const agent = agentName || detectAgentName();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), COMPRESS_TIMEOUT_MS);
 
-  // Call the SuperCompress API
-  const response = await fetch(SUPERCOMPRESS_API, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-API-Key": apiKey,
-    },
-    body: JSON.stringify({
-      context,
-      query,
-      mode: "compiler",
-      coding_agent: agent,
-    }),
-  });
+  let response;
+  try {
+    response = await fetch(SUPERCOMPRESS_API, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": apiKey,
+      },
+      body: JSON.stringify({
+        context,
+        query,
+        mode: "compiler",
+        coding_agent: agent,
+      }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    const reason = err?.name === "AbortError" ? "timeout" : "network_error";
+    console.error(`[supercompress] Compress ${reason} — passing through uncompressed`);
+    return passThrough(messages, wordCount, reason);
+  } finally {
+    clearTimeout(timer);
+  }
 
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");
     if (response.status === 401) {
       throw new Error(
         "Invalid SuperCompress API key. Run `supercompress setup` to update it " +
-        "or get a new key at https://www.supercompress.dev/dashboard"
+          "or get a new key at https://www.supercompress.dev/dashboard"
       );
     }
     const paywalled =
@@ -188,18 +213,14 @@ async function compress(messages, agentName) {
       throw err;
     }
     if (response.status === 429) {
-      // Pure rate limit — pass through uncompressed (do NOT soft-pass paywalls)
       console.error("[supercompress] Rate limit reached — passing through uncompressed");
-      return {
-        messages,
-        original_tokens: wordCount,
-        compressed_tokens: wordCount,
-        tokens_saved: 0,
-        savings_pct: 0,
-        skip_reason: "rate_limited",
-      };
+      return passThrough(messages, wordCount, "rate_limited");
     }
-    throw new Error(`SuperCompress API error (${response.status}): ${errorBody.slice(0, 200)}`);
+    // 5xx / other: fail open so a hosted outage does not brick the agent.
+    console.error(
+      `[supercompress] API error (${response.status}) — passing through uncompressed`
+    );
+    return passThrough(messages, wordCount, `http_${response.status}`);
   }
 
   const result = await response.json();
@@ -212,41 +233,27 @@ async function compress(messages, agentName) {
     result.kv_savings_pct ??
     (originalTokens > 0 ? Math.round((tokensSaved / originalTokens) * 100) : 0);
 
-  // Never forward an empty compression result — that would wipe agent context.
-  // This can happen on highly repetitive dumps where the policy drops everything.
   if (!compressedText.trim()) {
     console.error(
       "[supercompress] Compression returned empty context — passing through uncompressed"
     );
-    return {
-      messages,
-      original_tokens: result.original_tokens || wordCount,
-      compressed_tokens: result.kept_tokens || result.original_tokens || wordCount,
-      tokens_saved: 0,
-      savings_pct: 0,
-      skip_reason: "empty_compression",
-    };
+    return passThrough(messages, originalTokens, "empty_compression");
   }
 
-  // Reconstruct the messages array with compressed content
   const compressedMessages = [];
+  for (const sys of systemMsgs) compressedMessages.push(sys);
 
-  // Keep system message as-is
-  if (systemMsg) {
-    compressedMessages.push(systemMsg);
-  }
-
-  // Add compressed context as a system message
+  // User-role digest — never elevate tool/history content to system authority.
   compressedMessages.push({
-    role: "system",
-    content: `[Compressed context — ${tokensSaved} tokens saved (~${Math.round(tokensSavedPct)}%)]\n\n${compressedText}`,
+    role: "user",
+    content:
+      `[Compressed prior context — ${tokensSaved} tokens saved (~${Math.round(tokensSavedPct)}%)]\n\n` +
+      `${compressedText}\n\n` +
+      `(End compressed context. Follow the next user message as the active ask.)`,
   });
 
-  // Add the last user message (query) unchanged
-  const lastUserMsg = messages.filter((m) => m.role === "user").pop();
-  if (lastUserMsg) {
-    compressedMessages.push(lastUserMsg);
-  }
+  const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
+  if (lastUserMsg) compressedMessages.push(lastUserMsg);
 
   return {
     messages: compressedMessages,
@@ -257,4 +264,10 @@ async function compress(messages, agentName) {
   };
 }
 
-module.exports = { compress, assembleMessages, getApiKey };
+module.exports = {
+  compress,
+  assembleMessages,
+  getApiKey,
+  hasStructuredProtocol,
+  messageText,
+};

--- a/packages/proxy/src/forwarder.js
+++ b/packages/proxy/src/forwarder.js
@@ -4,19 +4,15 @@
  * Supports:
  *   - OpenAI (POST /v1/chat/completions) — streaming + non-streaming
  *   - Anthropic (POST /v1/messages) — streaming + non-streaming
+ *   - OpenAI Responses (POST /v1/responses)
  *
- * The user's original API key for the provider is extracted from the
- * Authorization header passed from the server route handler.
+ * Uses Node's native fetch (Node >=18). Streaming preserves tool_calls and
+ * other delta fields; SSE lines are buffered across TCP chunks.
  */
-
-const fetch = require("node-fetch");
 
 const OPENAI_BASE = process.env.SUPERCOMPRESS_OPENAI_BASE || "https://api.openai.com/v1";
 const ANTHROPIC_BASE = process.env.SUPERCOMPRESS_ANTHROPIC_BASE || "https://api.anthropic.com";
 
-/**
- * Extract Bearer token from an Authorization header string.
- */
 function extractBearer(authorization) {
   if (!authorization) return null;
   const match = authorization.match(/^Bearer\s+(.+)$/i);
@@ -27,10 +23,6 @@ function extractProviderKey(authorization, apiKeyHeader) {
   return extractBearer(authorization) || apiKeyHeader || null;
 }
 
-/**
- * Try to parse a provider error response into a human-readable message.
- * Falls back to raw text if JSON parsing fails.
- */
 function parseProviderError(status, body) {
   try {
     const errJson = JSON.parse(body);
@@ -41,35 +33,15 @@ function parseProviderError(status, body) {
 }
 
 function shouldFallbackResponses(status, body) {
-  // Some OpenAI-compatible gateways strip the JSON error body. A 401 on the
-  // Responses endpoint is still safe to retry through Chat Completions: an
-  // invalid key will fail there with the provider's actual auth error.
-  return status === 401 || (status === 403 && /api\.responses\.write|responses.*scope|responses.*permission|missing scope/i.test(body || ""));
+  return (
+    status === 401 ||
+    (status === 403 &&
+      /api\.responses\.write|responses.*scope|responses.*permission|missing scope/i.test(
+        body || ""
+      ))
+  );
 }
 
-/**
- * Build the OpenAI-style streaming response for a chunk.
- * Accepts an optional extraFields object to merge into the chunk data.
- */
-function openaiStreamChunk(id, model, content, finishReason, created, extraFields) {
-  const data = {
-    id,
-    object: "chat.completion.chunk",
-    created: created || Math.floor(Date.now() / 1000),
-    model,
-    choices: [{
-      index: 0,
-      delta: content ? { content } : {},
-      finish_reason: finishReason || null,
-    }],
-    ...extraFields,
-  };
-  return `data: ${JSON.stringify(data)}\n\n`;
-}
-
-/**
- * Set SSE headers on the response.
- */
 function setSSEHeaders(res) {
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
@@ -78,17 +50,83 @@ function setSSEHeaders(res) {
 }
 
 /**
+ * Pipe an SSE body to res, buffering across TCP chunks.
+ * Optional onEvent(parsed, rawLine) can rewrite a data payload.
+ */
+function pipeBufferedSSE(apiResponse, res, { onDataLine } = {}) {
+  if (!apiResponse.body) throw new Error("Provider returned no response body stream");
+  let buffer = "";
+  const reader = apiResponse.body;
+  // Node fetch body is a ReadableStream in undici, or Node Readable if polyfilled.
+  if (typeof reader.getReader === "function") {
+    // Web streams (shouldn't happen with node native for node-fetch style, but safe)
+    const webReader = reader.getReader();
+    const decoder = new TextDecoder();
+    (async () => {
+      try {
+        for (;;) {
+          const { done, value } = await webReader.read();
+          if (done) break;
+          buffer = flushSSEBuffer(buffer + decoder.decode(value, { stream: true }), res, onDataLine);
+        }
+        if (buffer.trim()) flushSSEBuffer(buffer + "\n", res, onDataLine);
+        res.end();
+      } catch (err) {
+        console.error("[supercompress] Stream error:", err.message);
+        if (!res.writableEnded) res.end();
+      }
+    })();
+    return;
+  }
+
+  reader.on("data", (chunk) => {
+    buffer = flushSSEBuffer(buffer + chunk.toString(), res, onDataLine);
+  });
+  reader.on("end", () => {
+    if (buffer.trim()) flushSSEBuffer(buffer + "\n", res, onDataLine);
+    res.end();
+  });
+  reader.on("error", (err) => {
+    console.error("[supercompress] Stream error:", err.message);
+    if (!res.writableEnded) res.end();
+  });
+}
+
+function flushSSEBuffer(buffer, res, onDataLine) {
+  const lines = buffer.split("\n");
+  const rest = lines.pop() || "";
+  for (const line of lines) {
+    if (onDataLine && line.startsWith("data: ") && line !== "data: [DONE]") {
+      try {
+        const parsed = JSON.parse(line.slice(6));
+        const rewritten = onDataLine(parsed, line);
+        if (rewritten == null) continue;
+        res.write(typeof rewritten === "string" ? rewritten : `data: ${JSON.stringify(rewritten)}\n\n`);
+        continue;
+      } catch {
+        // Incomplete JSON mid-buffer shouldn't reach here (we only flush full lines).
+        // If a single line is corrupt, forward raw so we don't drop the stream.
+        res.write(line + "\n");
+        continue;
+      }
+    }
+    res.write(line + "\n");
+  }
+  return rest;
+}
+
+/**
  * Forward to OpenAI chat completions — supports streaming.
  */
 async function forwardChat(model, compressed, extraParams, res, authHeader) {
   const apiKey = extractBearer(authHeader);
-
   if (!apiKey) {
-    throw new Error("No provider API key found in Authorization header. Login-only subscription sessions are not supported by this local proxy; use the provider's API-key mode.");
+    throw new Error(
+      "No provider API key found in Authorization header. Login-only subscription sessions are not supported by this local proxy; use the provider's API-key mode."
+    );
   }
 
   const isStream = extraParams.stream === true || extraParams.stream === "true";
-
   const body = {
     model,
     messages: compressed.messages,
@@ -96,7 +134,6 @@ async function forwardChat(model, compressed, extraParams, res, authHeader) {
     stream: isStream,
   };
 
-  // Build supercompress metadata once
   const scMeta = {
     _supercompress: {
       original_tokens: compressed.original_tokens,
@@ -107,10 +144,7 @@ async function forwardChat(model, compressed, extraParams, res, authHeader) {
   };
 
   if (isStream) {
-    // ── Streaming mode ──
-    // Set SSE headers before the fetch so they're set even on error
     setSSEHeaders(res);
-
     const apiResponse = await fetch(`${OPENAI_BASE}/chat/completions`, {
       method: "POST",
       headers: {
@@ -123,55 +157,25 @@ async function forwardChat(model, compressed, extraParams, res, authHeader) {
     if (!apiResponse.ok) {
       const errorBody = await apiResponse.text().catch(() => "");
       const msg = parseProviderError(apiResponse.status, errorBody);
-      // Send error as an SSE event so the client can parse it
       res.write(`data: ${JSON.stringify({ error: { message: msg, type: "provider_error" } })}\n\n`);
       res.write("data: [DONE]\n\n");
       res.end();
       return;
     }
 
-    if (!apiResponse.body) {
-      throw new Error("Provider returned no response body stream");
-    }
-
-    // Track whether we've sent the first chunk (to attach metadata)
     let firstChunkSent = false;
-    const streamId = `chatcmpl-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const created = Math.floor(Date.now() / 1000);
-
-    apiResponse.body.on("data", (chunk) => {
-      const text = chunk.toString();
-      const lines = text.split("\n");
-      for (const line of lines) {
-        if (line.startsWith("data: ") && line !== "data: [DONE]") {
-          try {
-            const parsed = JSON.parse(line.slice(6));
-            const delta = parsed.choices?.[0]?.delta?.content || "";
-            const finishReason = parsed.choices?.[0]?.finish_reason || null;
-
-            // Attach _supercompress metadata to the first chunk only
-            const extra = firstChunkSent ? undefined : scMeta;
-            res.write(openaiStreamChunk(streamId, model, delta, finishReason, created, extra));
-            firstChunkSent = true;
-          } catch {}
+    pipeBufferedSSE(apiResponse, res, {
+      onDataLine: (parsed) => {
+        if (!firstChunkSent) {
+          firstChunkSent = true;
+          return { ...parsed, ...scMeta };
         }
-      }
+        return parsed;
+      },
     });
-
-    apiResponse.body.on("end", () => {
-      res.write("data: [DONE]\n\n");
-      res.end();
-    });
-
-    apiResponse.body.on("error", (err) => {
-      console.error("[supercompress] Stream error:", err.message);
-      res.end();
-    });
-
     return;
   }
 
-  // ── Non-streaming mode ──
   const apiResponse = await fetch(`${OPENAI_BASE}/chat/completions`, {
     method: "POST",
     headers: {
@@ -183,48 +187,42 @@ async function forwardChat(model, compressed, extraParams, res, authHeader) {
 
   if (!apiResponse.ok) {
     const errorBody = await apiResponse.text().catch(() => "");
-    throw new Error(`Provider error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`);
+    throw new Error(
+      `Provider error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`
+    );
   }
 
   const data = await apiResponse.json();
-
-  // Preserve the provider response verbatim. Coding agents rely on fields
-  // beyond plain text, including tool_calls, function_call, logprobs, and
-  // provider-specific usage details.
   res.json({ ...data, ...scMeta });
 }
 
-/**
- * Build Anthropic SSE event string.
- */
 function anthropicSSE(eventType, data) {
   return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
-/**
- * Forward to Anthropic messages API — supports streaming.
- */
 async function forwardAnthropic(model, compressed, system, extraParams, res, authHeader, apiKeyHeader) {
   const apiKey = extractProviderKey(authHeader, apiKeyHeader);
-
   if (!apiKey) {
-    throw new Error("No provider API key found in Authorization header. Login-only subscription sessions are not supported by this local proxy; use the provider's API-key mode.");
+    throw new Error(
+      "No provider API key found in Authorization header. Login-only subscription sessions are not supported by this local proxy; use the provider's API-key mode."
+    );
   }
 
   const isStream = extraParams.stream === true || extraParams.stream === "true";
-
   const compressedMessages = compressed.messages || [];
 
   let systemContent = system || "";
-  let userMessages = [];
+  const userMessages = [];
 
   for (const msg of compressedMessages) {
-    if (msg.role === "system") {
-      systemContent = (systemContent ? systemContent + "\n\n" : "") + msg.content;
-    } else if (msg.role === "user") {
-      userMessages.push({ role: "user", content: msg.content });
-    } else if (msg.role === "assistant") {
-      userMessages.push({ role: "assistant", content: msg.content });
+    if (msg.role === "system" || msg.role === "developer") {
+      const text = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+      systemContent = systemContent ? `${systemContent}\n\n${text}` : text;
+    } else if (msg.role === "user" || msg.role === "assistant") {
+      userMessages.push({ role: msg.role, content: msg.content });
+    } else if (msg.role === "tool") {
+      // Anthropic tool results need native shape — if present, protocol skip should have fired.
+      userMessages.push({ role: "user", content: messageContentAsText(msg.content) });
     }
   }
 
@@ -233,10 +231,7 @@ async function forwardAnthropic(model, compressed, system, extraParams, res, aut
     messages: userMessages.length > 0 ? userMessages : [{ role: "user", content: "Continue." }],
     ...extraParams,
   };
-
-  if (systemContent) {
-    body.system = systemContent;
-  }
+  if (systemContent) body.system = systemContent;
 
   const apiResponse = await fetch(`${ANTHROPIC_BASE}/v1/messages`, {
     method: "POST",
@@ -250,49 +245,26 @@ async function forwardAnthropic(model, compressed, system, extraParams, res, aut
 
   if (!apiResponse.ok) {
     const errorBody = await apiResponse.text().catch(() => "");
-    throw new Error(`Anthropic error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`);
+    throw new Error(
+      `Anthropic error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`
+    );
   }
 
   if (isStream) {
-    // ── Streaming mode ──
     setSSEHeaders(res);
-
-    if (!apiResponse.body) {
-      throw new Error("Anthropic returned no response body stream");
-    }
-
-    // Send supercompress metadata as a custom event (Anthropic SSE format)
-    res.write(anthropicSSE("supercompress", {
-      original_tokens: compressed.original_tokens,
-      compressed_tokens: compressed.compressed_tokens,
-      tokens_saved: compressed.tokens_saved,
-      savings_pct: compressed.savings_pct,
-    }));
-
-    // Pipe Anthropic SSE stream through
-    apiResponse.body.on("data", (chunk) => {
-      const text = chunk.toString();
-      // Anthropic sends SSE events like:
-      // event: content_block_delta\n
-      // data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"..."}}\n\n
-      res.write(text);
-    });
-
-    apiResponse.body.on("end", () => {
-      res.end();
-    });
-
-    apiResponse.body.on("error", (err) => {
-      console.error("[supercompress] Anthropic stream error:", err.message);
-      res.end();
-    });
-
+    res.write(
+      anthropicSSE("supercompress", {
+        original_tokens: compressed.original_tokens,
+        compressed_tokens: compressed.compressed_tokens,
+        tokens_saved: compressed.tokens_saved,
+        savings_pct: compressed.savings_pct,
+      })
+    );
+    pipeBufferedSSE(apiResponse, res);
     return;
   }
 
-  // ── Non-streaming mode ──
   const data = await apiResponse.json();
-
   res.json({
     id: data.id,
     type: "message",
@@ -311,26 +283,80 @@ async function forwardAnthropic(model, compressed, system, extraParams, res, aut
   });
 }
 
-function responseContentToText(content) {
+function messageContentAsText(content) {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return content == null ? "" : JSON.stringify(content);
-  return content.map((part) => {
-    if (typeof part === "string") return part;
-    return part.text || part.content || part.input_text || part.output_text || "";
-  }).filter(Boolean).join("\n");
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      return part?.text || part?.content || part?.input_text || part?.output_text || "";
+    })
+    .filter(Boolean)
+    .join("\n");
 }
 
+function responseContentToText(content) {
+  return messageContentAsText(content);
+}
+
+/** Typed Responses items that must not be flattened. */
+function responsesInputHasStructuredItems(input) {
+  if (!Array.isArray(input)) return false;
+  for (const item of input) {
+    if (!item || typeof item !== "object") continue;
+    const type = String(item.type || "");
+    if (
+      type === "function_call" ||
+      type === "function_call_output" ||
+      type === "tool_call" ||
+      type === "tool_result" ||
+      type === "custom_tool_call" ||
+      type === "custom_tool_call_output" ||
+      type === "reasoning" ||
+      item.call_id ||
+      item.tool_call_id
+    ) {
+      return true;
+    }
+    if (Array.isArray(item.content)) {
+      for (const part of item.content) {
+        const t = String(part?.type || "");
+        if (t && t !== "input_text" && t !== "output_text" && t !== "text") return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Convert Responses input → chat messages for compression of plain text turns only.
+ * Structured items are not supported here — caller must skip compression.
+ */
 function responsesInputToMessages(input) {
   if (typeof input === "string") return [{ role: "user", content: input }];
   if (!Array.isArray(input)) return [{ role: "user", content: JSON.stringify(input) }];
 
-  const messages = input.filter(Boolean).map((item) => {
-    if (typeof item === "string") return { role: "user", content: item };
-    return {
-      role: item.role || "user",
-      content: responseContentToText(item.content ?? item.text ?? item.input_text ?? item.output_text ?? item),
-    };
-  });
+  const messages = [];
+  for (const item of input.filter(Boolean)) {
+    if (typeof item === "string") {
+      messages.push({ role: "user", content: item });
+      continue;
+    }
+    const type = String(item.type || "");
+    if (type === "message" || item.role) {
+      messages.push({
+        role: item.role || "user",
+        content: responseContentToText(item.content ?? item.text ?? item),
+      });
+      continue;
+    }
+    // Preserve opaque structured items as JSON user blobs only when forced —
+    // prefer skip via responsesInputHasStructuredItems.
+    messages.push({
+      role: "user",
+      content: JSON.stringify(item),
+    });
+  }
   return messages.length ? messages : [{ role: "user", content: "" }];
 }
 
@@ -352,8 +378,16 @@ function responsesToChatBody(model, compressed, extraParams, isStream) {
     stream: isStream,
   };
 
-  // Preserve the provider fields that Chat Completions and Responses share.
-  for (const key of ["temperature", "top_p", "tools", "tool_choice", "parallel_tool_calls", "user", "metadata", "store"]) {
+  for (const key of [
+    "temperature",
+    "top_p",
+    "tools",
+    "tool_choice",
+    "parallel_tool_calls",
+    "user",
+    "metadata",
+    "store",
+  ]) {
     if (extraParams[key] !== undefined) body[key] = extraParams[key];
   }
   if (extraParams.max_output_tokens !== undefined) body.max_tokens = extraParams.max_output_tokens;
@@ -364,13 +398,15 @@ function responsesToChatBody(model, compressed, extraParams, isStream) {
 function responsesFallbackObject(data, model) {
   const message = data.choices?.[0]?.message || { role: "assistant", content: "" };
   const text = responseContentToText(message.content);
-  const output = [{
-    id: `msg_${Date.now().toString(36)}`,
-    type: "message",
-    status: "completed",
-    role: message.role || "assistant",
-    content: [{ type: "output_text", text, annotations: [] }],
-  }];
+  const output = [
+    {
+      id: `msg_${Date.now().toString(36)}`,
+      type: "message",
+      status: "completed",
+      role: message.role || "assistant",
+      content: [{ type: "output_text", text, annotations: [] }],
+    },
+  ];
   return {
     id: data.id || `resp_${Date.now().toString(36)}`,
     object: "response",
@@ -383,10 +419,12 @@ function responsesFallbackObject(data, model) {
   };
 }
 
-async function forwardResponsesViaChat(model, compressed, extraParams, res, apiKey, providerError) {
+async function forwardResponsesViaChatFixed(model, compressed, extraParams, res, apiKey, providerError) {
   const isStream = extraParams.stream === true || extraParams.stream === "true";
   const body = responsesToChatBody(model, compressed, extraParams, isStream);
-  console.error(`[supercompress] Responses permission unavailable; using Chat Completions compatibility fallback (${providerError.slice(0, 160)})`);
+  console.error(
+    `[supercompress] Responses permission unavailable; using Chat Completions compatibility fallback (${providerError.slice(0, 160)})`
+  );
 
   const apiResponse = await fetch(`${OPENAI_BASE}/chat/completions`, {
     method: "POST",
@@ -398,7 +436,9 @@ async function forwardResponsesViaChat(model, compressed, extraParams, res, apiK
   });
   if (!apiResponse.ok) {
     const errorBody = await apiResponse.text().catch(() => "");
-    throw new Error(`OpenAI Chat Completions fallback error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`);
+    throw new Error(
+      `OpenAI Chat Completions fallback error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`
+    );
   }
 
   if (!isStream) {
@@ -420,14 +460,28 @@ async function forwardResponsesViaChat(model, compressed, extraParams, res, apiK
   const messageId = `msg_${Date.now().toString(36)}`;
   const created = Math.floor(Date.now() / 1000);
   const writeEvent = (type, data) => res.write(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`);
-  writeEvent("response.created", { type: "response.created", response: { id: responseId, object: "response", status: "in_progress", model } });
-  writeEvent("response.output_item.added", { type: "response.output_item.added", output_index: 0, item: { id: messageId, type: "message", status: "in_progress", role: "assistant", content: [] } });
-  writeEvent("response.content_part.added", { type: "response.content_part.added", item_id: messageId, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } });
+  writeEvent("response.created", {
+    type: "response.created",
+    response: { id: responseId, object: "response", status: "in_progress", model },
+  });
+  writeEvent("response.output_item.added", {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { id: messageId, type: "message", status: "in_progress", role: "assistant", content: [] },
+  });
+  writeEvent("response.content_part.added", {
+    type: "response.content_part.added",
+    item_id: messageId,
+    output_index: 0,
+    content_index: 0,
+    part: { type: "output_text", text: "", annotations: [] },
+  });
 
   let fullText = "";
   let buffer = "";
-  apiResponse.body.on("data", (chunk) => {
-    buffer += chunk.toString();
+  const reader = apiResponse.body;
+  const onChunk = (text) => {
+    buffer += text;
     const lines = buffer.split("\n");
     buffer = lines.pop() || "";
     for (const line of lines) {
@@ -437,32 +491,100 @@ async function forwardResponsesViaChat(model, compressed, extraParams, res, apiK
         const delta = parsed.choices?.[0]?.delta?.content || "";
         if (!delta) continue;
         fullText += delta;
-        writeEvent("response.output_text.delta", { type: "response.output_text.delta", item_id: messageId, output_index: 0, content_index: 0, delta, sequence_number: fullText.length });
+        writeEvent("response.output_text.delta", {
+          type: "response.output_text.delta",
+          item_id: messageId,
+          output_index: 0,
+          content_index: 0,
+          delta,
+          sequence_number: fullText.length,
+        });
       } catch {}
     }
-  });
-  apiResponse.body.on("end", () => {
-    writeEvent("response.output_text.done", { type: "response.output_text.done", item_id: messageId, output_index: 0, content_index: 0, text: fullText });
-    writeEvent("response.content_part.done", { type: "response.content_part.done", item_id: messageId, output_index: 0, content_index: 0, part: { type: "output_text", text: fullText, annotations: [] } });
-    writeEvent("response.output_item.done", { type: "response.output_item.done", output_index: 0, item: { id: messageId, type: "message", status: "completed", role: "assistant", content: [{ type: "output_text", text: fullText, annotations: [] }] } });
-    writeEvent("response.completed", { type: "response.completed", response: { id: responseId, object: "response", status: "completed", created_at: created, model, output_text: fullText } });
+  };
+  const onEnd = () => {
+    writeEvent("response.output_text.done", {
+      type: "response.output_text.done",
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      text: fullText,
+    });
+    writeEvent("response.content_part.done", {
+      type: "response.content_part.done",
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: fullText, annotations: [] },
+    });
+    writeEvent("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        id: messageId,
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [{ type: "output_text", text: fullText, annotations: [] }],
+      },
+    });
+    writeEvent("response.completed", {
+      type: "response.completed",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "completed",
+        created_at: created,
+        model,
+        output_text: fullText,
+      },
+    });
     res.end();
-  });
-  apiResponse.body.on("error", (err) => {
+  };
+
+  if (typeof reader.getReader === "function") {
+    const webReader = reader.getReader();
+    const decoder = new TextDecoder();
+    (async () => {
+      try {
+        for (;;) {
+          const { done, value } = await webReader.read();
+          if (done) break;
+          onChunk(decoder.decode(value, { stream: true }));
+        }
+        onEnd();
+      } catch (err) {
+        console.error("[supercompress] Responses compatibility stream error:", err.message);
+        if (!res.writableEnded) res.end();
+      }
+    })();
+    return;
+  }
+
+  reader.on("data", (chunk) => onChunk(chunk.toString()));
+  reader.on("end", onEnd);
+  reader.on("error", (err) => {
     console.error("[supercompress] Responses compatibility stream error:", err.message);
-    res.end();
+    if (!res.writableEnded) res.end();
   });
 }
 
-async function forwardResponses(model, compressed, extraParams, res, authHeader) {
+async function forwardResponses(model, compressed, extraParams, res, authHeader, originalInput) {
   const apiKey = extractBearer(authHeader);
-  if (!apiKey) throw new Error("No provider API key found in Authorization header. Login-only subscription sessions are not supported by this local proxy; use the provider's API-key mode.");
+  if (!apiKey) {
+    throw new Error(
+      "No provider API key found in Authorization header. Login-only subscription sessions are not supported by this local proxy; use the provider's API-key mode."
+    );
+  }
 
   const isStream = extraParams.stream === true || extraParams.stream === "true";
+  // When compression was skipped for structured protocol, forward original input.
+  const useOriginal =
+    compressed.skip_reason === "structured_protocol" && originalInput !== undefined;
   const body = {
     ...extraParams,
     model,
-    input: messagesToResponsesInput(compressed.messages),
+    input: useOriginal ? originalInput : messagesToResponsesInput(compressed.messages),
     stream: isStream,
   };
   const apiResponse = await fetch(`${OPENAI_BASE}/responses`, {
@@ -477,15 +599,24 @@ async function forwardResponses(model, compressed, extraParams, res, authHeader)
   if (!apiResponse.ok) {
     const errorBody = await apiResponse.text().catch(() => "");
     if (shouldFallbackResponses(apiResponse.status, errorBody)) {
-      await forwardResponsesViaChat(model, compressed, extraParams, res, apiKey, parseProviderError(apiResponse.status, errorBody));
+      await forwardResponsesViaChatFixed(
+        model,
+        compressed,
+        extraParams,
+        res,
+        apiKey,
+        parseProviderError(apiResponse.status, errorBody)
+      );
       return;
     }
-    throw new Error(`OpenAI Responses error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`);
+    throw new Error(
+      `OpenAI Responses error (${apiResponse.status}): ${parseProviderError(apiResponse.status, errorBody)}`
+    );
   }
 
   if (isStream) {
     setSSEHeaders(res);
-    apiResponse.body.pipe(res);
+    pipeBufferedSSE(apiResponse, res);
     return;
   }
 
@@ -506,5 +637,6 @@ module.exports = {
   forwardAnthropic,
   forwardResponses,
   responsesInputToMessages,
+  responsesInputHasStructuredItems,
   extractBearer,
 };

--- a/packages/proxy/src/server.js
+++ b/packages/proxy/src/server.js
@@ -24,21 +24,37 @@ const PORT = parseInt(process.argv[2] || process.env.PROXY_PORT || "8080", 10);
 
 const app = express();
 
+const ZSTD_MAX_COMPRESSED_BYTES = 12 * 1024 * 1024; // 12 MB compressed cap
+const ZSTD_MAX_DECODED_BYTES = 10 * 1024 * 1024; // match express.json limit
+
 // Codex sends compact JSON with zstd content encoding. Decode it before
 // Express's JSON parser, which otherwise rejects the request with HTTP 415.
 app.use((req, res, next) => {
   if (req.headers["content-encoding"] !== "zstd") return next();
 
   const chunks = [];
-  req.on("data", (chunk) => chunks.push(chunk));
+  let total = 0;
+  req.on("data", (chunk) => {
+    total += chunk.length;
+    if (total > ZSTD_MAX_COMPRESSED_BYTES) {
+      res.status(413).json({ error: { message: "zstd body too large", type: "payload_too_large" } });
+      req.destroy();
+      return;
+    }
+    chunks.push(chunk);
+  });
   req.on("end", () => {
     try {
       if (typeof zlib.zstdDecompressSync !== "function") {
         res.status(415).json({ error: { message: "zstd request bodies require Node.js 22.15 or newer", type: "unsupported_encoding" } });
         return;
       }
-      const decoded = zlib.zstdDecompressSync(Buffer.concat(chunks)).toString("utf8");
-      req.body = JSON.parse(decoded);
+      const decodedBuf = zlib.zstdDecompressSync(Buffer.concat(chunks));
+      if (decodedBuf.length > ZSTD_MAX_DECODED_BYTES) {
+        res.status(413).json({ error: { message: "decompressed zstd body too large", type: "payload_too_large" } });
+        return;
+      }
+      req.body = JSON.parse(decodedBuf.toString("utf8"));
       req.headers["content-encoding"] = "identity";
       req._body = true;
       next();
@@ -51,11 +67,20 @@ app.use((req, res, next) => {
 // ── Raw body capture for streaming detection ──
 app.use(express.json({ limit: "10mb" }));
 
-// ── CORS (allow any coding agent) ──
+// ── Local-only proxy: block browser CSRF/CORS abuse of the user's SC key ──
 app.use((req, res, next) => {
-  res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key");
+  // Do not advertise wildcard CORS — coding agents are non-browser clients.
+  const origin = req.headers.origin;
+  if (origin && /^https?:\/\//i.test(String(origin)) && req.path !== "/health") {
+    return res.status(403).json({
+      error: {
+        message: "Browser origins cannot call the local SuperCompress proxy",
+        type: "forbidden_origin",
+      },
+    });
+  }
   if (req.method === "OPTIONS") return res.sendStatus(204);
   next();
 });
@@ -204,8 +229,29 @@ app.post("/v1/responses", async (req, res) => {
 
   try {
     const agentName = detectCodingAgent(req);
-    const compressed = await compressor.compress(forwarder.responsesInputToMessages(input), agentName);
-    await forwarder.forwardResponses(rest.model, compressed, rest, res, req.headers.authorization);
+    let compressed;
+    if (forwarder.responsesInputHasStructuredItems(input)) {
+      // Tool / function_call items cannot round-trip through text compression.
+      const approx = JSON.stringify(input).split(/\s+/).length;
+      compressed = {
+        messages: [],
+        original_tokens: approx,
+        compressed_tokens: approx,
+        tokens_saved: 0,
+        savings_pct: 0,
+        skip_reason: "structured_protocol",
+      };
+    } else {
+      compressed = await compressor.compress(forwarder.responsesInputToMessages(input), agentName);
+    }
+    await forwarder.forwardResponses(
+      rest.model,
+      compressed,
+      rest,
+      res,
+      req.headers.authorization,
+      input
+    );
     const totalMs = Date.now() - startTime;
     console.error(`[supercompress] responses | ${rest.model || "unknown"} | ${compressed.original_tokens}→${compressed.compressed_tokens} tok | ${compressed.savings_pct}% saved | ${totalMs}ms total`);
   } catch (err) {

--- a/packages/proxy/test/protocol-safety.js
+++ b/packages/proxy/test/protocol-safety.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Protocol / runtime safety assertions for compressor + forwarder.
+ */
+const assert = require("assert");
+const path = require("path");
+
+const compressor = require("../src/compressor");
+const forwarder = require("../src/forwarder");
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    console.error(`  ✘ ${name}`);
+    throw err;
+  }
+}
+
+async function main() {
+  console.log("\n── protocol-safety ──\n");
+
+  await test("native fetch — no node-fetch require in forwarder", () => {
+    const src = require("fs").readFileSync(
+      path.join(__dirname, "../src/forwarder.js"),
+      "utf8"
+    );
+    assert.doesNotMatch(src, /require\(["']node-fetch["']\)/);
+  });
+
+  await test("hasStructuredProtocol detects tool_calls", () => {
+    assert.equal(
+      compressor.hasStructuredProtocol([
+        { role: "assistant", content: null, tool_calls: [{ id: "1" }] },
+      ]),
+      true
+    );
+    assert.equal(
+      compressor.hasStructuredProtocol([
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ]),
+      false
+    );
+  });
+
+  await test("assembleMessages keeps all system messages", () => {
+    const { systemMsgs, query, context } = compressor.assembleMessages([
+      { role: "system", content: "A" },
+      { role: "system", content: "B" },
+      { role: "user", content: "older" },
+      { role: "assistant", content: "reply" },
+      { role: "user", content: "ask now" },
+    ]);
+    assert.equal(systemMsgs.length, 2);
+    assert.equal(query, "ask now");
+    assert.match(context, /\[user\]: older/);
+    assert.match(context, /\[assistant\]: reply/);
+  });
+
+  await test("compress skips structured protocol without API call", async () => {
+    const messages = [
+      { role: "user", content: "x".repeat(500) },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "call_1", type: "function", function: { name: "grep", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "result " + "y".repeat(200) },
+      { role: "user", content: "continue" },
+    ];
+    const out = await compressor.compress(messages, "test");
+    assert.equal(out.skip_reason, "structured_protocol");
+    assert.deepEqual(out.messages, messages);
+  });
+
+  await test("responsesInputHasStructuredItems detects function_call", () => {
+    assert.equal(
+      forwarder.responsesInputHasStructuredItems([
+        { type: "function_call", call_id: "c1", name: "grep", arguments: "{}" },
+      ]),
+      true
+    );
+    assert.equal(
+      forwarder.responsesInputHasStructuredItems([
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      ]),
+      false
+    );
+  });
+
+  await test("PID helpers only match our process command", () => {
+    const bin = require("fs").readFileSync(
+      path.join(__dirname, "../bin/supercompress.js"),
+      "utf8"
+    );
+    assert.match(bin, /isOurProxyProcess/);
+    assert.match(bin, /Never SIGTERM an unrelated listener/);
+    assert.match(bin, /process\.execPath/);
+  });
+
+  console.log("\n✔ protocol-safety passed\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/proxy/test/run-all.js
+++ b/packages/proxy/test/run-all.js
@@ -8,6 +8,7 @@ const path = require("path");
 const ROOT = path.join(__dirname, "..");
 const suites = [
   ["smoke", "test/smoke.js"],
+  ["protocol-safety", "test/protocol-safety.js"],
   ["agent-plugins", "test/agent-plugins.js"],
   ["uninstall-clean", "test/uninstall-clean.js"],
   ["dual-launch", "test/dual-launch.js"],


### PR DESCRIPTION
## Summary
- Drop `node-fetch`; use native fetch (package already declares Node ≥18 + only `express`)
- `supercompress stop` / port cleanup only SIGTERMs processes that look like our `server.js` (PID reuse safe)
- Chat Completions streaming buffers SSE across TCP chunks and forwards full deltas (keeps `tool_calls`)
- Skip compression for structured tool / Responses items; inject digests as **user** (not system); keep all system messages
- Fail-open on compress timeout / 5xx; AbortSignal timeout; block browser `Origin` on local proxy; zstd size caps; spawn via `process.execPath`

## Test plan
- [x] `node packages/proxy/test/protocol-safety.js`
- [x] `node packages/proxy/test/smoke.js`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI Responses API requests and improved Anthropic message handling.
  * Preserved structured tool, function, and multimodal content without inappropriate compression.
  * Added configurable API endpoints and request timeouts.

* **Bug Fixes**
  * Improved streaming reliability and metadata delivery.
  * Prevented unsafe process termination and stale PID reuse.
  * Added request-size limits and blocked unauthorized browser-origin requests.
  * Added fallback behavior for temporary API, timeout, and rate-limit failures.

* **Tests**
  * Added protocol-safety coverage for structured messages, compression behavior, streaming, and process safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the local proxy and preserves structured LLM protocol data while switching network paths to native fetch.
- Buffers SSE streams and forwards complete provider deltas, including tool calls.
- Skips lossy compression for structured Chat Completions and Responses inputs.
- Adds compression timeouts, fail-open handling, browser-origin blocking, zstd limits, and safer process lifecycle handling.
- Adds protocol-safety coverage and includes it in the aggregate test runner.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until process ownership matching, structured Responses fallback, and invalid environment-key handling are corrected.

The changed paths can terminate an unrelated port listener, discard structured input during a documented compatibility fallback, and override a valid configured credential with known placeholder or malformed environment values.

**Files Needing Attention:** packages/proxy/bin/supercompress.js, packages/proxy/src/forwarder.js, packages/proxy/src/compressor.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/bin/supercompress.js | Uses process.execPath and introduces listener ownership checks, but the broad command match can still classify and terminate unrelated processes. |
| packages/proxy/src/compressor.js | Adds structured-protocol pass-through, user-role digests, timeouts, and fail-open behavior, but regresses invalid environment-key fallback. |
| packages/proxy/src/forwarder.js | Preserves complete buffered SSE events and original structured Responses input on the primary path, but loses that input during compatibility fallback. |
| packages/proxy/src/server.js | Adds origin restrictions, bounded zstd handling, and structured Responses routing; its empty synthetic message representation contributes to the fallback defect. |
| packages/proxy/test/protocol-safety.js | Adds focused protocol checks, though it does not exercise the structured Responses fallback. |
| packages/proxy/test/run-all.js | Adds the protocol-safety test to the aggregate runner. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Local coding agent request] --> B{Endpoint}
    B -->|Chat or Anthropic| C{Structured protocol?}
    B -->|Responses| D{Structured Responses items?}
    C -->|No| E[Compress text context]
    C -->|Yes| F[Pass through original messages]
    D -->|No| E
    D -->|Yes| G[Preserve original Responses input]
    E --> H[Forward to provider]
    F --> H
    G --> I[Responses endpoint]
    I -->|Success| J[Return provider response]
    I -->|401 or scoped 403| K[Chat Completions fallback]
    K --> L[Currently receives empty compressed messages]
    H --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): preserve tool protocol and h..."](https://github.com/supercompress/supercompress/commit/34894674ad7e3832e6998a3b2e8d90e1c26d6ae7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52021941)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->