### PR TITLE
fix(billing): transactional usage/wallet ledger and recharge locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Public page: https://www.supercompress.dev/changelog
 - Durable per-key usage metering + dashboard KPI preference for billing meter
 - Remove dead store Auth-stub helpers; CCR uses Firestore (docs match)
 - Fix demo CO₂ grams over-count (`×1000` bug)
+- Transactional Firestore billing ledger for usage + wallet burns; Stripe auto-recharge lock + idempotency; no pre-Checkout `sc_metered` mutation; micro-USD burns so tiny requests are not free
 
 ### Coding agent plugin
 - See **[0.5.17](#0517--2026-08-10)** / **[0.5.16](#0516--2026-08-09)** below

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -1,0 +1,322 @@
+/**
+ * Transactional billing ledger — source of truth for monthly usage + prepaid balance.
+ *
+ * Auth custom claims (`sc_usage`, `sc_credit_balance_usd`) are mirrored after
+ * commit for dashboard/compat reads, but concurrent compressions must not
+ * read-modify-write claims directly.
+ *
+ * Firestore doc: billing/{uid}
+ */
+const admin = require("firebase-admin");
+const { initFirebaseAdmin } = require("./auth");
+const {
+  FREE_TOKENS_PER_MONTH,
+  USD_PER_MILLION,
+  billableTokens,
+  roundUsd,
+  normalizeCreditLimitUsd,
+  DEFAULT_CREDIT_LIMIT_USD,
+  isComped,
+  isLegacyMetered,
+  isCreditWallet,
+  isPaygEnabled,
+} = require("./stripe");
+
+const MICROS_PER_USD = 1_000_000;
+
+let _db = null;
+function db() {
+  if (!_db) {
+    initFirebaseAdmin();
+    _db = admin.firestore();
+  }
+  return _db;
+}
+
+function monthKey(d = new Date()) {
+  return d.toISOString().slice(0, 7);
+}
+
+function usdToMicros(usd) {
+  return Math.round(Number(usd || 0) * MICROS_PER_USD);
+}
+
+function microsToUsd(micros) {
+  return Math.round(Number(micros || 0)) / MICROS_PER_USD;
+}
+
+/** Integer micro-USD for a token count at $0.30 / 1M (no per-request $0 rounding). */
+function tokensToMicros(tokenCount) {
+  // tokens * 0.30 micros/token  (== tokens/1e6 * 0.30 * 1e6)
+  return Math.ceil(Number(tokenCount || 0) * USD_PER_MILLION);
+}
+
+function emptyLedger(claims = {}) {
+  const month = monthKey();
+  const claimUsage = claims.sc_usage?.month === month ? claims.sc_usage : {};
+  return {
+    month,
+    tokens_in: Number(claimUsage.tokens_in || 0),
+    tokens_out: Number(claimUsage.tokens_out || 0),
+    tokens_saved: Number(claimUsage.tokens_saved || 0),
+    requests: Number(claimUsage.requests || 0),
+    tokens_reported: Number(claimUsage.tokens_reported || 0),
+    credit_balance_micros: usdToMicros(claims.sc_credit_balance_usd || 0),
+    credit_limit_usd: normalizeCreditLimitUsd(
+      claims.sc_credit_limit_usd,
+      DEFAULT_CREDIT_LIMIT_USD
+    ),
+    auto_recharge: Boolean(claims.sc_auto_recharge),
+    customer_id: claims.sc_customer_id || null,
+    credited_keys: Array.isArray(claims.sc_credited_sessions)
+      ? claims.sc_credited_sessions.slice(-40)
+      : [],
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function normalizeLedger(raw, claims = {}) {
+  const base = emptyLedger(claims);
+  if (!raw || typeof raw !== "object") return base;
+  const month = monthKey();
+  // Month rollover
+  if (raw.month && raw.month !== month) {
+    return {
+      ...base,
+      credit_balance_micros:
+        raw.credit_balance_micros != null
+          ? Number(raw.credit_balance_micros)
+          : base.credit_balance_micros,
+      credit_limit_usd:
+        raw.credit_limit_usd != null
+          ? normalizeCreditLimitUsd(raw.credit_limit_usd)
+          : base.credit_limit_usd,
+      auto_recharge: raw.auto_recharge != null ? Boolean(raw.auto_recharge) : base.auto_recharge,
+      customer_id: raw.customer_id || base.customer_id,
+      credited_keys: Array.isArray(raw.credited_keys) ? raw.credited_keys.slice(-40) : base.credited_keys,
+    };
+  }
+  return {
+    month,
+    tokens_in: Number(raw.tokens_in || 0),
+    tokens_out: Number(raw.tokens_out || 0),
+    tokens_saved: Number(raw.tokens_saved || 0),
+    requests: Number(raw.requests || 0),
+    tokens_reported: Number(raw.tokens_reported || 0),
+    credit_balance_micros:
+      raw.credit_balance_micros != null
+        ? Number(raw.credit_balance_micros)
+        : usdToMicros(claims.sc_credit_balance_usd || 0),
+    credit_limit_usd: normalizeCreditLimitUsd(
+      raw.credit_limit_usd ?? claims.sc_credit_limit_usd,
+      DEFAULT_CREDIT_LIMIT_USD
+    ),
+    auto_recharge:
+      raw.auto_recharge != null ? Boolean(raw.auto_recharge) : Boolean(claims.sc_auto_recharge),
+    customer_id: raw.customer_id || claims.sc_customer_id || null,
+    credited_keys: Array.isArray(raw.credited_keys)
+      ? raw.credited_keys.slice(-40)
+      : base.credited_keys,
+    updated_at: raw.updated_at || new Date().toISOString(),
+  };
+}
+
+async function loadLedger(uid, claims = {}) {
+  if (!uid || !initFirebaseAdmin()) return emptyLedger(claims);
+  try {
+    const snap = await db().collection("billing").doc(uid).get();
+    return normalizeLedger(snap.exists ? snap.data() : null, claims);
+  } catch (err) {
+    console.warn("billing-ledger load failed:", err.message || err);
+    return emptyLedger(claims);
+  }
+}
+
+async function mirrorClaims(uid, ledger, claimsBase = {}) {
+  if (!uid || !initFirebaseAdmin()) return;
+  try {
+    const fresh = await admin.auth().getUser(uid);
+    const prev = { ...(fresh.customClaims || {}), ...claimsBase };
+    await admin.auth().setCustomUserClaims(uid, {
+      ...prev,
+      sc_usage: {
+        month: ledger.month,
+        requests: ledger.requests,
+        tokens_in: ledger.tokens_in,
+        tokens_out: ledger.tokens_out,
+        tokens_saved: ledger.tokens_saved,
+        tokens_reported: ledger.tokens_reported,
+      },
+      sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+      ...(ledger.credit_limit_usd != null
+        ? { sc_credit_limit_usd: ledger.credit_limit_usd }
+        : {}),
+      ...(ledger.auto_recharge != null ? { sc_auto_recharge: ledger.auto_recharge } : {}),
+      ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
+    });
+  } catch (err) {
+    console.warn("billing-ledger claim mirror failed:", err.message || err);
+  }
+}
+
+/**
+ * Atomically record usage and burn prepaid credit for newly billable tokens.
+ * Returns updated ledger snapshot + burn metadata.
+ */
+async function applyUsageAndBurn({ uid, tokensIn, tokensOut, tokensSaved, claims = {} }) {
+  if (!uid) throw new Error("uid required");
+  if (!initFirebaseAdmin()) {
+    // Soft fallback — caller may still update claims (legacy path).
+    const ledger = emptyLedger(claims);
+    ledger.tokens_in += tokensIn;
+    ledger.tokens_out += tokensOut;
+    ledger.tokens_saved += tokensSaved;
+    ledger.requests += 1;
+    return { ledger, burned_micros: 0, fallback: true };
+  }
+
+  const ref = db().collection("billing").doc(uid);
+  const result = await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
+    const prevTokensIn = ledger.tokens_in;
+    ledger.tokens_in += Math.max(0, Number(tokensIn) || 0);
+    ledger.tokens_out += Math.max(0, Number(tokensOut) || 0);
+    ledger.tokens_saved += Math.max(0, Number(tokensSaved) || 0);
+    ledger.requests += 1;
+    ledger.updated_at = new Date().toISOString();
+
+    let burned_micros = 0;
+    const wallet =
+      !isComped(claims) &&
+      (isCreditWallet(claims) ||
+        (isPaygEnabled(claims.sc_plan) && !isLegacyMetered(claims)));
+    if (wallet) {
+      const prevBillable = billableTokens(prevTokensIn);
+      const newBillable = billableTokens(ledger.tokens_in);
+      const deltaBillable = Math.max(0, newBillable - prevBillable);
+      burned_micros = tokensToMicros(deltaBillable);
+      if (burned_micros > 0) {
+        ledger.credit_balance_micros = Math.max(
+          0,
+          Number(ledger.credit_balance_micros || 0) - burned_micros
+        );
+      }
+    }
+
+    tx.set(ref, ledger, { merge: true });
+    return { ledger, burned_micros };
+  });
+
+  await mirrorClaims(uid, result.ledger, claims);
+  return result;
+}
+
+/**
+ * Credit prepaid balance (Checkout / auto-recharge). Idempotent by creditKey.
+ */
+async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {} }) {
+  if (!uid || !creditKey) return { applied: false, reason: "missing_args" };
+  if (!initFirebaseAdmin()) return { applied: false, reason: "firebase_unavailable" };
+
+  const ref = db().collection("billing").doc(uid);
+  const result = await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
+    const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
+    if (keys.includes(creditKey)) {
+      return {
+        applied: true,
+        already: true,
+        ledger,
+        balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+      };
+    }
+    const add = usdToMicros(creditUsd);
+    ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
+    if (patch.credit_limit_usd != null) {
+      ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
+    }
+    if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
+    if (patch.customer_id) ledger.customer_id = patch.customer_id;
+    ledger.credited_keys = [...keys.slice(-40), creditKey];
+    ledger.updated_at = new Date().toISOString();
+    tx.set(ref, ledger, { merge: true });
+    return {
+      applied: true,
+      already: false,
+      ledger,
+      balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+    };
+  });
+
+  await mirrorClaims(uid, result.ledger, {
+    ...claims,
+    sc_plan: "payg",
+    sc_metered: false,
+    sc_credited_sessions: result.ledger.credited_keys,
+  });
+  return result;
+}
+
+/**
+ * Distributed lock for auto-recharge. Returns { acquired, release }.
+ * Lock TTL ~90s; held across Stripe PaymentIntent confirm.
+ */
+async function acquireRechargeLock(uid) {
+  if (!uid || !initFirebaseAdmin()) return { acquired: false, reason: "unavailable" };
+  const ref = db().collection("billing_locks").doc(uid);
+  const now = Date.now();
+  const until = now + 90_000;
+  try {
+    const acquired = await db().runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      const data = snap.exists ? snap.data() : null;
+      if (data?.until && Number(data.until) > now && data.kind === "recharge") {
+        return false;
+      }
+      tx.set(ref, { kind: "recharge", until, updated_at: new Date().toISOString() });
+      return true;
+    });
+    return {
+      acquired,
+      async release() {
+        try {
+          await ref.delete();
+        } catch {}
+      },
+    };
+  } catch (err) {
+    console.warn("recharge lock failed:", err.message || err);
+    return { acquired: false, reason: err.message };
+  }
+}
+
+async function markTokensReported(uid, tokensReported, claims = {}) {
+  if (!uid || !initFirebaseAdmin()) return null;
+  const ref = db().collection("billing").doc(uid);
+  const ledger = await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const next = normalizeLedger(snap.exists ? snap.data() : null, claims);
+    next.tokens_reported = Math.max(Number(next.tokens_reported || 0), Number(tokensReported || 0));
+    next.updated_at = new Date().toISOString();
+    tx.set(ref, next, { merge: true });
+    return next;
+  });
+  await mirrorClaims(uid, ledger, claims);
+  return ledger;
+}
+
+module.exports = {
+  loadLedger,
+  applyUsageAndBurn,
+  creditBalance,
+  acquireRechargeLock,
+  markTokensReported,
+  mirrorClaims,
+  tokensToMicros,
+  usdToMicros,
+  microsToUsd,
+  monthKey,
+  FREE_TOKENS_PER_MONTH,
+};

--- a/api/_lib/credit-topup.js
+++ b/api/_lib/credit-topup.js
@@ -140,8 +140,32 @@ async function applyCreditTopUp(session) {
 
   const grantFirstPayBonus = !prev.sc_first_pay_bonus_at;
   const bonusUsd = grantFirstPayBonus ? FIRST_PAY_BONUS_USD : 0;
-  const newBalance = roundUsd(Number(prev.sc_credit_balance_usd || 0) + creditUsd + bonusUsd);
-  const nextCredited = [...credited.slice(-40), session.id];
+  const limitUsd = normalizeCreditLimitUsd(
+    session.metadata?.credit_usd || prev.sc_credit_limit_usd,
+    creditUsd
+  );
+
+  // Ledger first (idempotent by session.id) — Auth claims mirror from ledger.
+  const { creditBalance } = require("./billing-ledger");
+  const ledgerResult = await creditBalance({
+    uid: userId,
+    creditUsd: creditUsd + bonusUsd,
+    creditKey: session.id,
+    claims: prev,
+    patch: {
+      credit_limit_usd: limitUsd,
+      auto_recharge: autoRecharge,
+      customer_id: session.customer,
+    },
+  });
+  const newBalance = roundUsd(
+    ledgerResult.balance != null
+      ? ledgerResult.balance
+      : Number(prev.sc_credit_balance_usd || 0) + creditUsd + bonusUsd
+  );
+  const nextCredited = Array.isArray(ledgerResult.ledger?.credited_keys)
+    ? ledgerResult.ledger.credited_keys
+    : [...credited.slice(-40), session.id];
 
   const persistPayload = {
     stripe_customer_id: session.customer,
@@ -150,18 +174,12 @@ async function applyCreditTopUp(session) {
     status: "active",
     sc_metered: false,
     sc_credit_balance_usd: newBalance,
-    sc_credit_limit_usd: normalizeCreditLimitUsd(
-      session.metadata?.credit_usd || prev.sc_credit_limit_usd,
-      creditUsd
-    ),
+    sc_credit_limit_usd: limitUsd,
     sc_auto_recharge: autoRecharge,
     sc_default_payment_method: paymentMethod ? String(paymentMethod) : undefined,
     sc_credited_sessions: nextCredited,
     credit_balance_usd: newBalance,
-    credit_limit_usd: normalizeCreditLimitUsd(
-      session.metadata?.credit_usd || prev.sc_credit_limit_usd,
-      creditUsd
-    ),
+    credit_limit_usd: limitUsd,
     auto_recharge: autoRecharge,
     updated_at: new Date().toISOString(),
   };

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -441,91 +441,85 @@ async function recordUsage(keyRec, owner, compressed) {
     } catch (_) {}
   }
 
-  // Owner monthly usage stays on the real Auth user for billing enforcement.
-  const month = now.slice(0, 7);
+  // Owner monthly usage + wallet burn — transactional Firestore ledger (not Auth RMW).
   const ownerClaims = owner.customClaims || {};
-  const ownerPrevious = ownerClaims.sc_usage?.month === month ? ownerClaims.sc_usage : {};
-  const prevTokensIn = ownerPrevious.tokens_in || 0;
-  const ownerTokensIn = prevTokensIn + compressed.original_tokens;
-  let ownerUsage = {
-    month,
-    requests: (ownerPrevious.requests || 0) + 1,
-    tokens_in: ownerTokensIn,
-    tokens_out: (ownerPrevious.tokens_out || 0) + compressed.kept_tokens,
-    tokens_saved: (ownerPrevious.tokens_saved || 0) + tokensSaved,
-    tokens_reported: ownerPrevious.tokens_reported || 0,
-  };
+  const { applyUsageAndBurn, microsToUsd } = require("./billing-ledger");
+  const { reportPaygUsage, isPaygEnabled, isComped, isLegacyMetered, roundUsd } = require("./stripe");
 
-  const {
-    reportPaygUsage,
-    isPaygEnabled,
-    isComped,
-    isLegacyMetered,
-    isCreditWallet,
-    billableTokens,
-    tokensToUsd,
-    attemptAutoRecharge,
-    roundUsd,
-  } = require("./stripe");
+  let ledger;
+  try {
+    const applied = await applyUsageAndBurn({
+      uid: owner.uid,
+      tokensIn: compressed.original_tokens,
+      tokensOut: compressed.kept_tokens,
+      tokensSaved,
+      claims: ownerClaims,
+    });
+    ledger = applied.ledger;
+  } catch (err) {
+    console.warn("recordUsage: billing ledger failed:", err.message || err);
+    ledger = null;
+  }
 
-  let nextClaims = { ...ownerClaims, sc_usage: ownerUsage };
+  const ownerUsage = ledger
+    ? {
+        month: ledger.month,
+        requests: ledger.requests,
+        tokens_in: ledger.tokens_in,
+        tokens_out: ledger.tokens_out,
+        tokens_saved: ledger.tokens_saved,
+        tokens_reported: ledger.tokens_reported || 0,
+      }
+    : {
+        month: now.slice(0, 7),
+        requests: 1,
+        tokens_in: compressed.original_tokens,
+        tokens_out: compressed.kept_tokens,
+        tokens_saved: tokensSaved,
+        tokens_reported: 0,
+      };
 
-  // Legacy metered: report to Stripe meters
+  // Legacy metered: report to Stripe meters (idempotent watermark on ledger).
   try {
     if (isPaygEnabled(ownerClaims.sc_plan) && isLegacyMetered(ownerClaims) && !isComped(ownerClaims)) {
       const freshOwner = {
         ...owner,
-        customClaims: { ...ownerClaims, sc_usage: ownerUsage },
+        customClaims: {
+          ...ownerClaims,
+          sc_usage: ownerUsage,
+          sc_credit_balance_usd: ledger
+            ? roundUsd(microsToUsd(ledger.credit_balance_micros))
+            : ownerClaims.sc_credit_balance_usd,
+        },
       };
-      const reported = await reportPaygUsage(freshOwner, ownerTokensIn);
+      const reported = await reportPaygUsage(freshOwner, ownerUsage.tokens_in);
       if (reported?.tokens_reported != null) {
         ownerUsage.tokens_reported = reported.tokens_reported;
-        nextClaims.sc_usage = ownerUsage;
       }
     }
   } catch (err) {
     console.warn("PAYG meter skipped:", err.message || err);
   }
 
-  // Prepaid credit wallet: burn $ for newly billable tokens
+  // Refresh in-memory owner claims from ledger mirror (applyUsageAndBurn already wrote Auth).
   try {
-    if (!isComped(ownerClaims) && (isCreditWallet(ownerClaims) || (isPaygEnabled(ownerClaims.sc_plan) && !isLegacyMetered(ownerClaims)))) {
-      const prevBillable = billableTokens(prevTokensIn);
-      const newBillable = billableTokens(ownerTokensIn);
-      const deltaBillable = Math.max(0, newBillable - prevBillable);
-      let cost = tokensToUsd(deltaBillable);
-      if (cost > 0) {
-        // Refresh claims in case enforceUsageLimit already auto-recharged
-        let balance = roundUsd(nextClaims.sc_credit_balance_usd || 0);
-        if (balance < cost && nextClaims.sc_auto_recharge) {
-          const recharge = await attemptAutoRecharge({
-            ...owner,
-            customClaims: nextClaims,
-          });
-          if (recharge.ok) {
-            const fresh = await auth().getUser(owner.uid);
-            nextClaims = { ...(fresh.customClaims || {}), sc_usage: ownerUsage };
-            balance = roundUsd(nextClaims.sc_credit_balance_usd || 0);
-          }
-        }
-        if (balance < cost) {
-          // Soft-fail burn: zero out — request already compressed; next call 402s.
-          nextClaims.sc_credit_balance_usd = 0;
-          nextClaims.sc_plan = "payg";
-          nextClaims.sc_metered = false;
-        } else {
-          nextClaims.sc_credit_balance_usd = roundUsd(balance - cost);
-          nextClaims.sc_plan = "payg";
-          nextClaims.sc_metered = false;
-        }
-      }
-    }
-  } catch (err) {
-    console.warn("Credit burn skipped:", err.message || err);
+    const fresh = await auth().getUser(owner.uid);
+    owner.customClaims = fresh.customClaims || {
+      ...ownerClaims,
+      sc_usage: ownerUsage,
+      ...(ledger
+        ? { sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)) }
+        : {}),
+    };
+  } catch (_) {
+    owner.customClaims = {
+      ...ownerClaims,
+      sc_usage: ownerUsage,
+      ...(ledger
+        ? { sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)) }
+        : {}),
+    };
   }
-
-  await auth().setCustomUserClaims(owner.uid, nextClaims);
-  owner.customClaims = nextClaims;
   return ownerUsage;
 }
 

--- a/api/_lib/stripe.js
+++ b/api/_lib/stripe.js
@@ -145,9 +145,11 @@ function roundUsd(n) {
   return Math.round(Number(n || 0) * 10000) / 10000;
 }
 
-/** USD cost for a token delta at $0.30 / 1M. */
+/** USD cost for a token delta at $0.30 / 1M (display/aggregate helper). */
 function tokensToUsd(tokenCount) {
-  return roundUsd((Number(tokenCount || 0) / TOKENS_PER_BILLING_UNIT) * USD_PER_MILLION);
+  // Keep sub-cent precision in micros, then round for display.
+  const micros = Math.ceil(Number(tokenCount || 0) * USD_PER_MILLION);
+  return Math.round(micros) / 1_000_000;
 }
 
 function normalizeCreditLimitUsd(raw, fallback = DEFAULT_CREDIT_LIMIT_USD) {
@@ -203,9 +205,9 @@ async function reportPaygUsage(owner, tokensInThisMonth) {
   if (!customerId) return null;
 
   const billable = billableTokens(tokensInThisMonth);
-  const month = new Date().toISOString().slice(0, 7);
-  const prev = claims.sc_usage?.month === month ? claims.sc_usage : {};
-  const alreadyReported = Number(prev.tokens_reported || 0);
+  const { loadLedger, markTokensReported } = require("./billing-ledger");
+  const ledger = await loadLedger(owner.uid, claims);
+  const alreadyReported = Number(ledger.tokens_reported || 0);
   const delta = billable - alreadyReported;
   if (delta <= 0) return null;
 
@@ -217,17 +219,24 @@ async function reportPaygUsage(owner, tokensInThisMonth) {
   }
 
   const eventName = envTrim("STRIPE_METER_EVENT_NAME", "supercompress_tokens_millions");
+  // Idempotent per customer + absolute billable watermark.
+  const idempotencyKey = `sc_meter_${customerId}_${billable}`.slice(0, 255);
 
   try {
     const stripe = getStripe();
-    await stripe.billing.meterEvents.create({
-      event_name: eventName,
-      payload: {
-        stripe_customer_id: customerId,
-        value: String(unitDelta),
+    await stripe.billing.meterEvents.create(
+      {
+        event_name: eventName,
+        payload: {
+          stripe_customer_id: customerId,
+          value: String(unitDelta),
+        },
+        identifier: idempotencyKey,
       },
-    });
+      { idempotencyKey }
+    );
 
+    await markTokensReported(owner.uid, billable, claims);
     return { tokens_reported: billable, units: unitDelta };
   } catch (err) {
     console.warn("PAYG usage report failed:", err.message || err);
@@ -300,16 +309,29 @@ async function createCreditTopUpCheckout({
  */
 async function attemptAutoRecharge(owner) {
   const claims = owner.customClaims || {};
-  if (!claims.sc_auto_recharge) {
+  const { loadLedger, acquireRechargeLock, creditBalance } = require("./billing-ledger");
+  const ledger = await loadLedger(owner.uid, claims);
+  if (!(claims.sc_auto_recharge || ledger.auto_recharge)) {
     return { ok: false, error: "auto_recharge_disabled" };
   }
-  const customerId = claims.sc_customer_id;
+  const customerId = claims.sc_customer_id || ledger.customer_id;
   if (!customerId) {
     return { ok: false, error: "no_customer" };
   }
 
-  const amount = normalizeCreditLimitUsd(claims.sc_credit_limit_usd, DEFAULT_CREDIT_LIMIT_USD);
+  const amount = normalizeCreditLimitUsd(
+    ledger.credit_limit_usd || claims.sc_credit_limit_usd,
+    DEFAULT_CREDIT_LIMIT_USD
+  );
+  const lock = await acquireRechargeLock(owner.uid);
+  if (!lock.acquired) {
+    return { ok: false, error: "recharge_in_progress" };
+  }
+
   const stripe = getStripe();
+  // Hour-bucketed key so concurrent compressions share one PI attempt.
+  const hourBucket = new Date().toISOString().slice(0, 13).replace(/[-:T]/g, "");
+  const idempotencyKey = `sc_ar_${owner.uid}_${Math.round(amount * 100)}_${hourBucket}`.slice(0, 255);
 
   try {
     const customer = await stripe.customers.retrieve(customerId);
@@ -327,65 +349,52 @@ async function attemptAutoRecharge(owner) {
       return { ok: false, error: "no_payment_method" };
     }
 
-    const pi = await stripe.paymentIntents.create({
-      amount: Math.round(amount * 100),
-      currency: "usd",
-      customer: customerId,
-      payment_method: pm,
-      off_session: true,
-      confirm: true,
-      description: `SuperCompress auto-recharge $${amount.toFixed(2)}`,
-      metadata: {
-        user_id: owner.uid,
-        plan_id: "payg",
-        kind: "credit_auto_recharge",
-        credit_usd: String(amount),
+    const pi = await stripe.paymentIntents.create(
+      {
+        amount: Math.round(amount * 100),
+        currency: "usd",
+        customer: customerId,
+        payment_method: pm,
+        off_session: true,
+        confirm: true,
+        description: `SuperCompress auto-recharge $${amount.toFixed(2)}`,
+        metadata: {
+          user_id: owner.uid,
+          plan_id: "payg",
+          kind: "credit_auto_recharge",
+          credit_usd: String(amount),
+        },
       },
-    });
+      { idempotencyKey }
+    );
 
     if (pi.status !== "succeeded") {
       return { ok: false, error: `payment_${pi.status}`, paymentIntentId: pi.id };
     }
 
-    // Apply credit immediately; webhook uses the same idempotency key
-    try {
-      const { initFirebaseAdmin } = require("./auth");
-      const admin = require("firebase-admin");
-      if (initFirebaseAdmin()) {
-        const fresh = await admin.auth().getUser(owner.uid);
-        const prev = fresh.customClaims || {};
-        const key = `pi_${pi.id}`;
-        const credited = Array.isArray(prev.sc_credited_sessions)
-          ? prev.sc_credited_sessions
-          : [];
-        if (!credited.includes(key)) {
-          const balance = roundUsd(Number(prev.sc_credit_balance_usd || 0) + amount);
-          await admin.auth().setCustomUserClaims(owner.uid, {
-            ...prev,
-            sc_plan: "payg",
-            sc_metered: false,
-            sc_credit_balance_usd: balance,
-            sc_credit_limit_usd: normalizeCreditLimitUsd(prev.sc_credit_limit_usd, amount),
-            sc_credited_sessions: [...credited.slice(-40), key],
-            sc_default_payment_method: String(pm),
-          });
-          return { ok: true, balanceAdd: amount, paymentIntentId: pi.id, balance };
-        }
-        return {
-          ok: true,
-          balanceAdd: 0,
-          paymentIntentId: pi.id,
-          balance: roundUsd(prev.sc_credit_balance_usd || 0),
-        };
-      }
-    } catch (err) {
-      console.warn("Auto-recharge claim update failed:", err.message || err);
-    }
+    const credited = await creditBalance({
+      uid: owner.uid,
+      creditUsd: amount,
+      creditKey: `pi_${pi.id}`,
+      claims,
+      patch: {
+        credit_limit_usd: amount,
+        auto_recharge: true,
+        customer_id: customerId,
+      },
+    });
 
-    return { ok: true, balanceAdd: amount, paymentIntentId: pi.id };
+    return {
+      ok: true,
+      balanceAdd: credited.already ? 0 : amount,
+      paymentIntentId: pi.id,
+      balance: credited.balance,
+    };
   } catch (err) {
     console.warn("Auto-recharge failed:", err.message || err);
     return { ok: false, error: err.message || "charge_failed" };
+  } finally {
+    if (lock.release) await lock.release();
   }
 }
 

--- a/api/billing.js
+++ b/api/billing.js
@@ -286,14 +286,9 @@ async function startCreditCheckout(req, res, user, body, existingSub, stripeBill
 
   const customerId = await ensureCustomer(user, existingSub, stripeBilling);
 
-  // Remember preferred pack size + auto-recharge before Checkout returns
-  await patchCreditClaims(user.uid, {
-    sc_credit_limit_usd: creditUsd,
-    sc_auto_recharge: autoRecharge,
-    sc_customer_id: customerId,
-    sc_metered: false,
-  });
-
+  // Do NOT flip sc_metered / wallet claims before payment succeeds — a canceled
+  // Checkout must not reclassify a legacy metered subscriber. Persist prefs only
+  // in the subscriptions store (+ Checkout metadata) until the webhook credits.
   try {
     await mutateStore((s) => {
       if (!s.subscriptions) s.subscriptions = {};
@@ -301,6 +296,8 @@ async function startCreditCheckout(req, res, user, body, existingSub, stripeBill
         ...(s.subscriptions[user.uid] || {}),
         stripe_customer_id: customerId,
         plan_id: s.subscriptions[user.uid]?.plan_id || "free",
+        pending_credit_limit_usd: creditUsd,
+        pending_auto_recharge: autoRecharge,
         credit_limit_usd: creditUsd,
         auto_recharge: autoRecharge,
         updated_at: new Date().toISOString(),
@@ -309,6 +306,13 @@ async function startCreditCheckout(req, res, user, body, existingSub, stripeBill
     });
   } catch (err) {
     if (err.status !== 503) throw err;
+  }
+
+  // Safe claim touch: customer id only (needed for Checkout), never sc_metered.
+  try {
+    await patchCreditClaims(user.uid, { sc_customer_id: customerId });
+  } catch (err) {
+    console.warn("checkout customer claim patch skipped:", err.message || err);
   }
 
   const { session, amount } = await createCreditTopUpCheckout({

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -36,10 +36,9 @@ async function enforceUsageLimit(owner) {
     // Transition: treat as credit wallet with 0 balance until top-up
   }
 
-  const month = new Date().toISOString().slice(0, 7);
-  const tokensUsedThisPeriod = claims.sc_usage?.month === month
-    ? claims.sc_usage.tokens_in || 0
-    : 0;
+  const { loadLedger, microsToUsd } = require("../_lib/billing-ledger");
+  const ledger = await loadLedger(owner.uid, claims);
+  const tokensUsedThisPeriod = Number(ledger.tokens_in || 0);
 
   if (tokensUsedThisPeriod < FREE_TOKENS_PER_MONTH) return;
 
@@ -71,17 +70,19 @@ async function enforceUsageLimit(owner) {
     throw err;
   }
 
-  let balance = roundUsd(claims.sc_credit_balance_usd || 0);
+  let balance = roundUsd(
+    microsToUsd(ledger.credit_balance_micros) || claims.sc_credit_balance_usd || 0
+  );
   if (balance > 0) return;
 
-  if (claims.sc_auto_recharge) {
+  if (claims.sc_auto_recharge || ledger.auto_recharge) {
     const recharge = await attemptAutoRecharge(owner);
     if (recharge.ok) {
-      const admin = require("firebase-admin");
-      const { initFirebaseAdmin } = require("../_lib/auth");
-      initFirebaseAdmin();
-      const fresh = await admin.auth().getUser(owner.uid);
-      owner.customClaims = fresh.customClaims || {};
+      const freshLedger = await loadLedger(owner.uid, owner.customClaims || claims);
+      owner.customClaims = {
+        ...(owner.customClaims || claims),
+        sc_credit_balance_usd: roundUsd(microsToUsd(freshLedger.credit_balance_micros)),
+      };
       if (roundUsd(owner.customClaims.sc_credit_balance_usd || 0) > 0) return;
     }
   }


### PR DESCRIPTION
## Summary
- New `billing/{uid}` Firestore ledger is the source of truth for monthly tokens + prepaid balance (Auth claims mirrored after commit)
- Concurrent compressions no longer lose updates via Auth claim RMW
- Auto-recharge uses a per-user lock + Stripe PaymentIntent idempotency key
- Legacy meter events use an idempotent watermark / identifier
- Checkout no longer sets `sc_metered:false` before payment (cancel-safe)
- Burns accumulate in micro-USD so sub-cent requests are not free

## Test plan
- [x] `node --check` on touched API modules
- [x] micro-USD math sanity (`1M tokens → $0.30`)
- [ ] Staging: two concurrent compress calls past free quota → one recharge, correct balance
- [ ] Cancel Checkout → legacy metered account classification unchanged

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves monthly usage and prepaid credit accounting into transactional Firestore ledgers, mirrors ledger state to Auth claims, and adds Stripe idempotency and per-user recharge locking.
- Adds transactional usage, micro-USD burn, credit, watermark, and recharge-lock operations.
- Routes compression enforcement, legacy meter reporting, checkout reconciliation, and auto-recharge through the new ledger.
- Avoids reclassifying legacy-metered users before Checkout succeeds.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until concurrent claim mirroring, legacy meter reporting, and repeated same-hour auto-recharges are made safe.

Concurrent operations can revert newer Auth claims, overlapping meter reports can overbill legacy customers, and a second legitimate recharge in the same hour can reuse an already-consumed PaymentIntent and leave the user paywalled.

**Files Needing Attention:** api/_lib/billing-ledger.js, api/_lib/stripe.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/_lib/billing-ledger.js | Introduces transactional ledger operations, but claim mirroring can overwrite newer unrelated Auth claims. |
| api/_lib/stripe.js | Adds ledger-backed meter reporting and recharge idempotency, with races in meter watermarking and an overly broad hourly recharge key. |
| api/_lib/firebase-key-store.js | Routes usage and wallet burns through the new ledger while retaining independently concurrent legacy-meter reporting. |
| api/v1/compress.js | Enforces quota and auto-recharge from ledger state, exposing the repeated-recharge failure when no new credit is added. |
| api/_lib/credit-topup.js | Makes Checkout credit application transactionally idempotent through the Firestore ledger. |
| api/billing.js | Defers wallet classification until successful Checkout while persisting pending preferences. |
| CHANGELOG.md | Documents the transactional billing and recharge changes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Compress request
    participant L as Firestore ledger
    participant A as Firebase Auth claims
    participant S as Stripe
    C->>L: Load usage and balance
    alt Balance available
        C->>C: Compress
        C->>L: Transactionally record usage and burn credit
    else Empty balance with auto-recharge
        C->>L: Acquire recharge lock
        C->>S: Create and confirm PaymentIntent
        S-->>C: PaymentIntent
        C->>L: Idempotently credit balance
        C->>L: Release recharge lock
        C->>C: Compress
        C->>L: Record usage and burn credit
    end
    L-->>A: Mirror usage and balance claims
    opt Legacy metered account
        C->>L: Read reported watermark
        C->>S: Emit meter delta
        C->>L: Advance reported watermark
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): transactional usage/wallet..."](https://github.com/supercompress/supercompress/commit/818008390ee7149e10e2564630e52ef95a52f837) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52022441)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->