### PR TITLE
fix(proxy): preserve tool-call order and rank on active user ask

### DIFF
--- a/packages/proxy/src/compressor.js
+++ b/packages/proxy/src/compressor.js
@@ -11,6 +11,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const crypto = require("crypto");
 
 const SUPERCOMPRESS_API =
   process.env.SUPERCOMPRESS_API_URL || "https://www.supercompress.dev/api/v1/compress";
@@ -167,7 +168,7 @@ function splitCompressiblePrefix(messages) {
     return { systemMsgs, compressible: [], preserved: rest, query: "" };
   }
   const compressible = [];
-  const preserved = rest.slice(-KEEP_TAIL);
+  const preservedHead = [];
   const head = rest.slice(0, -KEEP_TAIL);
   for (const msg of head) {
     const structured =
@@ -178,14 +179,17 @@ function splitCompressiblePrefix(messages) {
       msg.tool_call_id ||
       Array.isArray(msg.content);
     if (structured) {
-      // Keep structured tool turns verbatim in the preserved prefix area.
-      preserved.unshift(msg);
+      // Keep structured tool turns verbatim, in original order (never unshift).
+      preservedHead.push(msg);
     } else {
       compressible.push(msg);
     }
   }
+  const preserved = [...preservedHead, ...rest.slice(-KEEP_TAIL)];
+  // Rank against the active user ask from the full history (usually in the tail),
+  // not an older user turn that happened to land in the compressible prefix.
   let query = "Continue the conversation.";
-  const lastUser = [...compressible].reverse().find((m) => m.role === "user");
+  const lastUser = [...rest].reverse().find((m) => m.role === "user");
   if (lastUser) query = messageText(lastUser.content) || query;
   return { systemMsgs, compressible, preserved, query };
 }
@@ -210,12 +214,14 @@ async function compress(messages, agentName) {
     const agent = agentName || detectAgentName();
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), COMPRESS_TIMEOUT_MS);
+    const idempotencyKey = crypto.randomUUID();
     try {
       const response = await fetch(SUPERCOMPRESS_API, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "X-API-Key": apiKey,
+          "Idempotency-Key": idempotencyKey,
         },
         body: JSON.stringify({
           context,
@@ -223,6 +229,7 @@ async function compress(messages, agentName) {
           mode: "compiler",
           coding_agent: agent,
           source: "agent",
+          request_id: idempotencyKey,
         }),
         signal: controller.signal,
       });
@@ -279,6 +286,7 @@ async function compress(messages, agentName) {
   const agent = agentName || detectAgentName();
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), COMPRESS_TIMEOUT_MS);
+  const idempotencyKey = crypto.randomUUID();
 
   let response;
   try {
@@ -287,12 +295,14 @@ async function compress(messages, agentName) {
       headers: {
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
+        "Idempotency-Key": idempotencyKey,
       },
       body: JSON.stringify({
         context,
         query,
         mode: "compiler",
         coding_agent: agent,
+        request_id: idempotencyKey,
       }),
       signal: controller.signal,
     });
@@ -384,4 +394,5 @@ module.exports = {
   getApiKey,
   hasStructuredProtocol,
   messageText,
+  splitCompressiblePrefix,
 };

--- a/packages/proxy/test/protocol-safety.js
+++ b/packages/proxy/test/protocol-safety.js
@@ -75,6 +75,39 @@ async function main() {
     assert.deepEqual(out.messages, messages);
   });
 
+  await test("splitCompressiblePrefix keeps tool-call order and uses full-history query", () => {
+    const filler = (n) => ({ role: "user", content: `old ask ${n} ` + "z".repeat(40) });
+    const messages = [
+      filler(1),
+      filler(2),
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "A", type: "function", function: { name: "a", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "A", content: "result A" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{ id: "B", type: "function", function: { name: "b", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "B", content: "result B" },
+      filler(3),
+      filler(4),
+      filler(5),
+      filler(6),
+      { role: "user", content: "current coding task" },
+      { role: "assistant", content: "working" },
+    ];
+    const split = compressor.splitCompressiblePrefix(messages);
+    const ids = split.preserved
+      .map((m) => m.tool_call_id || m.tool_calls?.[0]?.id)
+      .filter(Boolean);
+    assert.deepEqual(ids, ["A", "A", "B", "B"]);
+    assert.equal(split.query, "current coding task");
+    assert.ok(split.compressible.some((m) => String(m.content).includes("old ask")));
+  });
+
   await test("responsesInputHasStructuredItems detects function_call", () => {
     assert.equal(
       forwarder.responsesInputHasStructuredItems([


### PR DESCRIPTION
## Summary
- Fix `splitCompressiblePrefix()` reversing tool-call/result order via `unshift` (breaks provider tool protocol)
- Select relevance query from the **full** history (active user ask in the preserved tail), not an old compressible prefix user turn
- Send `Idempotency-Key` on compress API calls for safer retries once billing idempotency lands

## Test plan
- [ ] `node packages/proxy/test/protocol-safety.js` (new split/order/query assertion)
- [ ] Tool-heavy coding-agent thread: preserved structured messages stay A→result A→B→result B
- [ ] Compression query matches the latest user message, not an older one in the compressible head

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unique request identifiers to compression requests to support safe retries and duplicate prevention.
  * Improved structured conversation handling by preserving protocol messages in their original order.
  * Queries now reflect the latest user message across the conversation history.

* **Bug Fixes**
  * Fixed handling of paired tool-call and tool-result messages during compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects structured tool-message ordering, derives relevance from the active user request, and attaches a shared request UUID to compression calls.
- Replaces reverse-building via `unshift` with order-preserving collection.
- Selects the latest user query from the complete non-system history.
- Sends the UUID through both `Idempotency-Key` and `request_id`.
- Adds focused protocol-order and query-selection coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The ordering change preserves tool-call/result chronology, the query now tracks the latest user request, and the added request identifiers are supported by the declared runtime.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/compressor.js | Preserves structured head ordering, ranks compression against the latest user ask, and adds per-request UUID metadata without an identified regression. |
| packages/proxy/test/protocol-safety.js | Adds a focused assertion covering multiple ordered tool-call/result pairs and query selection from the preserved tail. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Full message history] --> B[Separate system messages]
    B --> C[Split non-system history]
    C --> D[Compressible plain-text head]
    C --> E[Structured head in original order]
    C --> F[Untouched trailing window]
    C --> G[Latest user ask]
    D --> H[Compression API]
    G --> H
    H --> I[Compressed digest]
    I --> J[Reassembled messages]
    E --> J
    F --> J
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(proxy): preserve tool-call order and..."](https://github.com/supercompress/supercompress/commit/4f4164d28db1822b82fd0dab739151f8e62dbb64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52078245)</sub>

<!-- /greptile_comment -->