### PR TITLE
fix(billing): request idempotency and retry-safe accounting

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -6,8 +6,10 @@
  * read-modify-write claims directly.
  *
  * Firestore:
- *   billing/{uid}              — monthly usage + wallet balance
- *   billing_credits/{creditKey} — permanent Stripe session / PI idempotency
+ *   billing/{uid}                    — monthly usage + wallet balance
+ *   billing_credits/{creditKey}      — permanent Stripe session / PI idempotency
+ *   billing_usage/{uid}:{requestId}  — per-request usage burn idempotency
+ *   billing_bonus/{uid}:first_pay    — one-time first-pay bonus create-once
  */
 const { initFirebaseAdmin } = require("./auth");
 const {
@@ -177,8 +179,9 @@ function planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims = {} }
   if (wallet) {
     const prevBillable = billableTokens(prevTokensIn);
     const newBillable = billableTokens(nextTokensIn);
-    const deltaBillable = Math.max(0, newBillable - prevBillable);
-    burned_micros = tokensToMicros(deltaBillable);
+    // Cumulative ceil so fractional micro-USD amortizes across requests
+    // instead of ceil(delta * price) over-charging every tiny burn.
+    burned_micros = Math.max(0, tokensToMicros(newBillable) - tokensToMicros(prevBillable));
     if (burned_micros > nextBalance) {
       throw billingError(
         "credits_exhausted",
@@ -258,52 +261,140 @@ async function mirrorClaims(uid, ledger) {
 }
 
 /**
+ * Sanitize client/server request ids for Firestore doc ids.
+ * @returns {string|null}
+ */
+function sanitizeRequestId(raw) {
+  const s = String(raw || "").trim();
+  if (!s || s.length < 8 || s.length > 128) return null;
+  if (!/^[\w.:-]+$/.test(s)) return null;
+  return s;
+}
+
+/**
  * Atomically record usage and burn prepaid credit.
+ * Idempotent via billing_usage/{uid}:{requestId} (create-once).
  * Throws paywall / billing_unavailable — never silently under-charges.
  */
-async function applyUsageAndBurn({ uid, tokensIn, tokensOut, tokensSaved, claims = {} }) {
+async function applyUsageAndBurn({
+  uid,
+  tokensIn,
+  tokensOut,
+  tokensSaved,
+  claims = {},
+  requestId,
+}) {
   if (!uid) throw new Error("uid required");
+  const rid = sanitizeRequestId(requestId);
+  if (!rid) {
+    throw billingError("billing_unavailable", "Billing request id required");
+  }
   if (!initFirebaseAdmin()) {
     throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
 
   const ref = db().collection("billing").doc(uid);
+  const usageRef = db().collection("billing_usage").doc(`${uid}:${rid}`);
   const result = await db().runTransaction(async (tx) => {
+    // All reads before writes (Firestore txn rule).
+    const usageSnap = await tx.get(usageRef);
     const snap = await tx.get(ref);
     const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
+
+    if (usageSnap.exists) {
+      const prev = usageSnap.data() || {};
+      return {
+        burned_micros: Number(prev.burned_micros || 0),
+        ledger,
+        already: true,
+        request_id: rid,
+      };
+    }
+
     const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims });
     tx.set(ref, planned.ledger, { merge: true });
-    return planned;
+    tx.set(
+      usageRef,
+      {
+        uid,
+        request_id: rid,
+        tokens_in: Number(tokensIn) || 0,
+        tokens_out: Number(tokensOut) || 0,
+        tokens_saved: Number(tokensSaved) || 0,
+        burned_micros: planned.burned_micros,
+        created_at: new Date().toISOString(),
+      },
+      { merge: false }
+    );
+    return { ...planned, already: false, request_id: rid };
   });
 
-  await mirrorClaims(uid, result.ledger);
+  if (!result.already) {
+    await mirrorClaims(uid, result.ledger);
+  }
   return result;
 }
 
 /**
  * Credit prepaid balance. Idempotent via permanent billing_credits/{creditKey}.
+ * Optional first-pay bonus is create-once via billing_bonus/{uid}:first_pay
+ * (not Auth claims — avoids concurrent Checkout double-bonus races).
+ *
+ * @param {number} [firstPayBonusUsd=0] candidate bonus; txn grants at most once ever
  */
-async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {} }) {
+async function creditBalance({
+  uid,
+  creditUsd,
+  creditKey,
+  claims = {},
+  patch = {},
+  firstPayBonusUsd = 0,
+}) {
   if (!uid || !creditKey) return { applied: false, reason: "missing_args" };
   if (!initFirebaseAdmin()) return { applied: false, reason: "firebase_unavailable" };
 
   const ref = db().collection("billing").doc(uid);
   const creditRef = db().collection("billing_credits").doc(String(creditKey));
+  const bonusRef = db().collection("billing_bonus").doc(`${uid}:first_pay`);
+  const wantBonus = Math.max(0, Number(firstPayBonusUsd) || 0);
+
   const result = await db().runTransaction(async (tx) => {
     const creditSnap = await tx.get(creditRef);
+    const bonusSnap = wantBonus > 0 ? await tx.get(bonusRef) : null;
     const snap = await tx.get(ref);
     const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
 
     if (creditSnap.exists) {
+      const prevCredit = creditSnap.data() || {};
       return {
         applied: true,
         already: true,
         ledger,
         balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+        credit_usd: Number(prevCredit.credit_usd || 0),
+        bonus_usd: Number(prevCredit.bonus_usd || 0),
       };
     }
 
-    const add = usdToMicros(creditUsd);
+    let bonusUsd = 0;
+    if (wantBonus > 0 && bonusSnap && !bonusSnap.exists) {
+      bonusUsd = wantBonus;
+      tx.set(
+        bonusRef,
+        {
+          uid,
+          kind: "first_pay",
+          credit_usd: bonusUsd,
+          credit_key: String(creditKey),
+          created_at: new Date().toISOString(),
+        },
+        { merge: false }
+      );
+    }
+
+    const paymentUsd = Number(creditUsd) || 0;
+    const totalUsd = paymentUsd + bonusUsd;
+    const add = usdToMicros(totalUsd);
     ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
     if (patch.credit_limit_usd != null) {
       ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
@@ -318,7 +409,8 @@ async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {
       creditRef,
       {
         uid,
-        credit_usd: Number(creditUsd) || 0,
+        credit_usd: paymentUsd,
+        bonus_usd: bonusUsd,
         created_at: new Date().toISOString(),
       },
       { merge: false }
@@ -329,6 +421,8 @@ async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {
       already: false,
       ledger,
       balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+      credit_usd: paymentUsd,
+      bonus_usd: bonusUsd,
     };
   });
 
@@ -337,6 +431,13 @@ async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {
     try {
       const fresh = await admin().auth().getUser(uid);
       const prev = { ...(fresh.customClaims || {}) };
+      const bonusPatch =
+        result.bonus_usd > 0
+          ? {
+              sc_first_pay_bonus_at: new Date().toISOString(),
+              sc_first_pay_bonus_usd: result.bonus_usd,
+            }
+          : {};
       await admin().auth().setCustomUserClaims(uid, {
         ...prev,
         sc_plan: prev.sc_plan || "payg",
@@ -353,6 +454,7 @@ async function creditBalance({ uid, creditUsd, creditKey, claims = {}, patch = {
         sc_credit_limit_usd: result.ledger.credit_limit_usd,
         sc_auto_recharge: Boolean(result.ledger.auto_recharge),
         ...(result.ledger.customer_id ? { sc_customer_id: result.ledger.customer_id } : {}),
+        ...bonusPatch,
       });
     } catch (err) {
       console.warn("credit claim mirror failed:", err.message || err);
@@ -420,5 +522,6 @@ module.exports = {
   usdToMicros,
   microsToUsd,
   monthKey,
+  sanitizeRequestId,
   FREE_TOKENS_PER_MONTH,
 };

--- a/api/_lib/billing-ledger.test.js
+++ b/api/_lib/billing-ledger.test.js
@@ -112,6 +112,28 @@ mustThrow(
   assert.strictEqual(r.ledger.tokens_in, FREE_TOKENS_PER_MONTH + billable);
 }
 
+// Cumulative micro-USD: many 1-token burns must not over-charge vs ceil(total)
+{
+  const claims = { sc_plan: "payg", sc_metered: false, sc_credit_balance_usd: 1 };
+  let state = ledger({
+    tokens_in: FREE_TOKENS_PER_MONTH,
+    credit_balance_micros: 1_000_000, // $1
+  });
+  let totalBurned = 0;
+  for (let i = 0; i < 10; i++) {
+    const r = planUsageBurn(state, {
+      tokensIn: 1,
+      tokensOut: 0,
+      tokensSaved: 1,
+      claims,
+    });
+    totalBurned += r.burned_micros;
+    state = r.ledger;
+  }
+  assert.strictEqual(totalBurned, tokensToMicros(10));
+  assert.ok(totalBurned < 10, "must be cheaper than 10× ceil(1-token)");
+}
+
 // Comped skips gates
 {
   const r = planUsageBurn(ledger({ tokens_in: FREE_TOKENS_PER_MONTH * 5 }), {

--- a/api/_lib/credit-topup.js
+++ b/api/_lib/credit-topup.js
@@ -138,18 +138,17 @@ async function applyCreditTopUp(session) {
     console.warn("Could not attach default PM:", err.message || err);
   }
 
-  const grantFirstPayBonus = !prev.sc_first_pay_bonus_at;
-  const bonusUsd = grantFirstPayBonus ? FIRST_PAY_BONUS_USD : 0;
+  const grantFirstPayBonusUsd = FIRST_PAY_BONUS_USD;
   const limitUsd = normalizeCreditLimitUsd(
     session.metadata?.credit_usd || prev.sc_credit_limit_usd,
     creditUsd
   );
 
-  // Ledger first (idempotent by session.id) — Auth claims mirror from ledger.
+  // Ledger first (idempotent by session.id). First-pay bonus is create-once in txn.
   const { creditBalance } = require("./billing-ledger");
   const ledgerResult = await creditBalance({
     uid: userId,
-    creditUsd: creditUsd + bonusUsd,
+    creditUsd,
     creditKey: session.id,
     claims: prev,
     patch: {
@@ -157,7 +156,26 @@ async function applyCreditTopUp(session) {
       auto_recharge: autoRecharge,
       customer_id: session.customer,
     },
+    firstPayBonusUsd: grantFirstPayBonusUsd,
   });
+
+  if (ledgerResult.already) {
+    console.log("Credit top-up already applied (ledger):", session.id);
+    return {
+      applied: true,
+      already: true,
+      balance: roundUsd(
+        ledgerResult.balance != null
+          ? ledgerResult.balance
+          : Number(prev.sc_credit_balance_usd || 0)
+      ),
+      creditUsd: 0,
+      firstPayBonusUsd: 0,
+      firstPayBonusTokens: 0,
+    };
+  }
+
+  const bonusUsd = Number(ledgerResult.bonus_usd || 0);
   const newBalance = roundUsd(
     ledgerResult.balance != null
       ? ledgerResult.balance
@@ -183,7 +201,7 @@ async function applyCreditTopUp(session) {
     auto_recharge: autoRecharge,
     updated_at: new Date().toISOString(),
   };
-  if (grantFirstPayBonus) {
+  if (bonusUsd > 0) {
     persistPayload.sc_first_pay_bonus_at = new Date().toISOString();
     persistPayload.sc_first_pay_bonus_usd = bonusUsd;
   }
@@ -199,7 +217,7 @@ async function applyCreditTopUp(session) {
     balance: newBalance,
     creditUsd,
     firstPayBonusUsd: bonusUsd,
-    firstPayBonusTokens: grantFirstPayBonus ? FIRST_PAY_BONUS_TOKENS : 0,
+    firstPayBonusTokens: bonusUsd > 0 ? FIRST_PAY_BONUS_TOKENS : 0,
   };
 }
 

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -365,97 +365,79 @@ async function authenticateKey(secret) {
   return { user: rec, owner, ownerUid: rec.user_id, keyId: rec.id };
 }
 
-async function recordUsage(keyRec, owner, compressed) {
+async function recordUsage(keyRec, owner, compressed, opts = {}) {
   const keyId = keyRec.id || keyRec.uid;
   const ownerUid = owner?.uid || keyRec.user_id;
   const day = new Date().toISOString().slice(0, 10);
   const tokensSaved = Math.max(0, compressed.original_tokens - compressed.kept_tokens);
   const now = new Date().toISOString();
+  const crypto = require("crypto");
+  const { sanitizeRequestId, applyUsageAndBurn, microsToUsd } = require("./billing-ledger");
+  const {
+    reportPaygUsage,
+    isPaygEnabled,
+    isComped,
+    isLegacyMetered,
+    roundUsd,
+    attemptAutoRecharge,
+  } = require("./stripe");
 
-  // Primary: durable per-key usage doc (does not depend on monolithic config/store).
-  let durableOk = false;
-  try {
-    const { trackKeyUsage } = require("./store");
-    await trackKeyUsage(ownerUid, keyRec, {
-      day,
-      original_tokens: compressed.original_tokens,
-      kept_tokens: compressed.kept_tokens,
-      tokens_saved: tokensSaved,
-    });
-    durableOk = true;
-  } catch (err) {
-    console.warn("recordUsage: durable key_usage skipped:", err.message);
-  }
+  const requestId =
+    sanitizeRequestId(opts.requestId) ||
+    sanitizeRequestId(opts.idempotencyKey) ||
+    crypto.randomUUID();
 
-  // Best-effort: upsert key + last_used. Only bump legacy store.usage if durable write failed.
-  try {
-    await mutateStore((store) => {
-      if (!store.keys[keyId]) {
-        store.keys[keyId] = {
-          id: keyId,
-          user_id: ownerUid,
-          name: keyRec.name || "API key",
-          prefix: keyRec.prefix || "",
-          key_hash: keyRec.key_hash || null,
-          created_at: keyRec.created_at || now,
-          last_used_at: now,
-          revoked: false,
-        };
-        if (keyRec.key_hash) store.hash_index[keyRec.key_hash] = keyId;
-      } else {
-        store.keys[keyId].last_used_at = now;
-      }
-      if (durableOk) return store.keys[keyId];
-      if (!store.usage[keyId]) store.usage[keyId] = {};
-      if (!store.usage[keyId][day]) {
-        store.usage[keyId][day] = {
-          key_id: keyId,
-          requests: 0,
-          tokens_in: 0,
-          tokens_out: 0,
-          tokens_saved: 0,
-        };
-      }
-      const u = store.usage[keyId][day];
-      u.requests += 1;
-      u.tokens_in += compressed.original_tokens;
-      u.tokens_out += compressed.kept_tokens;
-      u.tokens_saved += tokensSaved;
-      return u;
-    });
-  } catch (err) {
-    // Compression already succeeded — don't 503 the client if store is flaky.
-    console.warn("recordUsage: store update skipped:", err.message);
-  }
-
-  // Also stamp Auth stub last_used when present (coding-agent keys).
-  if (String(keyId).startsWith(KEY_UID_PREFIX)) {
-    try {
-      const stub = await auth().getUser(keyId).catch(() => null);
-      if (stub?.customClaims?.sc_api_key) {
-        await auth().setCustomUserClaims(keyId, {
-          ...stub.customClaims,
-          sc_last: now,
-        });
-      }
-    } catch (_) {}
-  }
-
-  // Owner monthly usage + wallet burn — transactional Firestore ledger (not Auth RMW).
   const ownerClaims = owner.customClaims || {};
-  const { applyUsageAndBurn, microsToUsd } = require("./billing-ledger");
-  const { reportPaygUsage, isPaygEnabled, isComped, isLegacyMetered, roundUsd } = require("./stripe");
 
-  // Billing is fail-closed: never invent a fake usage object on ledger failure.
-  const applied = await applyUsageAndBurn({
-    uid: owner.uid,
-    tokensIn: compressed.original_tokens,
-    tokensOut: compressed.kept_tokens,
-    tokensSaved,
-    claims: ownerClaims,
-  });
+  // Authoritative wallet/quota first — never bump analytics before a durable burn.
+  let applied;
+  try {
+    applied = await applyUsageAndBurn({
+      uid: owner.uid,
+      tokensIn: compressed.original_tokens,
+      tokensOut: compressed.kept_tokens,
+      tokensSaved,
+      claims: ownerClaims,
+      requestId,
+    });
+  } catch (err) {
+    // Positive-but-insufficient balance: recharge once, retry same request id.
+    if (err.code === "credits_exhausted") {
+      let autoOn = Boolean(ownerClaims.sc_auto_recharge);
+      if (!autoOn) {
+        try {
+          const { loadLedger } = require("./billing-ledger");
+          const led = await loadLedger(owner.uid, ownerClaims);
+          autoOn = Boolean(led.auto_recharge);
+        } catch (_) {}
+      }
+      if (autoOn) {
+        const recharge = await attemptAutoRecharge(owner);
+        if (recharge.ok) {
+          try {
+            const fresh = await auth().getUser(owner.uid);
+            owner.customClaims = fresh.customClaims || owner.customClaims;
+          } catch (_) {}
+          applied = await applyUsageAndBurn({
+            uid: owner.uid,
+            tokensIn: compressed.original_tokens,
+            tokensOut: compressed.kept_tokens,
+            tokensSaved,
+            claims: owner.customClaims || ownerClaims,
+            requestId,
+          });
+        } else {
+          throw err;
+        }
+      } else {
+        throw err;
+      }
+    } else {
+      throw err;
+    }
+  }
+
   const ledger = applied.ledger;
-
   const ownerUsage = {
     month: ledger.month,
     requests: ledger.requests,
@@ -464,6 +446,75 @@ async function recordUsage(keyRec, owner, compressed) {
     tokens_saved: ledger.tokens_saved,
     tokens_reported: ledger.tokens_reported || 0,
   };
+
+  // Per-key analytics only after successful (or idempotent replay) billing.
+  // Skip on replay so timeout→retry does not inflate dashboard counters twice.
+  if (!applied.already) {
+    let durableOk = false;
+    try {
+      const { trackKeyUsage } = require("./store");
+      await trackKeyUsage(ownerUid, keyRec, {
+        day,
+        original_tokens: compressed.original_tokens,
+        kept_tokens: compressed.kept_tokens,
+        tokens_saved: tokensSaved,
+      });
+      durableOk = true;
+    } catch (err) {
+      console.warn("recordUsage: durable key_usage skipped:", err.message);
+    }
+
+    try {
+      await mutateStore((store) => {
+        if (!store.keys[keyId]) {
+          store.keys[keyId] = {
+            id: keyId,
+            user_id: ownerUid,
+            name: keyRec.name || "API key",
+            prefix: keyRec.prefix || "",
+            key_hash: keyRec.key_hash || null,
+            created_at: keyRec.created_at || now,
+            last_used_at: now,
+            revoked: false,
+          };
+          if (keyRec.key_hash) store.hash_index[keyRec.key_hash] = keyId;
+        } else {
+          store.keys[keyId].last_used_at = now;
+        }
+        if (durableOk) return store.keys[keyId];
+        if (!store.usage[keyId]) store.usage[keyId] = {};
+        if (!store.usage[keyId][day]) {
+          store.usage[keyId][day] = {
+            key_id: keyId,
+            requests: 0,
+            tokens_in: 0,
+            tokens_out: 0,
+            tokens_saved: 0,
+          };
+        }
+        const u = store.usage[keyId][day];
+        u.requests += 1;
+        u.tokens_in += compressed.original_tokens;
+        u.tokens_out += compressed.kept_tokens;
+        u.tokens_saved += tokensSaved;
+        return u;
+      });
+    } catch (err) {
+      console.warn("recordUsage: store update skipped:", err.message);
+    }
+
+    if (String(keyId).startsWith(KEY_UID_PREFIX)) {
+      try {
+        const stub = await auth().getUser(keyId).catch(() => null);
+        if (stub?.customClaims?.sc_api_key) {
+          await auth().setCustomUserClaims(keyId, {
+            ...stub.customClaims,
+            sc_last: now,
+          });
+        }
+      } catch (_) {}
+    }
+  }
 
   // Legacy metered: report to Stripe meters (idempotent watermark on ledger).
   try {
@@ -487,7 +538,6 @@ async function recordUsage(keyRec, owner, compressed) {
     console.warn("PAYG meter skipped:", err.message || err);
   }
 
-  // Refresh in-memory owner claims from ledger mirror (applyUsageAndBurn already wrote Auth).
   try {
     const fresh = await auth().getUser(owner.uid);
     owner.customClaims = fresh.customClaims || {
@@ -506,6 +556,8 @@ async function recordUsage(keyRec, owner, compressed) {
         : {}),
     };
   }
+  ownerUsage.request_id = requestId;
+  ownerUsage.billing_already = Boolean(applied.already);
   return ownerUsage;
 }
 

--- a/api/_lib/http.js
+++ b/api/_lib/http.js
@@ -124,25 +124,15 @@ function readBody(req) {
   return {};
 }
 
-module.exports = {
-  cors,
-  json,
-  jsonWithRateLimit,
-  methodNotAllowed,
-  securityHeaders,
-  rateLimitHeaders,
-  checkRateLimit,
-  clientIp,
-  readBody,
-  MAX_BODY_BYTES,
-};
-
 /* ── Response helpers ── */
 
 function cors(res) {
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,PATCH,DELETE,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization, X-API-Key, Idempotency-Key, X-Request-Id"
+  );
 }
 
 /** Attach security headers to every response. */

--- a/api/_lib/rate-limit-durable.js
+++ b/api/_lib/rate-limit-durable.js
@@ -7,11 +7,13 @@
  *
  * For authenticated paid endpoints, callers should treat backend !== "firestore"
  * as fail-closed (reject) so multi-instance fans-out cannot bypass the ceiling.
+ *
+ * Optional requestId makes increments idempotent: a timed-out txn that still
+ * commits will not burn a second slot when the client retries with the same id.
  */
 const crypto = require("crypto");
 const admin = require("firebase-admin");
 const { initFirebaseAdmin } = require("./auth");
-const { checkRateLimit } = require("./http");
 
 function bucketId(key, windowMs) {
   const bucket = Math.floor(Date.now() / windowMs);
@@ -31,13 +33,21 @@ function db() {
   }
 }
 
+function sanitizeHitId(raw) {
+  const s = String(raw || "").trim();
+  if (!s || s.length < 8 || s.length > 128) return null;
+  if (!/^[\w.:-]+$/.test(s)) return null;
+  return s;
+}
+
 /**
  * @param {string} key
  * @param {number} maxRequests
  * @param {number} [windowMs=60000]
+ * @param {{ requestId?: string }} [opts]
  * @returns {Promise<{ allowed: boolean, remaining: number, resetMs: number, limit: number, backend: string }>}
  */
-async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000) {
+async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000, opts = {}) {
   const resetMs = Math.ceil(Date.now() / windowMs) * windowMs;
   const firestore = db();
   if (!firestore) {
@@ -53,14 +63,25 @@ async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000) {
 
   const id = bucketId(key, windowMs);
   const ref = firestore.collection("rate_limits").doc(id);
+  const hitId = sanitizeHitId(opts.requestId);
+  const hitRef = hitId
+    ? firestore.collection("rate_limit_hits").doc(`${id}:${hitId}`)
+    : null;
   // Never let a stuck Firestore txn burn the whole serverless budget (→ 504).
   const FS_TIMEOUT_MS = 1500;
 
   try {
     const count = await Promise.race([
       firestore.runTransaction(async (tx) => {
+        const hitSnap = hitRef ? await tx.get(hitRef) : null;
         const snap = await tx.get(ref);
         const prev = snap.exists ? Number(snap.data().count || 0) : 0;
+
+        if (hitSnap?.exists) {
+          const stored = Number(hitSnap.data().count || prev);
+          return stored;
+        }
+
         const next = prev + 1;
         tx.set(
           ref,
@@ -73,6 +94,19 @@ async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000) {
           },
           { merge: true }
         );
+        if (hitRef) {
+          tx.set(
+            hitRef,
+            {
+              count: next,
+              key: String(key).slice(0, 120),
+              request_id: hitId,
+              created_at: new Date().toISOString(),
+              expires_at: resetMs,
+            },
+            { merge: false }
+          );
+        }
         return next;
       }),
       new Promise((_, reject) => {
@@ -102,12 +136,15 @@ async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000) {
 
 /**
  * Enforce several windows; first failure wins.
- * @param {Array<{ key: string, max: number, windowMs: number }>} rules
+ * @param {Array<{ key: string, max: number, windowMs: number, requestId?: string }>} rules
+ * @param {{ requestId?: string }} [opts]
  */
-async function enforceRateLimits(rules) {
+async function enforceRateLimits(rules, opts = {}) {
   let last = null;
   for (const rule of rules) {
-    last = await checkDurableRateLimit(rule.key, rule.max, rule.windowMs);
+    last = await checkDurableRateLimit(rule.key, rule.max, rule.windowMs, {
+      requestId: rule.requestId || opts.requestId,
+    });
     if (!last.allowed) return last;
   }
   return last || { allowed: true, remaining: 0, resetMs: Date.now(), limit: 0, backend: "none" };

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -18,6 +18,8 @@ const {
   attemptAutoRecharge,
   roundUsd,
 } = require("../_lib/stripe");
+const crypto = require("crypto");
+const { sanitizeRequestId } = require("../_lib/billing-ledger");
 
 const V1_RPM = 90; // per API key (in-memory fast path)
 const V1_IP_HOURLY = 600; // durable per-IP ceiling (stops stolen-key / fan-out abuse)
@@ -136,6 +138,19 @@ function stripRetrieveMarkers(text) {
     .trim();
 }
 
+function resolveRequestId(req, body) {
+  const header =
+    req.headers["idempotency-key"] ||
+    req.headers["x-idempotency-key"] ||
+    req.headers["x-request-id"];
+  return (
+    sanitizeRequestId(header) ||
+    sanitizeRequestId(body?.idempotency_key) ||
+    sanitizeRequestId(body?.request_id) ||
+    crypto.randomUUID()
+  );
+}
+
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
   // Compression is POST-only — never accept API keys or context in query strings.
@@ -151,12 +166,17 @@ module.exports = async (req, res) => {
   const requestStarted = Date.now();
   // Leave headroom under function maxDuration (60s for this route) for response flush.
   const HARD_BUDGET_MS = 55_000;
+  let requestId = null;
 
   try {
     const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization);
     if (!raw || !raw.startsWith(KEY_PREFIX)) {
       return json(res, 401, { detail: "Missing or invalid API key" });
     }
+
+    // Parse body early so Idempotency-Key can come from JSON when header omitted.
+    const body = readBody(req);
+    requestId = resolveRequestId(req, body);
 
     // ── Rate limit: fast per-key + durable per-IP hourly ceiling ──
     const keyPrefix = raw.slice(0, 24);
@@ -166,12 +186,16 @@ module.exports = async (req, res) => {
       return jsonWithRateLimit(res, 429, {
         detail: `Rate limit exceeded (${V1_RPM} requests/minute per key). Reduce request frequency or contact support.`,
         retry_after_seconds: Math.max(1, Math.ceil((rlMem.resetMs - Date.now()) / 1000)),
+        request_id: requestId,
       }, rlMem);
     }
     let rl;
     try {
       rl = await withTimeout(
-        enforceRateLimits([{ key: `v1ip:h:${ip}`, max: V1_IP_HOURLY, windowMs: 60 * 60_000 }]),
+        enforceRateLimits(
+          [{ key: `v1ip:h:${ip}`, max: V1_IP_HOURLY, windowMs: 60 * 60_000 }],
+          { requestId }
+        ),
         2000,
         "rate_limit"
       );
@@ -179,25 +203,27 @@ module.exports = async (req, res) => {
       return json(res, 503, {
         detail: "Rate limit service unavailable. Retry shortly.",
         code: "rate_limit_unavailable",
-      });
+        request_id: requestId,
+      }, { "Idempotency-Key": requestId });
     }
     if (rl.backend && rl.backend !== "firestore") {
       return json(res, 503, {
         detail: "Rate limit service unavailable. Retry shortly.",
         code: "rate_limit_unavailable",
-      });
+        request_id: requestId,
+      }, { "Idempotency-Key": requestId });
     }
     if (!rl.allowed) {
       return jsonWithRateLimit(res, 429, {
         detail: `IP rate limit exceeded (${V1_IP_HOURLY}/hour). Spread traffic or contact support.`,
         retry_after_seconds: Math.max(1, Math.ceil((rl.resetMs - Date.now()) / 1000)),
+        request_id: requestId,
       }, rl);
     }
     // Prefer showing the tighter remaining of the two windows
     rl.remaining = Math.min(rl.remaining, rlMem.remaining);
     rl.limit = V1_RPM;
 
-    const body = readBody(req);
     const context = body.context || "";
     const query = body.query || "Summarize this context.";
     const mode = body.mode || "compiler";
@@ -210,10 +236,14 @@ module.exports = async (req, res) => {
     const session_id = body.session_id || null;
 
     if (!context.trim()) {
-      return json(res, 422, { detail: "context required" });
+      return json(res, 422, { detail: "context required", request_id: requestId }, {
+        "Idempotency-Key": requestId,
+      });
     }
     if (context.length > 120_000) {
-      return json(res, 422, { detail: "context too long (120k max)" });
+      return json(res, 422, { detail: "context too long (120k max)", request_id: requestId }, {
+        "Idempotency-Key": requestId,
+      });
     }
 
     const authenticated = await withTimeout(authenticateKey(raw), 8000, "authenticate");
@@ -235,7 +265,7 @@ module.exports = async (req, res) => {
     // Billing is fail-closed: never return compressed text without a durable charge/quota write.
     try {
       await withTimeout(
-        recordUsage(authenticated.user, authenticated.owner, result),
+        recordUsage(authenticated.user, authenticated.owner, result, { requestId }),
         Math.max(1500, Math.min(12000, remainingMs() - 2000)),
         "record_usage"
       );
@@ -243,11 +273,12 @@ module.exports = async (req, res) => {
       if (err.paywall || err.status === 402) throw err;
       const e = new Error(
         err.code === "timeout"
-          ? "Billing timed out — compression not delivered. Retry."
-          : "Billing unavailable — compression not delivered. Retry."
+          ? "Billing timed out — compression not delivered. Retry with the same Idempotency-Key."
+          : "Billing unavailable — compression not delivered. Retry with the same Idempotency-Key."
       );
       e.status = err.status || 503;
       e.code = err.code || "billing_unavailable";
+      e.requestId = requestId;
       throw e;
     }
 
@@ -380,6 +411,7 @@ module.exports = async (req, res) => {
       ? wrapCompressedForCache(rawText, query).wrapped
       : rawText;
 
+    res.setHeader("Idempotency-Key", requestId);
     return jsonWithRateLimit(res, 200, {
       compressed_text: finalText,
       original_tokens: result.original_tokens,
@@ -406,6 +438,7 @@ module.exports = async (req, res) => {
       latency_ms: latencyMs,
       coding_agent: coding_agent || null,
       source: inferredSource,
+      request_id: requestId,
     }, rl);
   } catch (err) {
     let status = err.status || 500;
@@ -414,16 +447,19 @@ module.exports = async (req, res) => {
     // inflating Vercel Observability error rate via console.error.
     if (status >= 500) console.error("compress error", err);
     else console.warn("compress client error", status, err.message || err);
+    const idHeaders = requestId ? { "Idempotency-Key": requestId } : undefined;
     if (err.paywall && err.payload) {
       return json(res, status, {
         ...err.payload,
         detail: err.payload.detail || err.message || String(err),
-      });
+        ...(requestId ? { request_id: requestId } : {}),
+      }, idHeaders);
     }
     return json(res, status, {
       detail: err.message || String(err),
       ...(err.code ? { code: err.code } : {}),
       ...(err.paywall ? { paywall: true } : {}),
-    });
+      ...(requestId ? { request_id: requestId } : {}),
+    }, idHeaders);
   }
 };


### PR DESCRIPTION
## Summary
- Request-level usage burn idempotency via `billing_usage/{uid}:{requestId}` (accept `Idempotency-Key` / `request_id`, echo on responses) so billing timeouts + retries cannot double-charge
- Bill before per-key analytics; skip analytics on idempotent replay
- On `credits_exhausted`, auto-recharge once then retry the **same** request id (fixes positive-but-insufficient balance → 402)
- First-pay bonus create-once via `billing_bonus/{uid}:first_pay` inside the credit transaction
- Cumulative micro-USD rounding (`ceil(totalAfter) - ceil(totalBefore)`)
- Honest Checkout replay (`already: true`, `creditUsd: 0`) when `billing_credits` already has the session
- Durable rate-limit hits keyed by request id; remove duplicate `http.js` exports / stale `.gitkeep`

## Test plan
- [ ] `node api/_lib/billing-ledger.test.js` (includes cumulative fractional pricing)
- [ ] Compress with `Idempotency-Key`, kill mid-billing / force timeout, retry same key → single ledger burn
- [ ] Wallet ~$0.001, auto-recharge ON, cost > balance → recharge then succeed (not bare 402)
- [ ] Two concurrent first Checkouts → only one first-pay bonus
- [ ] Reconcile already-credited old session → `already: true`, `credited_usd: 0`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds request-level billing and rate-limit idempotency, retry-safe auto-recharge accounting, transactional first-payment bonuses, and cumulative micro-USD rounding. The new client-controlled replay identifier is not bound to request content, allowing distinct requests to bypass both billing and the durable IP ceiling.
- Adds Firestore usage, bonus, credit, and durable rate-limit hit records.
- Reorders compression accounting so billing precedes per-key analytics and retries reuse one request identifier.
- Makes Checkout reconciliation report zero newly credited funds for an existing credit record.
- Adjusts fractional token pricing to charge from cumulative rounded totals.

<h3>Confidence Score: 1/5</h3>

This PR is not safe to merge until idempotency replays are bound to the original logical request, because recycled identifiers currently bypass both usage billing and the durable IP limit.

Distinct compression payloads can execute under an existing client-selected identifier; billing then skips the new burn and the durable limiter skips the new hit while still allowing the response to be delivered.

**Files Needing Attention:** api/_lib/billing-ledger.js, api/_lib/rate-limit-durable.js, api/v1/compress.js, api/_lib/firebase-key-store.js

<details open><summary><h3>Security Review</h3></summary>

Two security-boundary defects were identified. Reusing one client-selected request identifier for different payloads suppresses wallet/quota accounting, and the same behavior suppresses increments of the durable per-IP hourly rate limit. In both paths, the identifier must be bound to the logical request or the original operation's result must be replayed rather than executing new work.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/_lib/billing-ledger.js | Adds transactional usage and bonus idempotency plus cumulative rounding, but accepts any existing request ID as a billing replay without validating the operation. |
| api/_lib/firebase-key-store.js | Moves billing ahead of analytics and retries after auto-recharge, while propagating the unbound request ID and suppressing accounting on replay. |
| api/_lib/rate-limit-durable.js | Adds durable request-hit idempotency, but recycled client IDs prevent distinct requests from incrementing the hourly counter. |
| api/v1/compress.js | Resolves and echoes request identifiers consistently, but permits client-selected IDs to govern billing and rate-limit replay for newly executed payloads. |
| api/_lib/credit-topup.js | Moves first-payment bonus allocation into the ledger transaction and returns honest zero-credit values for replayed Checkout sessions. |
| api/_lib/billing-ledger.test.js | Adds coverage for cumulative fractional micro-USD rounding, though it does not exercise the newly introduced replay paths. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant API as Compress API
    participant RL as Durable rate limiter
    participant B as Billing ledger
    C->>API: Request A + Idempotency-Key K
    API->>RL: Count K
    RL-->>API: Increment bucket
    API->>B: Burn usage under K
    B-->>API: New burn
    API-->>C: Result A
    C->>API: Different Request B + same K
    API->>RL: Count K
    RL-->>API: Existing hit, no increment
    API->>B: Burn usage under K
    B-->>API: "already=true, no burn"
    API-->>C: Result B without new accounting
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): request idempotency and re..."](https://github.com/supercompress/supercompress/commit/3778ca7decef95157a0268a1db6aefe5e6e56d70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52078241)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->