### PR TITLE
fix(billing): hard quota, credit idempotency, fail-closed charge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,19 @@ jobs:
           python examples/integrations/openai_wrapper.py >/dev/null
           python examples/integrations/langchain_hook.py >/dev/null
           python examples/demo_compare.py >/dev/null
+      - name: Install JS deps
+        run: npm ci --omit=optional --ignore-scripts --no-audit --no-fund
       - name: JS syntax smoke
         run: |
           node --check api/demo/compress.js
           node --check api/_lib/store.js
           node --check api/_lib/engine.js
-          node --check api/_lib/billing-ledger.js 2>/dev/null || true
-          node --check packages/proxy/src/server.js
+          node --check api/_lib/billing-ledger.js
           node --check packages/proxy/src/compressor.js
           node --check packages/proxy/src/forwarder.js
+          node --check packages/proxy/src/server.js
+      - name: Billing ledger unit tests
+        run: node api/_lib/billing-ledger.test.js
       - name: Proxy package tests
         run: |
           cd packages/proxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Public page: https://www.supercompress.dev/changelog
 - Fix demo CO₂ grams over-count (`×1000` bug)
 - Transactional Firestore billing ledger for usage + wallet burns; Stripe auto-recharge lock + idempotency; no pre-Checkout `sc_metered` mutation; micro-USD burns so tiny requests are not free
 - Fix `/api/v1/compress` 504s: kill O(n²) token-entropy scans in the engine, skip unused line annotations on the hosted path, soft-timeout Firestore side-effects, raise route `maxDuration` to 60s
+- Harden billing: fail-closed `recordUsage`, atomic free-quota/wallet rejection (no clamp-to-zero), permanent `billing_credits/{id}` idempotency, ledger-only claim mirroring
+- Compress POST-only (no query API keys/context); durable rate-limit fail-closed; CCR strips retrieve markers if persistence fails; dashboard reads billing ledger
 
 ### Coding agent plugin
 - Protocol/runtime safety: native `fetch` (drop `node-fetch`), owned-PID-only stop, buffered SSE that preserves `tool_calls`, skip compression for structured tool/Responses items, inject digests as user (not system), fail-open on compress timeout/5xx, block browser `Origin` on local proxy, zstd size caps, spawn via `process.execPath`

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -2,12 +2,13 @@
  * Transactional billing ledger — source of truth for monthly usage + prepaid balance.
  *
  * Auth custom claims (`sc_usage`, `sc_credit_balance_usd`) are mirrored after
- * commit for dashboard/compat reads, but concurrent compressions must not
+ * commit for dashboard/compat reads. Concurrent compressions must not
  * read-modify-write claims directly.
  *
- * Firestore doc: billing/{uid}
+ * Firestore:
+ *   billing/{uid}              — monthly usage + wallet balance
+ *   billing_credits/{creditKey} — permanent Stripe session / PI idempotency
  */
-const admin = require("firebase-admin");
 const { initFirebaseAdmin } = require("./auth");
 const {
   FREE_TOKENS_PER_MONTH,
@@ -24,11 +25,16 @@ const {
 
 const MICROS_PER_USD = 1_000_000;
 
+let _admin = null;
 let _db = null;
+function admin() {
+  if (!_admin) _admin = require("firebase-admin");
+  return _admin;
+}
 function db() {
   if (!_db) {
     initFirebaseAdmin();
-    _db = admin.firestore();
+    _db = admin().firestore();
   }
   return _db;
 }
@@ -47,8 +53,16 @@ function microsToUsd(micros) {
 
 /** Integer micro-USD for a token count at $0.30 / 1M (no per-request $0 rounding). */
 function tokensToMicros(tokenCount) {
-  // tokens * 0.30 micros/token  (== tokens/1e6 * 0.30 * 1e6)
   return Math.ceil(Number(tokenCount || 0) * USD_PER_MILLION);
+}
+
+function billingError(code, message, extra = {}) {
+  const err = new Error(message);
+  err.code = code;
+  err.status = code === "billing_unavailable" ? 503 : 402;
+  err.paywall = code !== "billing_unavailable";
+  Object.assign(err, extra);
+  return err;
 }
 
 function emptyLedger(claims = {}) {
@@ -68,6 +82,7 @@ function emptyLedger(claims = {}) {
     ),
     auto_recharge: Boolean(claims.sc_auto_recharge),
     customer_id: claims.sc_customer_id || null,
+    // Display-only recent keys; idempotency is billing_credits/{id}
     credited_keys: Array.isArray(claims.sc_credited_sessions)
       ? claims.sc_credited_sessions.slice(-40)
       : [],
@@ -79,7 +94,6 @@ function normalizeLedger(raw, claims = {}) {
   const base = emptyLedger(claims);
   if (!raw || typeof raw !== "object") return base;
   const month = monthKey();
-  // Month rollover
   if (raw.month && raw.month !== month) {
     return {
       ...base,
@@ -121,23 +135,107 @@ function normalizeLedger(raw, claims = {}) {
   };
 }
 
+/**
+ * Pure gate used inside the Firestore transaction (and unit tests).
+ * Rejects free-quota overshoot and wallet burns that exceed balance (no clamp-to-zero).
+ */
+function planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims = {} }) {
+  const prevTokensIn = Number(ledger.tokens_in || 0);
+  const addIn = Math.max(0, Number(tokensIn) || 0);
+  const addOut = Math.max(0, Number(tokensOut) || 0);
+  const addSaved = Math.max(0, Number(tokensSaved) || 0);
+  const nextTokensIn = prevTokensIn + addIn;
+
+  const comped = isComped(claims);
+  const legacy = isLegacyMetered(claims);
+  const wallet =
+    !comped &&
+    (isCreditWallet(claims) ||
+      (isPaygEnabled(claims.sc_plan) && !legacy));
+
+  if (!comped && !legacy && !wallet) {
+    if (prevTokensIn >= FREE_TOKENS_PER_MONTH || nextTokensIn > FREE_TOKENS_PER_MONTH) {
+      throw billingError(
+        "free_quota_exhausted",
+        `Free ${FREE_TOKENS_PER_MONTH / 1e6}M token allowance exhausted this month.`,
+        {
+          payload: {
+            ok: false,
+            paywall: true,
+            code: "free_quota_exhausted",
+            tokens_used: prevTokensIn,
+            free_tokens: FREE_TOKENS_PER_MONTH,
+            upgrade_url: "https://www.supercompress.dev/dashboard#billing",
+          },
+        }
+      );
+    }
+  }
+
+  let burned_micros = 0;
+  let nextBalance = Number(ledger.credit_balance_micros || 0);
+  if (wallet) {
+    const prevBillable = billableTokens(prevTokensIn);
+    const newBillable = billableTokens(nextTokensIn);
+    const deltaBillable = Math.max(0, newBillable - prevBillable);
+    burned_micros = tokensToMicros(deltaBillable);
+    if (burned_micros > nextBalance) {
+      throw billingError(
+        "credits_exhausted",
+        "Prepaid balance is insufficient for this compression.",
+        {
+          payload: {
+            ok: false,
+            paywall: true,
+            code: "credits_exhausted",
+            credit_balance_usd: roundUsd(microsToUsd(nextBalance)),
+            required_usd: roundUsd(microsToUsd(burned_micros)),
+            upgrade_url: "https://www.supercompress.dev/dashboard#billing",
+          },
+        }
+      );
+    }
+    nextBalance -= burned_micros;
+  }
+
+  return {
+    burned_micros,
+    ledger: {
+      ...ledger,
+      tokens_in: nextTokensIn,
+      tokens_out: Number(ledger.tokens_out || 0) + addOut,
+      tokens_saved: Number(ledger.tokens_saved || 0) + addSaved,
+      requests: Number(ledger.requests || 0) + 1,
+      credit_balance_micros: nextBalance,
+      updated_at: new Date().toISOString(),
+    },
+  };
+}
+
 async function loadLedger(uid, claims = {}) {
-  if (!uid || !initFirebaseAdmin()) return emptyLedger(claims);
+  if (!uid || !initFirebaseAdmin()) {
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
+  }
   try {
     const snap = await db().collection("billing").doc(uid).get();
     return normalizeLedger(snap.exists ? snap.data() : null, claims);
   } catch (err) {
+    if (err.code === "billing_unavailable") throw err;
     console.warn("billing-ledger load failed:", err.message || err);
-    return emptyLedger(claims);
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
 }
 
-async function mirrorClaims(uid, ledger, claimsBase = {}) {
+/**
+ * Mirror only ledger-owned claim fields. Never re-apply a stale claimsBase over
+ * fresher Auth state (plan / subscription / preferences from webhooks).
+ */
+async function mirrorClaims(uid, ledger) {
   if (!uid || !initFirebaseAdmin()) return;
   try {
-    const fresh = await admin.auth().getUser(uid);
-    const prev = { ...(fresh.customClaims || {}), ...claimsBase };
-    await admin.auth().setCustomUserClaims(uid, {
+    const fresh = await admin().auth().getUser(uid);
+    const prev = { ...(fresh.customClaims || {}) };
+    await admin().auth().setCustomUserClaims(uid, {
       ...prev,
       sc_usage: {
         month: ledger.month,
@@ -151,7 +249,7 @@ async function mirrorClaims(uid, ledger, claimsBase = {}) {
       ...(ledger.credit_limit_usd != null
         ? { sc_credit_limit_usd: ledger.credit_limit_usd }
         : {}),
-      ...(ledger.auto_recharge != null ? { sc_auto_recharge: ledger.auto_recharge } : {}),
+      ...(ledger.auto_recharge != null ? { sc_auto_recharge: Boolean(ledger.auto_recharge) } : {}),
       ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
     });
   } catch (err) {
@@ -160,71 +258,43 @@ async function mirrorClaims(uid, ledger, claimsBase = {}) {
 }
 
 /**
- * Atomically record usage and burn prepaid credit for newly billable tokens.
- * Returns updated ledger snapshot + burn metadata.
+ * Atomically record usage and burn prepaid credit.
+ * Throws paywall / billing_unavailable — never silently under-charges.
  */
 async function applyUsageAndBurn({ uid, tokensIn, tokensOut, tokensSaved, claims = {} }) {
   if (!uid) throw new Error("uid required");
   if (!initFirebaseAdmin()) {
-    // Soft fallback — caller may still update claims (legacy path).
-    const ledger = emptyLedger(claims);
-    ledger.tokens_in += tokensIn;
-    ledger.tokens_out += tokensOut;
-    ledger.tokens_saved += tokensSaved;
-    ledger.requests += 1;
-    return { ledger, burned_micros: 0, fallback: true };
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
 
   const ref = db().collection("billing").doc(uid);
   const result = await db().runTransaction(async (tx) => {
     const snap = await tx.get(ref);
     const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
-    const prevTokensIn = ledger.tokens_in;
-    ledger.tokens_in += Math.max(0, Number(tokensIn) || 0);
-    ledger.tokens_out += Math.max(0, Number(tokensOut) || 0);
-    ledger.tokens_saved += Math.max(0, Number(tokensSaved) || 0);
-    ledger.requests += 1;
-    ledger.updated_at = new Date().toISOString();
-
-    let burned_micros = 0;
-    const wallet =
-      !isComped(claims) &&
-      (isCreditWallet(claims) ||
-        (isPaygEnabled(claims.sc_plan) && !isLegacyMetered(claims)));
-    if (wallet) {
-      const prevBillable = billableTokens(prevTokensIn);
-      const newBillable = billableTokens(ledger.tokens_in);
-      const deltaBillable = Math.max(0, newBillable - prevBillable);
-      burned_micros = tokensToMicros(deltaBillable);
-      if (burned_micros > 0) {
-        ledger.credit_balance_micros = Math.max(
-          0,
-          Number(ledger.credit_balance_micros || 0) - burned_micros
-        );
-      }
-    }
-
-    tx.set(ref, ledger, { merge: true });
-    return { ledger, burned_micros };
+    const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims });
+    tx.set(ref, planned.ledger, { merge: true });
+    return planned;
   });
 
-  await mirrorClaims(uid, result.ledger, claims);
+  await mirrorClaims(uid, result.ledger);
   return result;
 }
 
 /**
- * Credit prepaid balance (Checkout / auto-recharge). Idempotent by creditKey.
+ * Credit prepaid balance. Idempotent via permanent billing_credits/{creditKey}.
  */
 async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {} }) {
   if (!uid || !creditKey) return { applied: false, reason: "missing_args" };
   if (!initFirebaseAdmin()) return { applied: false, reason: "firebase_unavailable" };
 
   const ref = db().collection("billing").doc(uid);
+  const creditRef = db().collection("billing_credits").doc(String(creditKey));
   const result = await db().runTransaction(async (tx) => {
+    const creditSnap = await tx.get(creditRef);
     const snap = await tx.get(ref);
     const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
-    const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
-    if (keys.includes(creditKey)) {
+
+    if (creditSnap.exists) {
       return {
         applied: true,
         already: true,
@@ -232,6 +302,7 @@ async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {
         balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
       };
     }
+
     const add = usdToMicros(creditUsd);
     ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
     if (patch.credit_limit_usd != null) {
@@ -239,8 +310,19 @@ async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {
     }
     if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
     if (patch.customer_id) ledger.customer_id = patch.customer_id;
-    ledger.credited_keys = [...keys.slice(-40), creditKey];
+    const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
+    ledger.credited_keys = [...keys.filter((k) => k !== creditKey).slice(-39), creditKey];
     ledger.updated_at = new Date().toISOString();
+
+    tx.set(
+      creditRef,
+      {
+        uid,
+        credit_usd: Number(creditUsd) || 0,
+        created_at: new Date().toISOString(),
+      },
+      { merge: false }
+    );
     tx.set(ref, ledger, { merge: true });
     return {
       applied: true,
@@ -250,19 +332,38 @@ async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {
     };
   });
 
-  await mirrorClaims(uid, result.ledger, {
-    ...claims,
-    sc_plan: "payg",
-    sc_metered: false,
-    sc_credited_sessions: result.ledger.credited_keys,
-  });
+  // Patch payg flags only when this credit actually applied (not on replay).
+  if (result.applied && !result.already) {
+    try {
+      const fresh = await admin().auth().getUser(uid);
+      const prev = { ...(fresh.customClaims || {}) };
+      await admin().auth().setCustomUserClaims(uid, {
+        ...prev,
+        sc_plan: prev.sc_plan || "payg",
+        sc_metered: false,
+        sc_usage: {
+          month: result.ledger.month,
+          requests: result.ledger.requests,
+          tokens_in: result.ledger.tokens_in,
+          tokens_out: result.ledger.tokens_out,
+          tokens_saved: result.ledger.tokens_saved,
+          tokens_reported: result.ledger.tokens_reported,
+        },
+        sc_credit_balance_usd: roundUsd(microsToUsd(result.ledger.credit_balance_micros)),
+        sc_credit_limit_usd: result.ledger.credit_limit_usd,
+        sc_auto_recharge: Boolean(result.ledger.auto_recharge),
+        ...(result.ledger.customer_id ? { sc_customer_id: result.ledger.customer_id } : {}),
+      });
+    } catch (err) {
+      console.warn("credit claim mirror failed:", err.message || err);
+      await mirrorClaims(uid, result.ledger);
+    }
+  } else {
+    await mirrorClaims(uid, result.ledger);
+  }
   return result;
 }
 
-/**
- * Distributed lock for auto-recharge. Returns { acquired, release }.
- * Lock TTL ~90s; held across Stripe PaymentIntent confirm.
- */
 async function acquireRechargeLock(uid) {
   if (!uid || !initFirebaseAdmin()) return { acquired: false, reason: "unavailable" };
   const ref = db().collection("billing_locks").doc(uid);
@@ -303,7 +404,7 @@ async function markTokensReported(uid, tokensReported, claims = {}) {
     tx.set(ref, next, { merge: true });
     return next;
   });
-  await mirrorClaims(uid, ledger, claims);
+  await mirrorClaims(uid, ledger);
   return ledger;
 }
 
@@ -314,6 +415,7 @@ module.exports = {
   acquireRechargeLock,
   markTokensReported,
   mirrorClaims,
+  planUsageBurn,
   tokensToMicros,
   usdToMicros,
   microsToUsd,

--- a/api/_lib/billing-ledger.test.js
+++ b/api/_lib/billing-ledger.test.js
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for billing ledger gate (no Firebase required).
+ * Run: node api/_lib/billing-ledger.test.js
+ */
+const assert = require("assert");
+const { planUsageBurn, FREE_TOKENS_PER_MONTH, tokensToMicros } = require("./billing-ledger");
+
+function ledger(partial = {}) {
+  return {
+    month: "2026-08",
+    tokens_in: 0,
+    tokens_out: 0,
+    tokens_saved: 0,
+    requests: 0,
+    tokens_reported: 0,
+    credit_balance_micros: 0,
+    credit_limit_usd: 10,
+    auto_recharge: false,
+    customer_id: null,
+    credited_keys: [],
+    updated_at: new Date().toISOString(),
+    ...partial,
+  };
+}
+
+function mustThrow(fn, code) {
+  let threw = false;
+  try {
+    fn();
+  } catch (err) {
+    threw = true;
+    assert.strictEqual(err.code, code, `expected ${code}, got ${err.code}: ${err.message}`);
+  }
+  assert.ok(threw, `expected throw ${code}`);
+}
+
+// Free user under quota
+{
+  const r = planUsageBurn(ledger({ tokens_in: 100 }), {
+    tokensIn: 50,
+    tokensOut: 20,
+    tokensSaved: 30,
+    claims: { sc_plan: "free" },
+  });
+  assert.strictEqual(r.ledger.tokens_in, 150);
+  assert.strictEqual(r.burned_micros, 0);
+}
+
+// Free user cannot cross 1M
+mustThrow(
+  () =>
+    planUsageBurn(ledger({ tokens_in: FREE_TOKENS_PER_MONTH - 10 }), {
+      tokensIn: 20,
+      tokensOut: 5,
+      tokensSaved: 15,
+      claims: { sc_plan: "free" },
+    }),
+  "free_quota_exhausted"
+);
+
+// Already at free ceiling
+mustThrow(
+  () =>
+    planUsageBurn(ledger({ tokens_in: FREE_TOKENS_PER_MONTH }), {
+      tokensIn: 1,
+      tokensOut: 0,
+      tokensSaved: 1,
+      claims: { sc_plan: "free" },
+    }),
+  "free_quota_exhausted"
+);
+
+// Wallet: reject when burn exceeds balance (no clamp-to-zero)
+{
+  const balance = tokensToMicros(1000); // enough for 1k billable tokens only
+  mustThrow(
+    () =>
+      planUsageBurn(
+        ledger({
+          tokens_in: FREE_TOKENS_PER_MONTH,
+          credit_balance_micros: balance,
+        }),
+        {
+          tokensIn: 50_000,
+          tokensOut: 10_000,
+          tokensSaved: 40_000,
+          claims: { sc_plan: "payg", sc_metered: false, sc_credit_balance_usd: 0.01 },
+        }
+      ),
+    "credits_exhausted"
+  );
+}
+
+// Wallet: exact burn succeeds
+{
+  const billable = 10_000;
+  const burn = tokensToMicros(billable);
+  const r = planUsageBurn(
+    ledger({
+      tokens_in: FREE_TOKENS_PER_MONTH,
+      credit_balance_micros: burn,
+    }),
+    {
+      tokensIn: billable,
+      tokensOut: 1000,
+      tokensSaved: 9000,
+      claims: { sc_plan: "payg", sc_metered: false, sc_credit_balance_usd: 1 },
+    }
+  );
+  assert.strictEqual(r.burned_micros, burn);
+  assert.strictEqual(r.ledger.credit_balance_micros, 0);
+  assert.strictEqual(r.ledger.tokens_in, FREE_TOKENS_PER_MONTH + billable);
+}
+
+// Comped skips gates
+{
+  const r = planUsageBurn(ledger({ tokens_in: FREE_TOKENS_PER_MONTH * 5 }), {
+    tokensIn: 1_000_000,
+    tokensOut: 1,
+    tokensSaved: 1,
+    claims: { sc_comped: true },
+  });
+  assert.strictEqual(r.burned_micros, 0);
+  assert.ok(r.ledger.tokens_in > FREE_TOKENS_PER_MONTH);
+}
+
+console.log("billing-ledger.test.js: ok");

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -446,38 +446,24 @@ async function recordUsage(keyRec, owner, compressed) {
   const { applyUsageAndBurn, microsToUsd } = require("./billing-ledger");
   const { reportPaygUsage, isPaygEnabled, isComped, isLegacyMetered, roundUsd } = require("./stripe");
 
-  let ledger;
-  try {
-    const applied = await applyUsageAndBurn({
-      uid: owner.uid,
-      tokensIn: compressed.original_tokens,
-      tokensOut: compressed.kept_tokens,
-      tokensSaved,
-      claims: ownerClaims,
-    });
-    ledger = applied.ledger;
-  } catch (err) {
-    console.warn("recordUsage: billing ledger failed:", err.message || err);
-    ledger = null;
-  }
+  // Billing is fail-closed: never invent a fake usage object on ledger failure.
+  const applied = await applyUsageAndBurn({
+    uid: owner.uid,
+    tokensIn: compressed.original_tokens,
+    tokensOut: compressed.kept_tokens,
+    tokensSaved,
+    claims: ownerClaims,
+  });
+  const ledger = applied.ledger;
 
-  const ownerUsage = ledger
-    ? {
-        month: ledger.month,
-        requests: ledger.requests,
-        tokens_in: ledger.tokens_in,
-        tokens_out: ledger.tokens_out,
-        tokens_saved: ledger.tokens_saved,
-        tokens_reported: ledger.tokens_reported || 0,
-      }
-    : {
-        month: now.slice(0, 7),
-        requests: 1,
-        tokens_in: compressed.original_tokens,
-        tokens_out: compressed.kept_tokens,
-        tokens_saved: tokensSaved,
-        tokens_reported: 0,
-      };
+  const ownerUsage = {
+    month: ledger.month,
+    requests: ledger.requests,
+    tokens_in: ledger.tokens_in,
+    tokens_out: ledger.tokens_out,
+    tokens_saved: ledger.tokens_saved,
+    tokens_reported: ledger.tokens_reported || 0,
+  };
 
   // Legacy metered: report to Stripe meters (idempotent watermark on ledger).
   try {

--- a/api/_lib/http.js
+++ b/api/_lib/http.js
@@ -82,9 +82,23 @@ function parseFormEncoded(str) {
  * and form-encoded (application/x-www-form-urlencoded) cases.
  * Returns parsed object, or throws 413 if body exceeds MAX_BODY_BYTES.
  */
+function estimateBodyBytes(value) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return MAX_BODY_BYTES + 1;
+  }
+}
+
 function readBody(req) {
   // Vercel serverless parses JSON bodies before the handler — req.body is already an object
   if (typeof req.body === "object" && req.body !== null && !Array.isArray(req.body)) {
+    const bytes = estimateBodyBytes(req.body);
+    if (bytes > MAX_BODY_BYTES) {
+      const err = new Error(`Request body too large (max ${MAX_BODY_BYTES / 1000}KB)`);
+      err.status = 413;
+      throw err;
+    }
     return req.body;
   }
   // Raw string body (bodyParser disabled or non-JSON content type)

--- a/api/_lib/rate-limit-durable.js
+++ b/api/_lib/rate-limit-durable.js
@@ -5,7 +5,8 @@
  * cold start, so scrapers / demo abusers can burn through invocation quotas.
  * Firestore gives a shared counter across instances.
  *
- * Fail-open to in-memory if Firebase is down (prefer serving over hard-down).
+ * For authenticated paid endpoints, callers should treat backend !== "firestore"
+ * as fail-closed (reject) so multi-instance fans-out cannot bypass the ceiling.
  */
 const crypto = require("crypto");
 const admin = require("firebase-admin");
@@ -40,8 +41,14 @@ async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000) {
   const resetMs = Math.ceil(Date.now() / windowMs) * windowMs;
   const firestore = db();
   if (!firestore) {
-    const local = checkRateLimit(key, maxRequests, windowMs);
-    return { ...local, backend: "memory" };
+    return {
+      allowed: false,
+      remaining: 0,
+      resetMs,
+      limit: maxRequests,
+      backend: "firestore-unavailable",
+      error: "firebase_unavailable",
+    };
   }
 
   const id = bucketId(key, windowMs);
@@ -81,9 +88,15 @@ async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000) {
       backend: "firestore",
     };
   } catch (err) {
-    console.warn("durable rate limit fallback", err?.message || err);
-    const local = checkRateLimit(key, maxRequests, windowMs);
-    return { ...local, backend: "memory-fallback" };
+    console.warn("durable rate limit unavailable", err?.message || err);
+    return {
+      allowed: false,
+      remaining: 0,
+      resetMs,
+      limit: maxRequests,
+      backend: "firestore-unavailable",
+      error: err?.message || "firestore_unavailable",
+    };
   }
 }
 

--- a/api/billing.js
+++ b/api/billing.js
@@ -168,25 +168,39 @@ async function handleGet(req, res, user) {
   let tokensUsedThisPeriod = 0;
   let requestsThisPeriod = 0;
 
-  const keys = store.keys || {};
-  const usage = store.usage || {};
-  for (const [keyId, keyRec] of Object.entries(keys)) {
-    if (keyRec && keyRec.user_id === user.uid && !keyRec.revoked) {
-      const keyUsage = usage[keyId] || {};
-      for (const [day, rec] of Object.entries(keyUsage)) {
-        if (rec && new Date(day + "T00:00:00Z") >= periodStart) {
-          tokensUsedThisPeriod += rec.tokens_in || 0;
-          requestsThisPeriod += rec.requests || 0;
+  // Prefer transactional billing ledger (source of truth) over store/claims mirrors.
+  try {
+    const { loadLedger, microsToUsd } = require("./_lib/billing-ledger");
+    const ledger = await loadLedger(user.uid, claims);
+    tokensUsedThisPeriod = Number(ledger.tokens_in || 0);
+    requestsThisPeriod = Number(ledger.requests || 0);
+    if (ledger.credit_balance_micros != null) {
+      claims.sc_credit_balance_usd = roundUsd(microsToUsd(ledger.credit_balance_micros));
+    }
+    if (ledger.credit_limit_usd != null) claims.sc_credit_limit_usd = ledger.credit_limit_usd;
+    if (ledger.auto_recharge != null) claims.sc_auto_recharge = Boolean(ledger.auto_recharge);
+  } catch (err) {
+    console.warn("billing ledger read skipped:", err.message || err);
+    const keys = store.keys || {};
+    const usage = store.usage || {};
+    for (const [keyId, keyRec] of Object.entries(keys)) {
+      if (keyRec && keyRec.user_id === user.uid && !keyRec.revoked) {
+        const keyUsage = usage[keyId] || {};
+        for (const [day, rec] of Object.entries(keyUsage)) {
+          if (rec && new Date(day + "T00:00:00Z") >= periodStart) {
+            tokensUsedThisPeriod += rec.tokens_in || 0;
+            requestsThisPeriod += rec.requests || 0;
+          }
         }
       }
     }
-  }
-  if (tokensUsedThisPeriod === 0 && requestsThisPeriod === 0) {
-    const claimUsage = claims.sc_usage;
-    const currentMonth = new Date().toISOString().slice(0, 7);
-    if (claimUsage?.month === currentMonth) {
-      tokensUsedThisPeriod = claimUsage.tokens_in || 0;
-      requestsThisPeriod = claimUsage.requests || 0;
+    if (tokensUsedThisPeriod === 0 && requestsThisPeriod === 0) {
+      const claimUsage = claims.sc_usage;
+      const currentMonth = new Date().toISOString().slice(0, 7);
+      if (claimUsage?.month === currentMonth) {
+        tokensUsedThisPeriod = claimUsage.tokens_in || 0;
+        requestsThisPeriod = claimUsage.requests || 0;
+      }
     }
   }
 

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -37,7 +37,15 @@ async function enforceUsageLimit(owner) {
   }
 
   const { loadLedger, microsToUsd } = require("../_lib/billing-ledger");
-  const ledger = await loadLedger(owner.uid, claims);
+  let ledger;
+  try {
+    ledger = await loadLedger(owner.uid, claims);
+  } catch (err) {
+    const e = new Error("Billing unavailable — try again shortly.");
+    e.status = 503;
+    e.code = "billing_unavailable";
+    throw e;
+  }
   const tokensUsedThisPeriod = Number(ledger.tokens_in || 0);
 
   if (tokensUsedThisPeriod < FREE_TOKENS_PER_MONTH) return;
@@ -121,30 +129,32 @@ function withTimeout(promise, ms, label) {
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
+function stripRetrieveMarkers(text) {
+  return String(text || "")
+    .replace(/\[SC-Retrieve:\s*[^\]]+\]/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
-  if (req.method !== "POST" && req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
+  // Compression is POST-only — never accept API keys or context in query strings.
+  if (req.method === "GET") {
+    return json(res, 405, {
+      ok: false,
+      detail: "Use POST /api/v1/compress with X-API-Key (or Authorization: Bearer). Query-string keys/context are not supported.",
+      allow: "POST",
+    });
+  }
+  if (req.method !== "POST") return json(res, 405, { detail: "Method not allowed" });
 
   const requestStarted = Date.now();
   // Leave headroom under function maxDuration (60s for this route) for response flush.
   const HARD_BUDGET_MS = 55_000;
 
   try {
-    // Support API key from: X-API-Key header, Authorization Bearer, or ?api_key query param
-    const raw = req.headers["x-api-key"]
-      || bearerToken(req.headers.authorization)
-      || (req.query && req.query.api_key);
+    const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization);
     if (!raw || !raw.startsWith(KEY_PREFIX)) {
-      // Scanners often GET /api/v1/compress. Soft 200 keeps Observability error rate
-      // from spiking; real clients use POST + key and still get hard 401.
-      if (req.method === "GET") {
-        return json(res, 200, {
-          ok: false,
-          auth: "required",
-          service: "supercompress",
-          detail: "Pass X-API-Key (sc_live_…) to compress. Prefer POST /api/v1/compress.",
-        });
-      }
       return json(res, 401, { detail: "Missing or invalid API key" });
     }
 
@@ -165,9 +175,17 @@ module.exports = async (req, res) => {
         2000,
         "rate_limit"
       );
-    } catch (_) {
-      rl = checkRateLimit(`v1ip:h:${ip}`, V1_IP_HOURLY, 60 * 60_000);
-      rl.backend = "memory-deadline";
+    } catch (err) {
+      return json(res, 503, {
+        detail: "Rate limit service unavailable. Retry shortly.",
+        code: "rate_limit_unavailable",
+      });
+    }
+    if (rl.backend && rl.backend !== "firestore") {
+      return json(res, 503, {
+        detail: "Rate limit service unavailable. Retry shortly.",
+        code: "rate_limit_unavailable",
+      });
     }
     if (!rl.allowed) {
       return jsonWithRateLimit(res, 429, {
@@ -179,32 +197,17 @@ module.exports = async (req, res) => {
     rl.remaining = Math.min(rl.remaining, rlMem.remaining);
     rl.limit = V1_RPM;
 
-    // Read input outside mutateStore to avoid await inside sync callback
-    let context, query, mode, budgetRatio, ccr, cache_prefix, coding_agent, skipLog, source, session_id;
-    if (req.method === "GET") {
-      context = (req.query && req.query.context) || "";
-      query = (req.query && req.query.query) || "Summarize this context.";
-      mode = (req.query && req.query.mode) || "compiler";
-      budgetRatio = mode === "fixed" ? parseFloat(req.query.budget_ratio || "0.35") : 0.35;
-      ccr = (req.query && req.query.ccr === "true");
-      cache_prefix = (req.query && req.query.cache_prefix === "true");
-      coding_agent = (req.query && req.query.coding_agent) || null;
-      skipLog = req.query && (req.query.log === "0" || req.query.log === "false");
-      source = (req.query && req.query.source) || null;
-      session_id = (req.query && req.query.session_id) || null;
-    } else {
-      const body = readBody(req);
-      context = body.context || "";
-      query = body.query || "Summarize this context.";
-      mode = body.mode || "compiler";
-      budgetRatio = mode === "fixed" ? (body.budget_ratio ?? 0.35) : 0.35;
-      ccr = body.ccr === true || body.ccr === "true";
-      cache_prefix = body.cache_prefix === true || body.cache_prefix === "true";
-      coding_agent = body.coding_agent || null;
-      skipLog = body.log === false || body.log === "false";
-      source = body.source || null;
-      session_id = body.session_id || null;
-    }
+    const body = readBody(req);
+    const context = body.context || "";
+    const query = body.query || "Summarize this context.";
+    const mode = body.mode || "compiler";
+    const budgetRatio = mode === "fixed" ? (body.budget_ratio ?? 0.35) : 0.35;
+    const ccr = body.ccr === true || body.ccr === "true";
+    const cache_prefix = body.cache_prefix === true || body.cache_prefix === "true";
+    const coding_agent = body.coding_agent || null;
+    const skipLog = body.log === false || body.log === "false";
+    const source = body.source || null;
+    const session_id = body.session_id || null;
 
     if (!context.trim()) {
       return json(res, 422, { detail: "context required" });
@@ -229,7 +232,7 @@ module.exports = async (req, res) => {
     const latencyMs = Math.max(0, Date.now() - compressStarted);
 
     const remainingMs = () => HARD_BUDGET_MS - (Date.now() - requestStarted);
-    // Billing must complete when possible; cap so a hung Firebase write can't 504.
+    // Billing is fail-closed: never return compressed text without a durable charge/quota write.
     try {
       await withTimeout(
         recordUsage(authenticated.user, authenticated.owner, result),
@@ -237,7 +240,15 @@ module.exports = async (req, res) => {
         "record_usage"
       );
     } catch (err) {
-      console.warn("recordUsage skipped:", err.message);
+      if (err.paywall || err.status === 402) throw err;
+      const e = new Error(
+        err.code === "timeout"
+          ? "Billing timed out — compression not delivered. Retry."
+          : "Billing unavailable — compression not delivered. Retry."
+      );
+      e.status = err.status || 503;
+      e.code = err.code || "billing_unavailable";
+      throw e;
     }
 
     // Infer source when client omitted it (agent key name / coding_agent).
@@ -301,62 +312,70 @@ module.exports = async (req, res) => {
     // persist each block's text to Blob so retrieval works across cold starts.
     // For fixed+CCR, fall back to basic full-context storage (no block markers).
     let ccrInfo = null;
-    if (ccr && remainingMs() > 2500) {
-      try {
-        if (result.ccr) {
-          // Compiler mode + CCR: compressCCR produced interspersed markers
-          const { stored, stored_hashes, full_stored } = await withTimeout(
-            storeCcrBlocks(result.ccr, context, {
-              ownerUid: authenticated.ownerUid,
-              keyId: authenticated.keyId || authenticated.user?.id,
-            }),
-            Math.min(8000, remainingMs() - 1000),
-            "ccr_store"
-          );
-          if (stored) {
-            ccrInfo = {
-              hash: result.ccr.hash,
-              marker_hashes: result.ccr.marker_hashes || [],
-              markers_count: result.ccr.markers_count || 0,
-              stored_hashes,
-              full_stored,
-              retrieve_url: `/retrieve?hash=${result.ccr.hash}`,
-            };
+    let compressedText = result.compressed_text;
+    if (ccr) {
+      let storedOk = false;
+      if (remainingMs() > 2500) {
+        try {
+          if (result.ccr) {
+            const { stored, stored_hashes, full_stored } = await withTimeout(
+              storeCcrBlocks(result.ccr, context, {
+                ownerUid: authenticated.ownerUid,
+                keyId: authenticated.keyId || authenticated.user?.id,
+              }),
+              Math.min(8000, remainingMs() - 1000),
+              "ccr_store"
+            );
+            if (stored) {
+              storedOk = true;
+              ccrInfo = {
+                hash: result.ccr.hash,
+                marker_hashes: result.ccr.marker_hashes || [],
+                markers_count: result.ccr.markers_count || 0,
+                stored_hashes,
+                full_stored,
+                retrieve_url: `/retrieve?hash=${result.ccr.hash}`,
+              };
+            }
+          } else {
+            const { simpleHash, ccrStoreFirestore } = require("../_lib/engine");
+            const ccrHash = simpleHash(context);
+            const stored = await withTimeout(
+              ccrStoreFirestore(ccrHash, context, {
+                ownerUid: authenticated.ownerUid,
+                keyId: authenticated.keyId || authenticated.user?.id,
+              }),
+              Math.min(5000, remainingMs() - 1000),
+              "ccr_store_full"
+            );
+            if (stored) {
+              storedOk = true;
+              ccrInfo = {
+                hash: ccrHash,
+                marker_hashes: [],
+                markers_count: 0,
+                stored_hashes: [],
+                full_stored: true,
+                retrieve_url: `/retrieve?hash=${ccrHash}`,
+              };
+            }
           }
-        } else {
-          // Fixed mode + CCR (or any mode where compressCCR wasn't used):
-          // Fall back to simple full-context storage with end-of-text marker
-          const { simpleHash, ccrStoreFirestore } = require("../_lib/engine");
-          const ccrHash = simpleHash(context);
-          const stored = await withTimeout(
-            ccrStoreFirestore(ccrHash, context, {
-              ownerUid: authenticated.ownerUid,
-              keyId: authenticated.keyId || authenticated.user?.id,
-            }),
-            Math.min(5000, remainingMs() - 1000),
-            "ccr_store_full"
-          );
-          if (stored) {
-            ccrInfo = {
-              hash: ccrHash,
-              marker_hashes: [],
-              markers_count: 0,
-              stored_hashes: [],
-              full_stored: true,
-              retrieve_url: `/retrieve?hash=${ccrHash}`,
-            };
-          }
+        } catch (err) {
+          console.warn("CCR store failed:", err.message);
         }
-      } catch (err) {
-        console.warn("CCR store skipped:", err.message);
+      }
+      // Persistence is part of a valid CCR result — never return dangling retrieve markers.
+      if (!storedOk) {
+        compressedText = stripRetrieveMarkers(compressedText);
+        ccrInfo = null;
       }
     }
 
     // CacheAligner: optionally wrap compressed text for provider prompt/prefix
     // caching. SuperCompress does not operate inside model KV cache.
     const rawText = ccrInfo && ccrInfo.markers_count === 0
-      ? result.compressed_text + `\n[SC-Retrieve: ${ccrInfo.hash}]\n`
-      : result.compressed_text;
+      ? compressedText + `\n[SC-Retrieve: ${ccrInfo.hash}]\n`
+      : compressedText;
     const finalText = cache_prefix
       ? wrapCompressedForCache(rawText, query).wrapped
       : rawText;

--- a/packages/proxy/src/compressor.js
+++ b/packages/proxy/src/compressor.js
@@ -16,8 +16,19 @@ const SUPERCOMPRESS_API =
   process.env.SUPERCOMPRESS_API_URL || "https://www.supercompress.dev/api/v1/compress";
 const COMPRESS_TIMEOUT_MS = Number(process.env.SUPERCOMPRESS_COMPRESS_TIMEOUT_MS || 12_000);
 
+function isValidApiKey(value) {
+  const key = String(value || "").trim();
+  if (!key) return false;
+  if (key.includes("${") || /SUPERCOMPRESS_API_KEY|your.?key|xxx|placeholder/i.test(key)) {
+    return false;
+  }
+  // Real keys look like sc_live_… / sc_<agent>_…
+  return /^sc_[a-z0-9]+_[A-Za-z0-9]{12,}$/.test(key);
+}
+
 function getApiKey() {
-  if (process.env.SUPERCOMPRESS_API_KEY) return process.env.SUPERCOMPRESS_API_KEY;
+  const envKey = String(process.env.SUPERCOMPRESS_API_KEY || "").trim();
+  if (isValidApiKey(envKey)) return envKey;
   try {
     const configPath = path.join(
       process.env.SUPERCOMPRESS_CONFIG_DIR || path.join(os.homedir(), ".supercompress"),
@@ -25,7 +36,7 @@ function getApiKey() {
     );
     if (fs.existsSync(configPath)) {
       const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-      return config.api_key || null;
+      if (isValidApiKey(config.api_key)) return config.api_key;
     }
   } catch {}
   return null;
@@ -140,12 +151,115 @@ function passThrough(messages, wordCount, skipReason) {
 }
 
 /**
- * Compress a list of messages via the SuperCompress API.
+ * For tool-heavy histories: compress eligible older text turns, keep structured
+ * / recent protocol messages verbatim.
  */
+function splitCompressiblePrefix(messages) {
+  const systemMsgs = [];
+  const rest = [];
+  for (const msg of messages || []) {
+    if (msg?.role === "system" || msg?.role === "developer") systemMsgs.push(msg);
+    else rest.push(msg);
+  }
+  // Keep the trailing window (often active tool loop) untouched.
+  const KEEP_TAIL = 6;
+  if (rest.length <= KEEP_TAIL) {
+    return { systemMsgs, compressible: [], preserved: rest, query: "" };
+  }
+  const compressible = [];
+  const preserved = rest.slice(-KEEP_TAIL);
+  const head = rest.slice(0, -KEEP_TAIL);
+  for (const msg of head) {
+    const structured =
+      msg.role === "tool" ||
+      msg.role === "function" ||
+      msg.tool_calls ||
+      msg.function_call ||
+      msg.tool_call_id ||
+      Array.isArray(msg.content);
+    if (structured) {
+      // Keep structured tool turns verbatim in the preserved prefix area.
+      preserved.unshift(msg);
+    } else {
+      compressible.push(msg);
+    }
+  }
+  let query = "Continue the conversation.";
+  const lastUser = [...compressible].reverse().find((m) => m.role === "user");
+  if (lastUser) query = messageText(lastUser.content) || query;
+  return { systemMsgs, compressible, preserved, query };
+}
+
 async function compress(messages, agentName) {
   if (hasStructuredProtocol(messages)) {
-    const words = messageText(JSON.stringify(messages)).split(/\s+/).length;
-    return passThrough(messages, words, "structured_protocol");
+    const split = splitCompressiblePrefix(messages);
+    const context = split.compressible
+      .map((m) => `[${m.role}]: ${messageText(m.content)}`)
+      .join("\n\n");
+    const wordCount = context.split(/\s+/).filter(Boolean).length;
+    if (wordCount < 100) {
+      const words = messageText(JSON.stringify(messages)).split(/\s+/).length;
+      return passThrough(messages, words, "structured_protocol");
+    }
+    // Fall through to API compress using assembled context, then re-stitch.
+    const apiKey = getApiKey();
+    if (!apiKey) {
+      const words = messageText(JSON.stringify(messages)).split(/\s+/).length;
+      return passThrough(messages, words, "structured_protocol");
+    }
+    const agent = agentName || detectAgentName();
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), COMPRESS_TIMEOUT_MS);
+    try {
+      const response = await fetch(SUPERCOMPRESS_API, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": apiKey,
+        },
+        body: JSON.stringify({
+          context,
+          query: split.query,
+          mode: "compiler",
+          coding_agent: agent,
+          source: "agent",
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const words = messageText(JSON.stringify(messages)).split(/\s+/).length;
+        return passThrough(messages, words, "structured_protocol");
+      }
+      const data = await response.json();
+      const digest = String(data.compressed_text || "").trim();
+      const out = [
+        ...split.systemMsgs,
+        ...(digest
+          ? [
+              {
+                role: "user",
+                content: `[Compressed context — query kept whole]\n\n${digest}`,
+              },
+            ]
+          : []),
+        ...split.preserved,
+      ];
+      const original = wordCount;
+      const compressed = digest.split(/\s+/).filter(Boolean).length;
+      return {
+        messages: out,
+        original_tokens: data.original_tokens || original,
+        compressed_tokens: data.kept_tokens || compressed,
+        tokens_saved: data.tokens_saved || Math.max(0, original - compressed),
+        savings_pct: data.tokens_saved_pct || 0,
+        skip_reason: null,
+      };
+    } catch {
+      const words = messageText(JSON.stringify(messages)).split(/\s+/).length;
+      return passThrough(messages, words, "structured_protocol");
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   const { context, query, systemMsgs } = assembleMessages(messages);

--- a/packages/proxy/src/forwarder.js
+++ b/packages/proxy/src/forwarder.js
@@ -419,9 +419,38 @@ function responsesFallbackObject(data, model) {
   };
 }
 
-async function forwardResponsesViaChatFixed(model, compressed, extraParams, res, apiKey, providerError) {
+async function forwardResponsesViaChatFixed(
+  model,
+  compressed,
+  extraParams,
+  res,
+  apiKey,
+  providerError,
+  originalInput
+) {
   const isStream = extraParams.stream === true || extraParams.stream === "true";
-  const body = responsesToChatBody(model, compressed, extraParams, isStream);
+  const emptyCompressed = !compressed.messages || compressed.messages.length === 0;
+  const preferOriginal =
+    originalInput !== undefined &&
+    (compressed.skip_reason === "structured_protocol" || emptyCompressed);
+  if (preferOriginal && responsesInputHasStructuredItems(originalInput)) {
+    throw new Error(
+      "OpenAI Responses API unavailable, and this request has structured tool items that cannot use the Chat Completions fallback. Enable Responses access for this key."
+    );
+  }
+  if (emptyCompressed && !preferOriginal) {
+    throw new Error(
+      "OpenAI Responses Chat Completions fallback received empty messages (structured compression skip). Enable Responses access for this key."
+    );
+  }
+  const body = responsesToChatBody(
+    model,
+    preferOriginal
+      ? { ...compressed, messages: responsesInputToMessages(originalInput) }
+      : compressed,
+    extraParams,
+    isStream
+  );
   console.error(
     `[supercompress] Responses permission unavailable; using Chat Completions compatibility fallback (${providerError.slice(0, 160)})`
   );
@@ -605,7 +634,8 @@ async function forwardResponses(model, compressed, extraParams, res, authHeader,
         extraParams,
         res,
         apiKey,
-        parseProviderError(apiResponse.status, errorBody)
+        parseProviderError(apiResponse.status, errorBody),
+        originalInput
       );
       return;
     }


### PR DESCRIPTION
## Summary
- Fail-closed billing: no HTTP 200 if `recordUsage` / ledger write fails
- Atomic free-quota + wallet gates in `applyUsageAndBurn` (no clamp-to-zero under concurrency)
- Permanent Stripe credit idempotency via `billing_credits/{sessionId}` (no 40-key replay)
- `mirrorClaims` only patches ledger-owned fields (no stale claimsBase overwrite)
- Compress is POST-only (no query API keys/context); durable IP rate limit fail-closed
- CCR: strip `[SC-Retrieve]` markers if persistence fails
- Proxy: validate `SUPERCOMPRESS_API_KEY`, compress eligible text in structured histories, Responses→Chat fallback won’t send empty messages
- Dashboard reads billing ledger; CI runs ledger unit tests (and `npm ci`)

## Test plan
- [x] `node api/_lib/billing-ledger.test.js`
- [x] `node --check` on touched JS
- [x] `packages/proxy` smoke
- [ ] CI green on PR
- [ ] Spot-check compress 402 near free ceiling / empty wallet
- [ ] Replay old Checkout session id does not double-credit


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter billing controls for quota, prepaid credits, and credit processing.
  - Dashboard billing information now reflects ledger-based usage and credit data.
  - Improved structured-request compression while preserving important protocol messages.
  - Added clearer fallback handling for Responses-to-Chat requests.

- **Bug Fixes**
  - Oversized request bodies are now rejected consistently.
  - Rate limiting blocks requests when durable storage is unavailable.
  - Failed compression persistence no longer leaves invalid retrieval markers.
  - Compression now requires POST requests and body-based input only.

- **Documentation**
  - Updated the unreleased changelog with billing, compression, and rate-limiting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens billing, quota enforcement, credit idempotency, rate limiting, CCR persistence, and proxy handling.
- Makes usage recording and durable rate limiting fail closed.
- Adds atomic free-quota and wallet gates plus permanent Stripe credit markers.
- Restricts compression to POST and enforces body-size limits for parsed requests.
- Extends proxy compression to older text in structured histories and improves Responses fallback behavior.
- Adds billing-ledger tests and strengthens JavaScript CI checks.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until structured tool-message ordering and quota consumption after durable rate-limit timeouts are corrected.

Structured history reconstruction can reverse tool-call/result pairs sent to providers, while an uncancelled durable rate-limit transaction can charge quota after the request has already returned 503.

**Files Needing Attention:** packages/proxy/src/compressor.js, api/v1/compress.js, api/_lib/rate-limit-durable.js

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/_lib/billing-ledger.js | Adds transactional quota and wallet gates, permanent credit idempotency records, fail-closed ledger reads, and safer claim mirroring. |
| api/v1/compress.js | Makes compression POST-only and billing/rate limiting fail closed, but timed-out durable checks can still consume quota before clients retry. |
| packages/proxy/src/compressor.js | Adds compression of eligible text in structured histories, but reverses older structured messages while reconstructing the history. |
| packages/proxy/src/forwarder.js | Prevents empty Responses-to-Chat fallback payloads and retains original input when a safe conversion is available. |
| api/_lib/rate-limit-durable.js | Replaces process-local fallback with fail-closed results while retaining non-cancellable transactional increments. |
| api/_lib/firebase-key-store.js | Propagates ledger failures instead of fabricating usage data, enforcing the intended fail-closed billing behavior. |
| api/_lib/http.js | Applies the request-size ceiling to framework-parsed object bodies. |
| api/billing.js | Reads usage and wallet state from the transactional ledger with legacy fallbacks when the ledger is unavailable. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[POST compression request] --> B[Authenticate API key]
  B --> C[Durable rate-limit transaction]
  C -->|Allowed| D[Compress context]
  C -->|Rejected or unavailable| E[429 or 503]
  D --> F[Atomic usage and wallet transaction]
  F -->|Committed| G[CCR persistence]
  F -->|Quota, credit, or ledger failure| H[402 or 503 without compressed output]
  G -->|Stored| I[Return compressed text and retrieval metadata]
  G -->|Failed| J[Strip retrieval markers]
  J --> K[Return compressed text]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/v1/compress.js`, line 170-178 ([link](https://github.com/supercompress/supercompress/blob/e1971988f45998053e0cb3b23952b0a78b525938/api/v1/compress.js#L170-L178)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Timed-out checks still consume quota**

   When a durable rate-limit transaction exceeds the two-second timeout, `Promise.race` returns a 503 without cancelling the Firestore transaction, so its increment can still commit and client retries can exhaust the hourly quota without receiving compression results.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(billing): hard quota, permanent cred..."](https://github.com/supercompress/supercompress/commit/e1971988f45998053e0cb3b23952b0a78b525938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52036620)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->