### PR TITLE
fix(plugin): non-destructive agent integration and safer connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,11 @@ Public page: https://www.supercompress.dev/changelog
 - Transactional Firestore billing ledger for usage + wallet burns; Stripe auto-recharge lock + idempotency; no pre-Checkout `sc_metered` mutation; micro-USD burns so tiny requests are not free
 
 ### Coding agent plugin
+<<<<<<< HEAD
 - Protocol/runtime safety: native `fetch` (drop `node-fetch`), owned-PID-only stop, buffered SSE that preserves `tool_calls`, skip compression for structured tool/Responses items, inject digests as user (not system), fail-open on compress timeout/5xx, block browser `Origin` on local proxy, zstd size caps, spawn via `process.execPath`
+=======
+- Non-destructive setup: only clear SuperCompress-owned base URLs; backup before plugin writers; fix instruction-block idempotency; don’t markSeen on compress timeout/error; don’t split long asks without paragraph breaks; secure inbox/session modes; fail connect instead of rotating production API keys; atomic device-link consume via Firestore
+>>>>>>> 80b33bf (fix(plugin): non-destructive agent integration and safer connect)
 - See **[0.5.17](#0517--2026-08-10)** / **[0.5.16](#0516--2026-08-09)** below
 
 ### Repository hygiene

--- a/api/_lib/auth-connect.js
+++ b/api/_lib/auth-connect.js
@@ -192,9 +192,10 @@ async function putDeviceLink(code, { ownerUid, secret, source = "oauth", agents 
       displayName: `Device link ${String(code).slice(0, 8)}`,
     });
   }
+  const codeNorm = String(code).trim().toLowerCase();
   await auth().setCustomUserClaims(uid, {
     sc_device_link: true,
-    code: String(code).trim().toLowerCase(),
+    code: codeNorm,
     owner_uid: ownerUid,
     secret,
     source: String(source || "oauth").slice(0, 40),
@@ -203,8 +204,24 @@ async function putDeviceLink(code, { ownerUid, secret, source = "oauth", agents 
     linked_at: now,
     created_at: existing?.customClaims?.created_at || now,
   });
+  try {
+    await admin.firestore().collection("device_links").doc(uid).set(
+      {
+        code: codeNorm,
+        owner_uid: ownerUid,
+        secret,
+        source: String(source || "oauth").slice(0, 40),
+        status: "linked",
+        linked_at: now,
+        created_at: existing?.customClaims?.created_at || now,
+      },
+      { merge: true }
+    );
+  } catch (err) {
+    console.warn("putDeviceLink firestore mirror skipped:", err.message || err);
+  }
   return {
-    code: String(code).trim().toLowerCase(),
+    code: codeNorm,
     status: "linked",
     owner_uid: ownerUid,
     secret,
@@ -241,6 +258,66 @@ async function clearDeviceLinkSecret(code) {
   await auth().setCustomUserClaims(uid, c);
 }
 
+/**
+ * Atomically take the device-link secret (single-use).
+ * Prefers a Firestore transaction; falls back to Auth clear-then-return.
+ * Returns { secret, owner_uid, linked_at, created_at } or null if already consumed.
+ */
+async function consumeDeviceLinkSecret(code) {
+  const normalized = String(code || "").trim().toLowerCase();
+  if (!normalized) return null;
+
+  // Firestore CAS when available
+  try {
+    const { initFirebaseAdmin } = require("./auth");
+    if (initFirebaseAdmin()) {
+      const db = admin.firestore();
+      const ref = db.collection("device_links").doc(linkUidFromCode(normalized));
+      const taken = await db.runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        if (!snap.exists) return null;
+        const data = snap.data() || {};
+        if (!data.secret) return null;
+        const out = {
+          secret: data.secret,
+          owner_uid: data.owner_uid || null,
+          linked_at: data.linked_at || null,
+          created_at: data.created_at || null,
+        };
+        tx.set(
+          ref,
+          {
+            ...data,
+            secret: null,
+            status: "consumed",
+            consumed_at: new Date().toISOString(),
+          },
+          { merge: true }
+        );
+        return out;
+      });
+      if (taken) {
+        try { await clearDeviceLinkSecret(normalized); } catch (_) {}
+        return taken;
+      }
+    }
+  } catch (err) {
+    console.warn("consumeDeviceLinkSecret firestore path:", err.message || err);
+  }
+
+  // Auth fallback: read → clear → return (still a small race under Auth-only).
+  const status = await getDeviceLink(normalized);
+  if (!status?.secret) return null;
+  const secret = status.secret;
+  await clearDeviceLinkSecret(normalized);
+  return {
+    secret,
+    owner_uid: status.owner_uid || null,
+    linked_at: status.linked_at || null,
+    created_at: status.created_at || null,
+  };
+}
+
 module.exports = {
   KEY_UID_PREFIX,
   LINK_UID_PREFIX,
@@ -251,5 +328,6 @@ module.exports = {
   putDeviceLink,
   getDeviceLink,
   clearDeviceLinkSecret,
+  consumeDeviceLinkSecret,
   generateAuthBackedKey,
 };

--- a/api/account.js
+++ b/api/account.js
@@ -150,7 +150,16 @@ async function mintConnectKey(ownerUid, maxKeys) {
       .filter((k) => ROTATABLE_KEY_NAME.test(String(k.name || "")))
       .slice()
       .sort((a, b) => String(a.created_at || "").localeCompare(String(b.created_at || "")));
-    const victims = (pool.length ? pool : existing).slice(0, Math.max(1, existing.length - maxKeys + 1));
+    // Never fall back to rotating arbitrary production keys — fail setup instead.
+    if (!pool.length) {
+      const err = new Error(
+        `API key limit reached (${maxKeys}). Revoke an unused coding-agent/CLI key in the dashboard, then retry connect.`
+      );
+      err.status = 409;
+      err.code = "key_limit_reached";
+      throw err;
+    }
+    const victims = pool.slice(0, Math.max(1, existing.length - maxKeys + 1));
     for (const victim of victims.slice(0, 3)) {
       try {
         await revokeAuthPluginKey(ownerUid, victim.id);
@@ -229,17 +238,26 @@ async function handleConnectDevice(req, res) {
         });
       }
 
-      // Single-use: return secret once, then strip it so scanners cannot re-harvest.
-      const secret = status.secret;
-      const ownerUid = status.owner_uid || null;
-      try { await clearDeviceLinkSecret(code); } catch (_) { /* best-effort */ }
+      // Single-use: atomically consume secret (Firestore CAS when available).
+      const { consumeDeviceLinkSecret } = require("./_lib/auth-connect");
+      const taken = await consumeDeviceLinkSecret(code);
+      if (!taken?.secret) {
+        return json(res, 200, {
+          code,
+          status: "consumed",
+          owner_uid: status.owner_uid || null,
+          secret: null,
+          linked_at: status.linked_at || null,
+          created_at: status.created_at || null,
+        });
+      }
       return json(res, 200, {
         code,
         status: "linked",
-        owner_uid: ownerUid,
-        secret,
-        linked_at: status.linked_at || null,
-        created_at: status.created_at || null,
+        owner_uid: taken.owner_uid || null,
+        secret: taken.secret,
+        linked_at: taken.linked_at || status.linked_at || null,
+        created_at: taken.created_at || status.created_at || null,
       });
     } catch (err) {
       return json(res, err.status || 500, { detail: err.message || "Lookup failed" });

--- a/packages/proxy/src/agent-plugins.js
+++ b/packages/proxy/src/agent-plugins.js
@@ -661,6 +661,16 @@ function pluginDetected(plugin) {
   return false;
 }
 
+function backupBeforeWrite(filePath) {
+  try {
+    if (!filePath || !fs.existsSync(filePath)) return;
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    fs.copyFileSync(filePath, `${filePath}.sc-bak.${stamp}`);
+  } catch (err) {
+    console.error(`  ⚠ backup failed for ${filePath}: ${err.message}`);
+  }
+}
+
 function installPlugin(plugin, { force = false } = {}) {
   const should = force || plugin.alwaysInstall || pluginDetected(plugin);
   if (!should) return null;
@@ -671,17 +681,22 @@ function installPlugin(plugin, { force = false } = {}) {
     }
     const writer = FORMAT_WRITERS[plugin.format];
     if (!writer) throw new Error(`No writer for format ${plugin.format}`);
+    backupBeforeWrite(plugin.configPath);
     writer.write(plugin.configPath);
     for (const extra of plugin.extraWriters || []) {
       const fmt = extra.format || "mcp-json";
       const cfg = expandHome(extra.configPath);
       if (!cfg) continue;
       const w = FORMAT_WRITERS[fmt];
-      if (w) w.write(cfg);
+      if (w) {
+        backupBeforeWrite(cfg);
+        w.write(cfg);
+      }
     }
   }
 
   if (plugin.instructionPath) {
+    backupBeforeWrite(expandHome(plugin.instructionPath) || plugin.instructionPath);
     writeInstructionFile(plugin.instructionPath);
   }
   return plugin.name;

--- a/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
+++ b/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
@@ -48,24 +48,20 @@ function splitAskAndContext(text) {
   if (raw.trim().length < minSplit) {
     return { ask: raw.trim(), context: "" };
   }
+  // Only split on a clear paragraph boundary. Never arbitrarily carve the first
+  // ~400 chars of a long instruction — that would compress the user's ask.
   const parts = raw.split(/\n\s*\n/);
-  if (parts.length >= 2 && parts[0].trim().length <= 500) {
+  if (parts.length >= 2 && parts[0].trim().length > 0 && parts[0].trim().length <= 800) {
     return {
       ask: parts[0].trim(),
       context: parts.slice(1).join("\n\n").trim(),
     };
   }
-  const head = raw.slice(0, 400);
-  const nl = head.lastIndexOf("\n");
-  const cut = nl > 80 ? nl : 400;
-  return {
-    ask: raw.slice(0, cut).trim() || "Compress the following context for the coding task.",
-    context: raw.slice(cut).trim(),
-  };
+  return { ask: raw.trim(), context: "" };
 }
 
 function writeInbox(query, compressed, meta, extra = {}) {
-  fs.mkdirSync(INBOX_DIR, { recursive: true });
+  fs.mkdirSync(INBOX_DIR, { recursive: true, mode: 0o700 });
   const latestMd = path.join(INBOX_DIR, "latest.md");
   const latestJson = path.join(INBOX_DIR, "latest.json");
   const body = [
@@ -85,7 +81,7 @@ function writeInbox(query, compressed, meta, extra = {}) {
     compressed || "(empty)",
     "",
   ].join("\n");
-  fs.writeFileSync(latestMd, body);
+  fs.writeFileSync(latestMd, body, { mode: 0o600 });
   fs.writeFileSync(
     latestJson,
     JSON.stringify(
@@ -98,7 +94,8 @@ function writeInbox(query, compressed, meta, extra = {}) {
       },
       null,
       2
-    )
+    ),
+    { mode: 0o600 }
   );
   return latestMd;
 }
@@ -157,9 +154,8 @@ function loadSession(sessionId) {
 
 function saveSession(sessionId, state) {
   const { dir, statePath, memoryPath } = sessionPaths(sessionId);
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   state.updated_at = new Date().toISOString();
-  fs.writeFileSync(memoryPath, state.memory || "");
   const disk = {
     session_id: sessionId,
     seen: state.seen || {},
@@ -168,7 +164,13 @@ function saveSession(sessionId, state) {
     compacted_at: state.compacted_at || null,
     memory_chars: (state.memory || "").length,
   };
-  fs.writeFileSync(statePath, JSON.stringify(disk, null, 2));
+  // Atomic-ish write: temp + rename reduces cross-hook lost updates.
+  const memTmp = `${memoryPath}.${process.pid}.tmp`;
+  const stateTmp = `${statePath}.${process.pid}.tmp`;
+  fs.writeFileSync(memTmp, state.memory || "", { mode: 0o600 });
+  fs.writeFileSync(stateTmp, JSON.stringify(disk, null, 2), { mode: 0o600 });
+  fs.renameSync(memTmp, memoryPath);
+  fs.renameSync(stateTmp, statePath);
 }
 
 function markSeen(state, hash) {
@@ -322,8 +324,11 @@ async function compressIncremental({ context, query, codingAgent, sessionId, kin
     deltaResult.skipped === "empty" ||
     deltaResult.skipped === "too_small" ||
     deltaResult.skipped === "no_key" ||
+    deltaResult.skipped === "timeout" ||
+    deltaResult.skipped === "error" ||
     String(deltaResult.skipped || "").startsWith("http_")
   ) {
+    // Do not markSeen on timeout/error — temporary outages must remain retryable.
     return { ...deltaResult, session_id: sid, compacted: false, delta: "" };
   }
 

--- a/packages/proxy/src/detector.js
+++ b/packages/proxy/src/detector.js
@@ -618,8 +618,9 @@ const AGENTS = [
     },
     configure: (config, revert) => {
       if (revert) {
-        delete config["openAiBaseUrl"];
-        delete config["openAIBaseUrl"];
+        // Only clear values we wrote — never wipe a user's custom API base.
+        if (config["openAiBaseUrl"] === PROXY_BASE) delete config["openAiBaseUrl"];
+        if (config["openAIBaseUrl"] === PROXY_BASE) delete config["openAIBaseUrl"];
       } else {
         config["openAiBaseUrl"] = PROXY_BASE;
       }
@@ -646,8 +647,8 @@ const AGENTS = [
     },
     configure: (config, revert) => {
       if (revert) {
-        delete config["apiBaseUrl"];
-        delete config["api_base_url"];
+        if (config["apiBaseUrl"] === PROXY_BASE) delete config["apiBaseUrl"];
+        if (config["api_base_url"] === PROXY_BASE) delete config["api_base_url"];
       } else {
         config["apiBaseUrl"] = PROXY_BASE;
       }
@@ -719,9 +720,9 @@ const AGENTS = [
     },
     configure: (config, revert) => {
       if (revert) {
-        delete config["openAiBaseUrl"];
-        delete config["apiBaseUrl"];
-        delete config["api_base_url"];
+        if (config["openAiBaseUrl"] === PROXY_BASE) delete config["openAiBaseUrl"];
+        if (config["apiBaseUrl"] === PROXY_BASE) delete config["apiBaseUrl"];
+        if (config["api_base_url"] === PROXY_BASE) delete config["api_base_url"];
       } else {
         config["openAiBaseUrl"] = PROXY_BASE;
         config["apiProvider"] = "openai-compatible";
@@ -1604,11 +1605,15 @@ function writeAgentInstructionFiles() {
       let next = body;
       if (fs.existsSync(filePath)) {
         const prev = fs.readFileSync(filePath, "utf8");
-        if (prev.includes("SuperCompress (always on)")) {
+        if (/SuperCompress \(always on/i.test(prev)) {
           next = prev.replace(
-            /# SuperCompress \(always on\)[\s\S]*?(?=\n# |\n## |$)/,
+            /# SuperCompress \(always on[^\n]*\)[\s\S]*?(?=\n# (?!#)|\n*$)/,
             body.trim() + "\n\n"
           );
+          // If the heading variant didn't match the regex, avoid appending a duplicate.
+          if (next === prev) {
+            next = prev; // already present under a recognized heading
+          }
         } else {
           next = `${prev.trimEnd()}\n\n${body}`;
         }

--- a/packages/proxy/src/mcp.js
+++ b/packages/proxy/src/mcp.js
@@ -140,14 +140,15 @@ async function handleToolCall(name, args = {}) {
           try {
             config = JSON.parse(fs.readFileSync(configPath, "utf8"));
           } catch {}
-          fs.mkdirSync(path.dirname(configPath), { recursive: true });
+          fs.mkdirSync(path.dirname(configPath), { recursive: true, mode: 0o700 });
           fs.writeFileSync(
             configPath,
             JSON.stringify(
               { ...config, api_key: body.secret, connected_at: new Date().toISOString() },
               null,
               2
-            )
+            ),
+            { mode: 0o600 }
           );
           return toolText("SuperCompress account connected. Future compression usage is metered to this account.");
         }


### PR DESCRIPTION
## Summary
- `clearProxyOverrides` / agent revert only removes SuperCompress `localhost` base URLs
- Plugin framework backups config/instruction files before mutation
- Instruction-block replace matches `always on · …` headings (no duplicates)
- Hooks: no `markSeen` on timeout/error; no arbitrary 400-char ask split; 0700/0600 session+inbox; atomic rename writes
- `mintConnectKey` fails with 409 instead of revoking non-plugin production keys
- Device-link secret consume is transactional via Firestore when available
- MCP `config.json` writes use restrictive modes

## Test plan
- [x] `node packages/proxy/test/agent-plugins.js`
- [x] `node packages/proxy/test/uninstall-clean.js`
- [ ] Manual: setup twice → single instruction block; custom Cursor base URL preserved

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes coding-agent integration less destructive, adds plugin-file backups and restrictive local storage modes, changes device-link consumption and key-limit handling, and improves prompt/session behavior. However, the single-use secret path remains replayable after a partial failure, existing sensitive files are not remediated to restrictive permissions, and the changelog contains unresolved conflict markers.
- Preserves user-owned agent base URL overrides during revert.
- Adds backups before plugin configuration and instruction mutations.
- Changes connect-key exhaustion and device-link consumption behavior.
- Updates prompt splitting, retry handling, session persistence, and MCP configuration writes.

<h3>Confidence Score: 0/5</h3>

The PR is not safe to merge until device-link replay, existing sensitive-file permissions, and the unresolved changelog conflict are fixed.

A failed Auth cleanup allows a Firestore-consumed connection secret to be returned again, existing permissive files can retain access to newly written credentials and prompt data, and the changelog currently exposes raw conflict markers.

**Files Needing Attention:** api/_lib/auth-connect.js, packages/proxy/src/mcp.js, packages/proxy/src/cursor-hooks/compress-prompt-lib.js, CHANGELOG.md

<details open><summary><h3>Security Review</h3></summary>

Two security issues remain: a consumed device-link secret can be replayed when Auth cleanup fails, and existing permissive config/inbox files retain their modes while receiving credentials or prompt data.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/_lib/auth-connect.js | Adds Firestore-backed device-link consumption, but stale Auth claims can re-enable an already-consumed secret. |
| api/account.js | Avoids revoking arbitrary production keys and delegates device-link secret retrieval to the new consume operation. |
| packages/proxy/src/agent-plugins.js | Adds timestamped backups before configured plugin and instruction writers mutate existing files. |
| packages/proxy/src/cursor-hooks/compress-prompt-lib.js | Improves splitting and atomic session writes, but inbox mode options do not remediate existing permissive files. |
| packages/proxy/src/detector.js | Limits revert cleanup to SuperCompress-owned proxy URLs and broadens instruction-heading recognition. |
| packages/proxy/src/mcp.js | Writes connected account credentials with a restrictive creation mode, but existing config files retain prior permissions. |
| CHANGELOG.md | Contains unresolved merge-conflict markers in the coding-agent plugin section. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(plugin): non-destructive agent integ..."](https://github.com/supercompress/supercompress/commit/ab3b92c07acf97cb3973dea8509bcc913cfa474f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52022841)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->