### PR TITLE
feat(proxy): OpenClaw auto-compress parity with Hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Public page: https://www.supercompress.dev/changelog
 - Cumulative micro-USD rounding (`ceil(totalAfter) − ceil(totalBefore)`); idempotent durable rate-limit hits
 
 ### Coding agent plugin
+- **OpenClaw auto-compress parity with Hermes**: `supercompress setup` / `plugin` wires MCP (absolute node+mcp), `AGENTS.md`, managed skill, internal hooks (`agent:bootstrap` + `session:compact:before`), and an extension plugin that compresses large tool dumps into the inbox
 - Protocol/runtime safety: native `fetch` (drop `node-fetch`), owned-PID-only stop, buffered SSE that preserves `tool_calls`, skip compression for structured tool/Responses items, inject digests as user (not system), fail-open on compress timeout/5xx, block browser `Origin` on local proxy, zstd size caps, spawn via `process.execPath`
 - Non-destructive setup: only clear SuperCompress-owned base URLs; backup before plugin writers; fix instruction-block idempotency; don’t markSeen on compress timeout/error; don’t split long asks without paragraph breaks; secure inbox/session modes; fail connect instead of rotating production API keys; atomic device-link consume via Firestore
 - **Preserve tool-call / tool-result order** when splitting compressible history (no reverse via `unshift`)

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -4,6 +4,7 @@ Versions track `supercompress-proxy` on npm. Full product notes: [CHANGELOG.md](
 
 ## [Unreleased]
 
+- **OpenClaw auto-compress parity with Hermes**: setup/plugin installs MCP + `AGENTS.md` + managed skill + internal hooks + extension plugin (tool dumps → inbox); uninstall cleans them.
 - **Preserve tool-call / tool-result order** when splitting compressible history (no reverse via `unshift`).
 - Rank structured-history compression against the **latest user ask in the full thread**, not an older compressible-prefix turn.
 - Send `Idempotency-Key` on compress API calls for safer retries with request-level billing idempotency.

--- a/packages/proxy/bin/supercompress.js
+++ b/packages/proxy/bin/supercompress.js
@@ -149,6 +149,10 @@ async function main() {
         console.log(`  ✓ Hermes auto-compress: ${result.hermes.installed.join(", ")}`);
         console.log("    → pre_llm_call + post_tool_call hooks + transform plugin + native compact");
       }
+      if (result.openclaw?.installed?.length) {
+        console.log(`  ✓ OpenClaw auto-compress: ${result.openclaw.installed.join(", ")}`);
+        console.log("    → MCP + skill + managed hooks + extension plugin (tool dump → inbox)");
+      }
       if (result.cleared.length) {
         console.log(`  ✓ Cleared provider API-key proxy overrides: ${result.cleared.join(", ")}`);
       }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -13,7 +13,9 @@
     "llm-cost",
     "context-compression",
     "opencode",
-    "aider"
+    "aider",
+    "hermes",
+    "openclaw"
   ],
   "homepage": "https://docs.supercompress.dev/coding-agents",
   "repository": {

--- a/packages/proxy/src/agent-plugins.js
+++ b/packages/proxy/src/agent-plugins.js
@@ -1,8 +1,8 @@
 /**
  * Pluggable coding-agent MCP adapters.
  *
- * Built-ins: Hermes (~/.hermes/config.yaml mcp_servers),
- *            OpenClaw (~/.openclaw/openclaw.json mcp.servers),
+ * Built-ins: Hermes (~/.hermes/config.yaml mcp_servers + auto-compress),
+ *            OpenClaw (~/.openclaw/openclaw.json mcp.servers + auto-compress),
  *            plus Cursor-style mcp-json / OpenCode / Codex formats for custom agents.
  *
  * Custom plugins: ~/.supercompress/agent-plugins.json
@@ -24,7 +24,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { execFileSync } = require("child_process");
+const { execFileSync, spawnSync } = require("child_process");
 
 const HOME = os.homedir();
 const CONFIG_DIR = process.env.SUPERCOMPRESS_CONFIG_DIR || path.join(HOME, ".supercompress");
@@ -214,7 +214,8 @@ function writeOpenClawJson(filePath) {
   }
   data.mcp = data.mcp && typeof data.mcp === "object" ? data.mcp : {};
   data.mcp.servers = data.mcp.servers && typeof data.mcp.servers === "object" ? data.mcp.servers : {};
-  const entry = mcpStdioEntry();
+  // Always absolute node+mcp — OpenClaw gateway PATH often lacks npm bins
+  const entry = mcpStdioEntry({ preferAbsolute: true });
   data.mcp.servers.supercompress = {
     command: entry.command,
     args: entry.args,
@@ -644,6 +645,227 @@ hooks:
   return { configPath, hooksDest, pluginDest, instructionPath, installed };
 }
 
+function copyTree(src, dest) {
+  if (!src || !fs.existsSync(src)) return false;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const ent of fs.readdirSync(src, { withFileTypes: true })) {
+    const from = path.join(src, ent.name);
+    const to = path.join(dest, ent.name);
+    if (ent.isDirectory()) copyTree(from, to);
+    else fs.copyFileSync(from, to);
+  }
+  return true;
+}
+
+function enableOpenClawAutoConfig(configPath, { pluginDest } = {}) {
+  let data = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      data = parseLooseJson(fs.readFileSync(configPath, "utf8"));
+    } catch (err) {
+      throw new Error(`OpenClaw config is not valid JSON/JSON5 (${configPath}): ${err.message}`);
+    }
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error(`OpenClaw config must be a JSON object (${configPath})`);
+  }
+
+  data.hooks = data.hooks && typeof data.hooks === "object" ? data.hooks : {};
+  data.hooks.internal =
+    data.hooks.internal && typeof data.hooks.internal === "object" ? data.hooks.internal : {};
+  data.hooks.internal.enabled = true;
+  data.hooks.internal.entries =
+    data.hooks.internal.entries && typeof data.hooks.internal.entries === "object"
+      ? data.hooks.internal.entries
+      : {};
+  data.hooks.internal.entries["supercompress-bootstrap"] = {
+    ...(data.hooks.internal.entries["supercompress-bootstrap"] || {}),
+    enabled: true,
+  };
+  data.hooks.internal.entries["supercompress-compact"] = {
+    ...(data.hooks.internal.entries["supercompress-compact"] || {}),
+    enabled: true,
+  };
+
+  data.plugins = data.plugins && typeof data.plugins === "object" ? data.plugins : {};
+  data.plugins.entries =
+    data.plugins.entries && typeof data.plugins.entries === "object" ? data.plugins.entries : {};
+  data.plugins.entries.supercompress = {
+    ...(data.plugins.entries.supercompress || {}),
+    enabled: true,
+    hooks: {
+      ...((data.plugins.entries.supercompress && data.plugins.entries.supercompress.hooks) || {}),
+      allowConversationAccess: true,
+      timeoutMs: 25000,
+    },
+  };
+
+  data.plugins.load =
+    data.plugins.load && typeof data.plugins.load === "object" ? data.plugins.load : {};
+  const loadPaths = Array.isArray(data.plugins.load.paths) ? [...data.plugins.load.paths] : [];
+  if (pluginDest) {
+    const already = loadPaths.some(
+      (p) => String(p).includes("extensions/supercompress") || String(p) === pluginDest
+    );
+    if (!already) loadPaths.push(pluginDest);
+  }
+  data.plugins.load.paths = loadPaths;
+
+  if (Array.isArray(data.plugins.allow) && !data.plugins.allow.includes("supercompress")) {
+    data.plugins.allow.push("supercompress");
+  }
+
+  fs.writeFileSync(configPath, JSON.stringify(data, null, 2) + "\n");
+}
+
+/**
+ * Wire OpenClaw: MCP + AGENTS.md + managed skill + internal hooks + extension plugin.
+ * Parity with Hermes auto-compress (OpenClaw uses plugins/hooks instead of shell yaml hooks).
+ */
+function writeOpenClawAutoCompress(openclawHome = path.join(HOME, ".openclaw")) {
+  const installed = [];
+  fs.mkdirSync(openclawHome, { recursive: true });
+
+  const configPath = path.join(openclawHome, "openclaw.json");
+  writeOpenClawJson(configPath);
+  installed.push("mcp");
+
+  const instructionPath = path.join(openclawHome, "AGENTS.md");
+  writeInstructionFile(instructionPath);
+  installed.push("AGENTS.md");
+
+  const assetsRoot = path.join(__dirname, "openclaw-hooks");
+  const libSrc = path.join(__dirname, "cursor-hooks", "compress-prompt-lib.js");
+
+  const skillDest = path.join(openclawHome, "skills", "supercompress");
+  if (copyTree(path.join(assetsRoot, "skills", "supercompress"), skillDest)) {
+    installed.push("skill");
+  }
+
+  const hooksRoot = path.join(openclawHome, "hooks");
+  for (const name of ["supercompress-bootstrap", "supercompress-compact"]) {
+    const dest = path.join(hooksRoot, name);
+    if (copyTree(path.join(assetsRoot, "hooks", name), dest)) {
+      if (fs.existsSync(libSrc)) {
+        fs.copyFileSync(libSrc, path.join(dest, "compress-prompt-lib.js"));
+      }
+    }
+  }
+  installed.push("hooks");
+
+  const pluginDest = path.join(openclawHome, "extensions", "supercompress");
+  if (copyTree(path.join(assetsRoot, "plugin"), pluginDest)) {
+    if (fs.existsSync(libSrc)) {
+      fs.copyFileSync(libSrc, path.join(pluginDest, "compress-prompt-lib.js"));
+    }
+    installed.push("plugin");
+  }
+
+  enableOpenClawAutoConfig(configPath, { pluginDest });
+  installed.push("hooks+plugins config");
+
+  // Best-effort CLI enable when openclaw/claw is on PATH
+  for (const bin of ["openclaw", "claw"]) {
+    if (!commandExists(bin)) continue;
+    try {
+      for (const hook of ["supercompress-bootstrap", "supercompress-compact"]) {
+        spawnSync(bin, ["hooks", "enable", hook], {
+          encoding: "utf8",
+          timeout: 15000,
+          env: process.env,
+        });
+      }
+      spawnSync(bin, ["plugins", "enable", "supercompress"], {
+        encoding: "utf8",
+        timeout: 15000,
+        env: process.env,
+      });
+      installed.push(`cli:${bin}`);
+    } catch {
+      /* ignore — config already enables hooks/plugin */
+    }
+    break;
+  }
+
+  return { configPath, skillDest, hooksRoot, pluginDest, instructionPath, installed };
+}
+
+/** Drop OpenClaw skill / hooks / plugin + config entries written by writeOpenClawAutoCompress. */
+function removeOpenClawAutoCompressArtifacts(openclawHome = path.join(HOME, ".openclaw")) {
+  const removed = [];
+  if (!fs.existsSync(openclawHome)) return removed;
+
+  for (const rel of [
+    ["skills", "supercompress"],
+    ["hooks", "supercompress-bootstrap"],
+    ["hooks", "supercompress-compact"],
+    ["extensions", "supercompress"],
+  ]) {
+    const dest = path.join(openclawHome, ...rel);
+    if (!fs.existsSync(dest)) continue;
+    try {
+      fs.rmSync(dest, { recursive: true, force: true });
+      removed.push(`OpenClaw ${rel.join("/")}`);
+    } catch (err) {
+      console.error(`  ✗ Failed to remove ${dest}: ${err.message}`);
+    }
+  }
+
+  const configPath = path.join(openclawHome, "openclaw.json");
+  if (fs.existsSync(configPath)) {
+    try {
+      let data = parseLooseJson(fs.readFileSync(configPath, "utf8"));
+      let changed = false;
+
+      if (data?.hooks?.internal?.entries?.["supercompress-bootstrap"]) {
+        delete data.hooks.internal.entries["supercompress-bootstrap"];
+        changed = true;
+      }
+      if (data?.hooks?.internal?.entries?.["supercompress-compact"]) {
+        delete data.hooks.internal.entries["supercompress-compact"];
+        changed = true;
+      }
+      if (data?.plugins?.entries?.supercompress) {
+        delete data.plugins.entries.supercompress;
+        changed = true;
+      }
+      if (Array.isArray(data?.plugins?.load?.paths)) {
+        const next = data.plugins.load.paths.filter(
+          (p) => !String(p).includes("extensions/supercompress")
+        );
+        if (next.length !== data.plugins.load.paths.length) {
+          data.plugins.load.paths = next;
+          changed = true;
+        }
+      }
+      if (Array.isArray(data?.plugins?.allow)) {
+        const nextAllow = data.plugins.allow.filter((id) => id !== "supercompress");
+        if (nextAllow.length !== data.plugins.allow.length) {
+          data.plugins.allow = nextAllow;
+          changed = true;
+        }
+      }
+      if (data?.mcp?.servers?.supercompress) {
+        delete data.mcp.servers.supercompress;
+        if (data.mcp.servers && Object.keys(data.mcp.servers).length === 0) {
+          delete data.mcp.servers;
+        }
+        if (data.mcp && Object.keys(data.mcp).length === 0) delete data.mcp;
+        changed = true;
+      }
+
+      if (changed) {
+        fs.writeFileSync(configPath, JSON.stringify(data, null, 2) + "\n");
+        removed.push("OpenClaw auto config");
+      }
+    } catch (err) {
+      console.error(`  ✗ Failed to clean OpenClaw config: ${err.message}`);
+    }
+  }
+
+  return removed;
+}
+
 function pluginDetected(plugin) {
   // Explicitly registered custom plugins always count as present
   if (plugin.alwaysInstall || (!plugin.builtin && plugin.id)) {
@@ -892,7 +1114,10 @@ module.exports = {
   writeHermesYaml,
   removeHermesYaml,
   writeHermesAutoCompress,
+  writeOpenClawAutoCompress,
+  removeOpenClawAutoCompressArtifacts,
   writeOpenClawJson,
+  removeOpenClawJson,
   writeMcpJson,
   writeInstructionFile,
   instructionBody,

--- a/packages/proxy/src/detector.js
+++ b/packages/proxy/src/detector.js
@@ -1190,6 +1190,8 @@ function removePluginArtifacts(skip = new Set()) {
 
   // Hermes auto-compress copies hooks/plugins outside the instruction file.
   removed.push(...removeHermesAutoCompressArtifacts());
+  // OpenClaw auto-compress copies skill/hooks/plugin outside the instruction file.
+  removed.push(...removeOpenClawAutoCompressArtifacts());
 
   return removed;
 }
@@ -1244,6 +1246,14 @@ function removeHermesAutoCompressArtifacts() {
   }
 
   return removed;
+}
+
+/** Drop OpenClaw skill / hooks / plugin written by writeOpenClawAutoCompress. */
+function removeOpenClawAutoCompressArtifacts() {
+  if (typeof agentPlugins.removeOpenClawAutoCompressArtifacts === "function") {
+    return agentPlugins.removeOpenClawAutoCompressArtifacts();
+  }
+  return [];
 }
 
 /**
@@ -1650,6 +1660,21 @@ function installAutoPlugin() {
       console.error(`  ⚠ Hermes auto-compress: ${err.message}`);
     }
   }
+  let openclaw = null;
+  if (
+    commandExists("openclaw") ||
+    commandExists("claw") ||
+    fs.existsSync(path.join(HOME, ".openclaw"))
+  ) {
+    try {
+      const openclawHome = path.join(HOME, ".openclaw");
+      backupFile(path.join(openclawHome, "AGENTS.md"));
+      backupFile(path.join(openclawHome, "openclaw.json"));
+      openclaw = agentPlugins.writeOpenClawAutoCompress(openclawHome);
+    } catch (err) {
+      console.error(`  ⚠ OpenClaw auto-compress: ${err.message}`);
+    }
+  }
   const cleared = clearProxyOverrides();
   return {
     found,
@@ -1659,6 +1684,7 @@ function installAutoPlugin() {
     agentHooks,
     instructions,
     hermes,
+    openclaw,
     cleared,
   };
 }

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/HOOK.md
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/HOOK.md
@@ -1,0 +1,25 @@
+---
+name: supercompress-bootstrap
+description: "Inject SuperCompress inbox digest into agent bootstrap context when present."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🗜️",
+        "events": ["agent:bootstrap"],
+        "always": true,
+      },
+  }
+---
+
+# SuperCompress bootstrap
+
+On `agent:bootstrap`, if `~/.supercompress/inbox/latest.md` exists, inject it as a bootstrap file named `SUPERCOMPRESS.md` so the agent prefers the session digest over re-pasting raw dumps.
+
+Enable with:
+
+```bash
+openclaw hooks enable supercompress-bootstrap
+```
+
+Or run `supercompress setup` / `supercompress plugin`, which writes this hook and enables it in `openclaw.json`.

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/handler.js
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/handler.js
@@ -1,0 +1,54 @@
+/**
+ * OpenClaw internal hook — inject SuperCompress inbox into bootstrap files.
+ * Fail-open. ESM (OpenClaw hook loader).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const INBOX = path.join(os.homedir(), ".supercompress", "inbox", "latest.md");
+const BOOTSTRAP_NAME = "SUPERCOMPRESS.md";
+
+function normalizeEntry(entry) {
+  if (!entry) return null;
+  if (typeof entry === "string") return { name: path.basename(entry), path: entry };
+  if (typeof entry === "object") return entry;
+  return null;
+}
+
+const handler = async (event) => {
+  try {
+    if (event?.type !== "agent" || event?.action !== "bootstrap") return;
+    if (!fs.existsSync(INBOX)) return;
+    const files = event.context?.bootstrapFiles;
+    if (!Array.isArray(files)) return;
+
+    const already = files.some((raw) => {
+      const e = normalizeEntry(raw);
+      if (!e) return false;
+      const name = String(e.name || e.path || "");
+      return name === BOOTSTRAP_NAME || /supercompress/i.test(name);
+    });
+    if (already) return;
+
+    let content = "";
+    try {
+      content = fs.readFileSync(INBOX, "utf8");
+    } catch {
+      return;
+    }
+    if (!content.trim()) return;
+
+    files.push({
+      name: BOOTSTRAP_NAME,
+      path: INBOX,
+      content,
+    });
+  } catch (err) {
+    console.warn(
+      `[supercompress-bootstrap] ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+};
+
+export default handler;

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/HOOK.md
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/HOOK.md
@@ -1,0 +1,26 @@
+---
+name: supercompress-compact
+description: "Before OpenClaw session compaction, nudge to prefer SuperCompress digests and refresh inbox when possible."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🗜️",
+        "events": ["session:compact:before"],
+        "always": true,
+        "requires": { "bins": ["node"] },
+      },
+  }
+---
+
+# SuperCompress compact
+
+On `session:compact:before`, remind the chat to prefer SuperCompress digests and fire-and-forget a background compact of rolling session memory (via shared compress-prompt-lib).
+
+Enable with:
+
+```bash
+openclaw hooks enable supercompress-compact
+```
+
+Or run `supercompress setup` / `supercompress plugin`.

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/handler.js
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/handler.js
@@ -1,0 +1,67 @@
+/**
+ * OpenClaw internal hook — session compact:before.
+ * Nudges the chat + fire-and-forget session memory compact.
+ * Fail-open. ESM.
+ */
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+function loadLib() {
+  const candidates = [
+    path.join(__dirname, "compress-prompt-lib.js"),
+    path.join(__dirname, "..", "..", "extensions", "supercompress", "compress-prompt-lib.js"),
+    // Dev / package-relative fallback when hooks live next to cursor-hooks
+    path.join(__dirname, "..", "..", "..", "cursor-hooks", "compress-prompt-lib.js"),
+  ];
+  for (const p of candidates) {
+    try {
+      return require(p);
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+const handler = async (event) => {
+  try {
+    if (event?.type !== "session" || event?.action !== "compact:before") return;
+
+    if (Array.isArray(event.messages)) {
+      event.messages.push(
+        "🗜️ SuperCompress: prefer ~/.supercompress/inbox/latest.md digests over raw dumps while context is compacted."
+      );
+    }
+
+    const lib = loadLib();
+    if (!lib?.compressIncremental) return;
+
+    const sessionId = String(
+      event.context?.sessionId ||
+        event.sessionKey ||
+        event.context?.sessionKey ||
+        "openclaw"
+    ).replace(/[^\w.-]+/g, "_").slice(0, 80);
+
+    // Fire-and-forget — do not block compaction.
+    void lib
+      .compressIncremental({
+        context: "",
+        query: "Compact OpenClaw session memory before native compaction.",
+        codingAgent: "OpenClaw",
+        sessionId,
+        kind: "openclaw:compact",
+      })
+      .catch(() => {});
+  } catch (err) {
+    console.warn(
+      `[supercompress-compact] ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+};
+
+export default handler;

--- a/packages/proxy/src/openclaw-hooks/plugin/index.js
+++ b/packages/proxy/src/openclaw-hooks/plugin/index.js
@@ -1,0 +1,185 @@
+/**
+ * SuperCompress OpenClaw plugin — Headroom-parity auto-compress.
+ *
+ * - after_tool_call: compress large tool results into session inbox (async)
+ * - before_prompt_build: prepend inbox digest so the model prefers digests
+ *
+ * Uses a local definePluginEntry stub (same pattern as community plugins) so
+ * we do not need openclaw as a hard dependency at install time.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const MIN_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MIN_CHARS || 400);
+const MAX_IN = Number(process.env.SUPERCOMPRESS_HOOK_MAX_CHARS || 180000);
+const INBOX_MD = path.join(os.homedir(), ".supercompress", "inbox", "latest.md");
+
+function definePluginEntry(options) {
+  return options;
+}
+
+function loadLib() {
+  try {
+    return require(path.join(__dirname, "compress-prompt-lib.js"));
+  } catch {
+    try {
+      return require(path.join(__dirname, "..", "..", "cursor-hooks", "compress-prompt-lib.js"));
+    } catch {
+      return null;
+    }
+  }
+}
+
+function extractText(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((part) => {
+        if (typeof part === "string") return part;
+        if (part && typeof part === "object") {
+          if (typeof part.text === "string") return part.text;
+          if (typeof part.content === "string") return part.content;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (typeof value === "object") {
+    if (typeof value.text === "string") return value.text;
+    if (typeof value.content === "string") return value.content;
+    if (value.content != null) return extractText(value.content);
+    if (value.result != null) return extractText(value.result);
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function resolveSessionId(event = {}, ctx = {}) {
+  const raw =
+    event.sessionId ||
+    ctx.sessionId ||
+    event.sessionKey ||
+    ctx.sessionKey ||
+    process.env.SUPERCOMPRESS_SESSION_ID ||
+    "openclaw";
+  return String(raw).replace(/[^\w.-]+/g, "_").slice(0, 80);
+}
+
+function readInboxDigest() {
+  try {
+    if (!fs.existsSync(INBOX_MD)) return "";
+    const body = fs.readFileSync(INBOX_MD, "utf8").trim();
+    return body.length > 40 ? body : "";
+  } catch {
+    return "";
+  }
+}
+
+export default definePluginEntry({
+  id: "supercompress",
+  name: "SuperCompress",
+  description:
+    "Compress bulky OpenClaw tool dumps into session digests; never compress the user ask.",
+  register(api) {
+    const logger = api?.logger || console;
+    logger.info?.("[supercompress] plugin activated");
+
+    const safeOn = (event, handler, opts) => {
+      try {
+        api.on(
+          event,
+          async (...args) => {
+            try {
+              return await handler(...args);
+            } catch (err) {
+              logger.warn?.(
+                `[supercompress] ${event} error: ${err instanceof Error ? err.message : String(err)}`
+              );
+            }
+          },
+          opts
+        );
+      } catch (err) {
+        logger.warn?.(
+          `[supercompress] failed to register ${event}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    };
+
+    safeOn(
+      "after_tool_call",
+      async (event, ctx) => {
+        const toolName = String(event?.toolName || ctx?.toolName || "");
+        if (/compress_context|connect_account|usage_summary|headroom_/i.test(toolName)) {
+          return;
+        }
+        if (event?.error) return;
+
+        let text = extractText(event?.result);
+        if (text.length < MIN_CHARS) return;
+        const clipped = text.length > MAX_IN ? text.slice(0, MAX_IN) : text;
+
+        const lib = loadLib();
+        if (!lib?.compressIncremental || !lib?.writeInbox) return;
+
+        const sessionId = resolveSessionId(event, ctx);
+        const query =
+          `Compress new ${toolName || "tool"} output for the current OpenClaw task. ` +
+          "Preserve code, paths, errors, numbers, and decisions.";
+
+        const result = await lib.compressIncremental({
+          context: clipped,
+          query,
+          codingAgent: "OpenClaw",
+          sessionId,
+          kind: `openclaw:tool:${toolName || "unknown"}`,
+        });
+
+        if (!result?.compressed) return;
+        if (result.skipped === "no_key" || String(result.skipped || "").startsWith("http_")) {
+          return;
+        }
+        if (result.skipped === "already_seen" && !result.delta) return;
+
+        const meta = `${result.original_tokens}→${result.compressed_tokens} (−${result.savings_pct}%)`;
+        lib.writeInbox(query, result.compressed, meta, {
+          kind: "openclaw-post-tool",
+          session_id: sessionId,
+          tool: toolName,
+          compacted: Boolean(result.compacted),
+        });
+      },
+      { priority: 40, timeoutMs: 25000 }
+    );
+
+    safeOn(
+      "before_prompt_build",
+      async () => {
+        const digest = readInboxDigest();
+        if (!digest) return;
+        return {
+          prependContext: [
+            "[SuperCompress] Prefer this session digest over raw tool dumps:",
+            "",
+            digest,
+          ].join("\n"),
+        };
+      },
+      { priority: 40, timeoutMs: 5000 }
+    );
+  },
+});

--- a/packages/proxy/src/openclaw-hooks/plugin/openclaw.plugin.json
+++ b/packages/proxy/src/openclaw-hooks/plugin/openclaw.plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "supercompress",
+  "name": "SuperCompress",
+  "description": "Headroom-parity auto-compress for OpenClaw — compress bulky tool dumps into session digests; never compress the user ask.",
+  "version": "1.0.0",
+  "skills": ["../skills/supercompress"],
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false
+  }
+}

--- a/packages/proxy/src/openclaw-hooks/plugin/package.json
+++ b/packages/proxy/src/openclaw-hooks/plugin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "supercompress-openclaw",
+  "version": "1.0.0",
+  "description": "SuperCompress auto-compress plugin for OpenClaw",
+  "type": "module",
+  "main": "index.js",
+  "openclaw": {
+    "extensions": ["./index.js"],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2"
+    }
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/proxy/src/openclaw-hooks/skills/supercompress/SKILL.md
+++ b/packages/proxy/src/openclaw-hooks/skills/supercompress/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: supercompress
+description: "Always-on context compression for OpenClaw. Compress bulky tool dumps / files / logs via MCP compress_context; never compress the user's ask. Prefer ~/.supercompress/inbox/latest.md digests."
+---
+
+# SuperCompress (OpenClaw)
+
+**Auto (Headroom-parity):** compress every *new* bulky context dump; when rolling session memory gets large, compact it. Never compress the user's ask/query. Skip already-seen chunks.
+
+## When to use
+
+After large tool results, file reads, diffs, logs, scrapes, or pasted blobs — anything that is **not** the current user question.
+
+## How
+
+1. If `~/.supercompress/inbox/latest.md` exists, **Read it first** — session digest (ask is unchanged).
+2. Else call MCP `compress_context` with `context`=<new dump only> and `query`=<user ask>. Prefer the returned digest over raw dumps.
+3. The SuperCompress OpenClaw plugin also auto-compresses large tool results into the inbox when installed.
+4. If `compress_context` fails with account-not-linked, call `connect_account` once, then retry.
+
+## Do not
+
+- Compress the user's question / instructions.
+- Re-paste raw tool dumps after a digest exists.
+- Require provider API-key proxy mode — normal login is fine.

--- a/packages/proxy/test/agent-plugins.js
+++ b/packages/proxy/test/agent-plugins.js
@@ -34,6 +34,43 @@ if (!/model: gpt/.test(hy)) throw new Error("hermes wiped unrelated keys");
 const oj = JSON.parse(fs.readFileSync(openclaw, "utf8"));
 if (!oj.mcp.servers.supercompress.command) throw new Error("openclaw missing server");
 
+// OpenClaw auto-compress parity (skill + hooks + plugin + config enable)
+const ocHome = path.join(${JSON.stringify(tmp)}, ".openclaw");
+const ocAuto = ap.writeOpenClawAutoCompress(ocHome);
+if (!ocAuto.installed.includes("mcp")) throw new Error("openclaw auto missing mcp");
+if (!ocAuto.installed.includes("skill")) throw new Error("openclaw auto missing skill");
+if (!ocAuto.installed.includes("hooks")) throw new Error("openclaw auto missing hooks");
+if (!ocAuto.installed.includes("plugin")) throw new Error("openclaw auto missing plugin");
+if (!fs.existsSync(path.join(ocHome, "skills", "supercompress", "SKILL.md"))) {
+  throw new Error("openclaw skill not written");
+}
+if (!fs.existsSync(path.join(ocHome, "hooks", "supercompress-bootstrap", "handler.js"))) {
+  throw new Error("openclaw bootstrap hook missing");
+}
+if (!fs.existsSync(path.join(ocHome, "extensions", "supercompress", "index.js"))) {
+  throw new Error("openclaw plugin missing");
+}
+const ocCfg = JSON.parse(fs.readFileSync(path.join(ocHome, "openclaw.json"), "utf8"));
+if (!ocCfg.hooks?.internal?.enabled) throw new Error("openclaw hooks not enabled");
+if (!ocCfg.hooks?.internal?.entries?.["supercompress-bootstrap"]?.enabled) {
+  throw new Error("openclaw bootstrap hook not enabled in config");
+}
+if (!ocCfg.plugins?.entries?.supercompress?.enabled) throw new Error("openclaw plugin not enabled");
+if (!ocCfg.mcp?.servers?.supercompress?.env?.SUPERCOMPRESS_CONFIG_DIR) {
+  throw new Error("openclaw mcp env missing CONFIG_DIR");
+}
+const agentsOc = fs.readFileSync(path.join(ocHome, "AGENTS.md"), "utf8");
+if (!/compress_context/.test(agentsOc)) throw new Error("openclaw AGENTS.md missing instructions");
+
+const ocRemoved = ap.removeOpenClawAutoCompressArtifacts(ocHome);
+if (!ocRemoved.length) throw new Error("openclaw uninstall removed nothing");
+if (fs.existsSync(path.join(ocHome, "skills", "supercompress"))) {
+  throw new Error("openclaw skill still present after uninstall");
+}
+const ocAfter = JSON.parse(fs.readFileSync(path.join(ocHome, "openclaw.json"), "utf8"));
+if (ocAfter.mcp?.servers?.supercompress) throw new Error("openclaw mcp still present after uninstall");
+if (ocAfter.plugins?.entries?.supercompress) throw new Error("openclaw plugin entry still present");
+
 // Custom plugin: no --config → defaults, always installs, writes AGENTS.md
 const { plugin } = ap.addCustomPlugin({
   id: "demo",

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -236,6 +236,7 @@
           </ul>
           <h3>Coding agent plugin</h3>
           <ul>
+            <li><strong>OpenClaw auto-compress</strong> parity with Hermes: setup/plugin installs MCP + <code>AGENTS.md</code> + managed skill + internal hooks + extension plugin (large tool dumps → inbox).</li>
             <li><strong>Preserve tool-call order</strong> when splitting compressible history; rank compression against the latest user ask in the full thread.</li>
             <li>Proxy sends <code>Idempotency-Key</code> on compress API calls.</li>
             <li>See <a href="#v0.5.17">0.5.17</a> / <a href="#v0.5.16">0.5.16</a> for the latest published npm fixes.</li>


### PR DESCRIPTION
## Summary
- OpenClaw now gets Hermes-style auto-compress on `supercompress setup` / `plugin`: MCP (absolute node+mcp + real CONFIG_DIR), `AGENTS.md`, managed skill, internal hooks (`agent:bootstrap` + `session:compact:before`), and an extension plugin that compresses large tool dumps into the inbox
- Uninstall cleans OpenClaw skill/hooks/plugin/config entries the same way Hermes artifacts are removed
- Tests cover install + uninstall; changelog Unreleased updated

## Test plan
- [x] `node packages/proxy/test/agent-plugins.js`
- [x] Live `writeOpenClawAutoCompress(~/.openclaw)` — MCP CONFIG_DIR points at `~/.supercompress`, hooks/plugin enabled
- [ ] Restart OpenClaw gateway and confirm skill/hooks/plugin load (`openclaw hooks list` / `openclaw plugins list` when CLI available)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Hermes-style automatic compression support for OpenClaw during setup and plugin installation, with corresponding uninstall cleanup.
- Installs and enables OpenClaw MCP configuration, instructions, a managed skill, internal lifecycle hooks, and an extension plugin.
- Compresses large tool results into an inbox digest and injects that digest during prompt construction.
- Extends detection, CLI reporting, tests, package metadata, and changelogs for the new integration.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until OpenClaw digest injection is session-scoped and uninstall cleanup preserves unrelated plugin paths.

The new prompt hook can disclose stale tool context across OpenClaw sessions through a shared inbox, while the cleanup path can silently remove user configuration that merely contains the managed extension path as a substring.

**Files Needing Attention:** packages/proxy/src/openclaw-hooks/plugin/index.js and packages/proxy/src/agent-plugins.js

<details open><summary><h3>Security Review</h3></summary>

The shared OpenClaw inbox is injected without session validation, allowing a digest produced from one session's tool output to enter another session's prompt. **How this was verified:** The writer and reader both use the same fixed `~/.supercompress/inbox/latest.md` path, while the prompt hook does not inspect the recorded session ID.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/agent-plugins.js | Adds OpenClaw installation, configuration, and cleanup; uninstall can remove unrelated plugin load paths because ownership is matched by substring. |
| packages/proxy/src/openclaw-hooks/plugin/index.js | Adds automatic tool-result compression and prompt injection, but the global inbox permits cross-session context disclosure. |
| packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/handler.js | Adds bootstrap injection from the shared inbox, inheriting the integration's user-wide digest semantics. |
| packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/handler.js | Adds a fail-open pre-compaction hook and asynchronous session-memory compression. |
| packages/proxy/src/detector.js | Integrates OpenClaw installation and cleanup into existing setup and removal flows. |
| packages/proxy/test/agent-plugins.js | Covers artifact installation and basic cleanup but does not exercise session isolation or preservation of similar unrelated load paths. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant SA as OpenClaw Session A
  participant Plugin as SuperCompress Plugin
  participant Inbox as Shared latest.md
  participant SB as OpenClaw Session B
  SA->>Plugin: after_tool_call(result, session A)
  Plugin->>Inbox: Write compressed digest
  SB->>Plugin: before_prompt_build()
  Plugin->>Inbox: Read latest digest
  Inbox-->>Plugin: Session A digest
  Plugin-->>SB: prependContext with Session A digest
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(proxy): OpenClaw auto-compress pari..."](https://github.com/supercompress/supercompress/commit/cd0ab18755e9850fe0dd4380d8b8d75161eeb58d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52083151)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->