### PR TITLE
fix: fingerprint-bound idempotency + OpenClaw session inbox isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,15 @@ Public page: https://www.supercompress.dev/changelog
 - Auto-recharge once when balance is positive but insufficient, then retry the same request id
 - First-pay bonus create-once via `billing_bonus/{uid}:first_pay`; honest Checkout replay (`already: true`, `creditUsd: 0`)
 - Cumulative micro-USD rounding (`ceil(totalAfter) − ceil(totalBefore)`); idempotent durable rate-limit hits
+- **Bind Idempotency-Key to a server SHA-256 payload fingerprint** — reused key with a different compress body returns `409 idempotency_conflict` (not free recompress)
+- Durable hourly rate-limit hits use the **payload fingerprint**, not the client-chosen request id (stops limit evasion)
 
 ### Coding agent plugin
 - **OpenClaw auto-compress parity with Hermes**: `supercompress setup` / `plugin` wires MCP (absolute node+mcp), `AGENTS.md`, managed skill, internal hooks (`agent:bootstrap` + `session:compact:before`), and an extension plugin that compresses large tool dumps into the inbox
+- **Session-scoped OpenClaw inbox** (`inbox/<sessionId>/latest.md`) so sessions/projects cannot cross-contaminate digests; honor `SUPERCOMPRESS_CONFIG_DIR`
+- OpenClaw plugin path install/uninstall uses **exact absolute path** equality (no substring deletes of `extensions/supercompress-*`)
+- Real `compactSessionMemory()` for OpenClaw `compact:before` (no empty-context no-op)
+- Chunk tool dumps into ≤120k API blocks; hooks send stable `Idempotency-Key` = hash(session + content + mode)
 - Protocol/runtime safety: native `fetch` (drop `node-fetch`), owned-PID-only stop, buffered SSE that preserves `tool_calls`, skip compression for structured tool/Responses items, inject digests as user (not system), fail-open on compress timeout/5xx, block browser `Origin` on local proxy, zstd size caps, spawn via `process.execPath`
 - Non-destructive setup: only clear SuperCompress-owned base URLs; backup before plugin writers; fix instruction-block idempotency; don’t markSeen on compress timeout/error; don’t split long asks without paragraph breaks; secure inbox/session modes; fail connect instead of rotating production API keys; atomic device-link consume via Firestore
 - **Preserve tool-call / tool-result order** when splitting compressible history (no reverse via `unshift`)

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -61,10 +61,69 @@ function tokensToMicros(tokenCount) {
 function billingError(code, message, extra = {}) {
   const err = new Error(message);
   err.code = code;
-  err.status = code === "billing_unavailable" ? 503 : 402;
-  err.paywall = code !== "billing_unavailable";
+  if (Number.isFinite(Number(extra.status))) {
+    err.status = Number(extra.status);
+  } else if (code === "billing_unavailable") {
+    err.status = 503;
+  } else if (code === "idempotency_conflict") {
+    err.status = 409;
+  } else {
+    err.status = 402;
+  }
+  err.paywall = code !== "billing_unavailable" && code !== "idempotency_conflict";
   Object.assign(err, extra);
   return err;
+}
+
+/**
+ * SHA-256 fingerprint of billing-relevant compress request fields.
+ * Used to bind Idempotency-Key / request_id to a specific payload.
+ */
+function computeCompressFingerprint(body = {}) {
+  const crypto = require("crypto");
+  const mode = String(body.mode || "compiler");
+  const normalized = JSON.stringify({
+    context: String(body.context || ""),
+    query: String(body.query || "Summarize this context."),
+    mode,
+    budget_ratio: mode === "fixed" ? Number(body.budget_ratio ?? 0.35) : 0.35,
+    ccr: body.ccr === true || body.ccr === "true",
+    cache_prefix: body.cache_prefix === true || body.cache_prefix === "true",
+  });
+  return crypto.createHash("sha256").update(normalized).digest("hex");
+}
+
+/**
+ * Decide whether an existing billing_usage row is a safe replay.
+ * Throws idempotency_conflict (409) when the key is reused with a different payload.
+ */
+function assertUsageIdempotencyMatch(prev, { fingerprint, tokensIn, tokensOut, tokensSaved }) {
+  if (!prev || typeof prev !== "object") return;
+  const prevFp = String(prev.fingerprint || "").trim();
+  const fp = String(fingerprint || "").trim();
+  if (fp) {
+    if (prevFp && prevFp !== fp) {
+      throw billingError(
+        "idempotency_conflict",
+        "Idempotency-Key reused with a different request payload",
+        { status: 409 }
+      );
+    }
+    if (!prevFp) {
+      // Legacy rows (pre-fingerprint): require identical billing token tuple.
+      const same =
+        Number(prev.tokens_in || 0) === Number(tokensIn || 0) &&
+        Number(prev.tokens_out || 0) === Number(tokensOut || 0) &&
+        Number(prev.tokens_saved || 0) === Number(tokensSaved || 0);
+      if (!same) {
+        throw billingError(
+          "idempotency_conflict",
+          "Idempotency-Key reused with a different request payload",
+          { status: 409 }
+        );
+      }
+    }
+  }
 }
 
 function emptyLedger(claims = {}) {
@@ -273,7 +332,9 @@ function sanitizeRequestId(raw) {
 
 /**
  * Atomically record usage and burn prepaid credit.
- * Idempotent via billing_usage/{uid}:{requestId} (create-once).
+ * Idempotent via billing_usage/{uid}:{requestId} (create-once), bound to a
+ * server-calculated request fingerprint so key reuse with a different payload
+ * returns idempotency_conflict (409) instead of already:true.
  * Throws paywall / billing_unavailable — never silently under-charges.
  */
 async function applyUsageAndBurn({
@@ -283,12 +344,14 @@ async function applyUsageAndBurn({
   tokensSaved,
   claims = {},
   requestId,
+  fingerprint,
 }) {
   if (!uid) throw new Error("uid required");
   const rid = sanitizeRequestId(requestId);
   if (!rid) {
     throw billingError("billing_unavailable", "Billing request id required");
   }
+  const fp = String(fingerprint || "").trim() || null;
   if (!initFirebaseAdmin()) {
     throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
@@ -303,11 +366,18 @@ async function applyUsageAndBurn({
 
     if (usageSnap.exists) {
       const prev = usageSnap.data() || {};
+      assertUsageIdempotencyMatch(prev, {
+        fingerprint: fp,
+        tokensIn,
+        tokensOut,
+        tokensSaved,
+      });
       return {
         burned_micros: Number(prev.burned_micros || 0),
         ledger,
         already: true,
         request_id: rid,
+        fingerprint: prev.fingerprint || fp || null,
       };
     }
 
@@ -318,6 +388,7 @@ async function applyUsageAndBurn({
       {
         uid,
         request_id: rid,
+        fingerprint: fp,
         tokens_in: Number(tokensIn) || 0,
         tokens_out: Number(tokensOut) || 0,
         tokens_saved: Number(tokensSaved) || 0,
@@ -326,7 +397,7 @@ async function applyUsageAndBurn({
       },
       { merge: false }
     );
-    return { ...planned, already: false, request_id: rid };
+    return { ...planned, already: false, request_id: rid, fingerprint: fp };
   });
 
   if (!result.already) {
@@ -523,5 +594,7 @@ module.exports = {
   microsToUsd,
   monthKey,
   sanitizeRequestId,
+  computeCompressFingerprint,
+  assertUsageIdempotencyMatch,
   FREE_TOKENS_PER_MONTH,
 };

--- a/api/_lib/billing-ledger.test.js
+++ b/api/_lib/billing-ledger.test.js
@@ -3,7 +3,13 @@
  * Run: node api/_lib/billing-ledger.test.js
  */
 const assert = require("assert");
-const { planUsageBurn, FREE_TOKENS_PER_MONTH, tokensToMicros } = require("./billing-ledger");
+const {
+  planUsageBurn,
+  FREE_TOKENS_PER_MONTH,
+  tokensToMicros,
+  computeCompressFingerprint,
+  assertUsageIdempotencyMatch,
+} = require("./billing-ledger");
 
 function ledger(partial = {}) {
   return {
@@ -145,5 +151,59 @@ mustThrow(
   assert.strictEqual(r.burned_micros, 0);
   assert.ok(r.ledger.tokens_in > FREE_TOKENS_PER_MONTH);
 }
+
+// Fingerprint: same payload → same hash; different context → different hash
+{
+  const a = computeCompressFingerprint({
+    context: "hello world catalog noise",
+    query: "hello",
+    mode: "compiler",
+  });
+  const b = computeCompressFingerprint({
+    context: "hello world catalog noise",
+    query: "hello",
+    mode: "compiler",
+  });
+  const c = computeCompressFingerprint({
+    context: "completely different dump",
+    query: "hello",
+    mode: "compiler",
+  });
+  assert.strictEqual(a, b);
+  assert.notStrictEqual(a, c);
+  assert.strictEqual(a.length, 64);
+}
+
+// Idempotency: same fingerprint replays OK
+assertUsageIdempotencyMatch(
+  { fingerprint: "abc", tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
+  { fingerprint: "abc", tokensIn: 99, tokensOut: 1, tokensSaved: 98 }
+);
+
+// Idempotency: different fingerprint → conflict
+mustThrow(
+  () =>
+    assertUsageIdempotencyMatch(
+      { fingerprint: "aaa", tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
+      { fingerprint: "bbb", tokensIn: 10, tokensOut: 5, tokensSaved: 5 }
+    ),
+  "idempotency_conflict"
+);
+
+// Legacy (no fingerprint): token mismatch → conflict
+mustThrow(
+  () =>
+    assertUsageIdempotencyMatch(
+      { tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
+      { fingerprint: "newfp", tokensIn: 11, tokensOut: 5, tokensSaved: 6 }
+    ),
+  "idempotency_conflict"
+);
+
+// Legacy (no fingerprint): matching tokens OK
+assertUsageIdempotencyMatch(
+  { tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
+  { fingerprint: "newfp", tokensIn: 10, tokensOut: 5, tokensSaved: 5 }
+);
 
 console.log("billing-ledger.test.js: ok");

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -386,6 +386,7 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
     sanitizeRequestId(opts.requestId) ||
     sanitizeRequestId(opts.idempotencyKey) ||
     crypto.randomUUID();
+  const fingerprint = String(opts.fingerprint || "").trim() || null;
 
   const ownerClaims = owner.customClaims || {};
 
@@ -399,6 +400,7 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
       tokensSaved,
       claims: ownerClaims,
       requestId,
+      fingerprint,
     });
   } catch (err) {
     // Positive-but-insufficient balance: recharge once, retry same request id.
@@ -425,6 +427,7 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
             tokensSaved,
             claims: owner.customClaims || ownerClaims,
             requestId,
+            fingerprint,
           });
         } else {
           throw err;

--- a/api/_lib/rate-limit-durable.js
+++ b/api/_lib/rate-limit-durable.js
@@ -8,8 +8,10 @@
  * For authenticated paid endpoints, callers should treat backend !== "firestore"
  * as fail-closed (reject) so multi-instance fans-out cannot bypass the ceiling.
  *
- * Optional requestId makes increments idempotent: a timed-out txn that still
- * commits will not burn a second slot when the client retries with the same id.
+ * Optional requestId makes increments idempotent for *true* retries. Callers
+ * MUST pass a server-calculated operation fingerprint (e.g. SHA-256 of the
+ * billing-relevant payload) — never a client-supplied Idempotency-Key alone,
+ * or distinct requests can share one hit and evade the durable ceiling.
  */
 const crypto = require("crypto");
 const admin = require("firebase-admin");

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -19,7 +19,10 @@ const {
   roundUsd,
 } = require("../_lib/stripe");
 const crypto = require("crypto");
-const { sanitizeRequestId } = require("../_lib/billing-ledger");
+const {
+  sanitizeRequestId,
+  computeCompressFingerprint,
+} = require("../_lib/billing-ledger");
 
 const V1_RPM = 90; // per API key (in-memory fast path)
 const V1_IP_HOURLY = 600; // durable per-IP ceiling (stops stolen-key / fan-out abuse)
@@ -177,6 +180,9 @@ module.exports = async (req, res) => {
     // Parse body early so Idempotency-Key can come from JSON when header omitted.
     const body = readBody(req);
     requestId = resolveRequestId(req, body);
+    // Bind durable rate-limit + billing idempotency to a server-side payload
+    // fingerprint — never to a client-chosen key alone (abuse / free compress).
+    const fingerprint = computeCompressFingerprint(body);
 
     // ── Rate limit: fast per-key + durable per-IP hourly ceiling ──
     const keyPrefix = raw.slice(0, 24);
@@ -194,7 +200,8 @@ module.exports = async (req, res) => {
       rl = await withTimeout(
         enforceRateLimits(
           [{ key: `v1ip:h:${ip}`, max: V1_IP_HOURLY, windowMs: 60 * 60_000 }],
-          { requestId }
+          // Hit id = payload fingerprint (same retry OK; different body always counts).
+          { requestId: fingerprint }
         ),
         2000,
         "rate_limit"
@@ -265,7 +272,10 @@ module.exports = async (req, res) => {
     // Billing is fail-closed: never return compressed text without a durable charge/quota write.
     try {
       await withTimeout(
-        recordUsage(authenticated.user, authenticated.owner, result, { requestId }),
+        recordUsage(authenticated.user, authenticated.owner, result, {
+          requestId,
+          fingerprint,
+        }),
         Math.max(1500, Math.min(12000, remainingMs() - 2000)),
         "record_usage"
       );

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -5,6 +5,9 @@ Versions track `supercompress-proxy` on npm. Full product notes: [CHANGELOG.md](
 ## [Unreleased]
 
 - **OpenClaw auto-compress parity with Hermes**: setup/plugin installs MCP + `AGENTS.md` + managed skill + internal hooks + extension plugin (tool dumps → inbox); uninstall cleans them.
+- **Session-scoped inbox** (`inbox/<sessionId>/`) + `SUPERCOMPRESS_CONFIG_DIR` for OpenClaw plugin/hooks (no global `latest.md` cross-session leak).
+- Exact OpenClaw plugin path match on install/uninstall (no substring deletes).
+- `compactSessionMemory()` for OpenClaw compact:before; chunk dumps ≤120k; stable hook `Idempotency-Key`.
 - **Preserve tool-call / tool-result order** when splitting compressible history (no reverse via `unshift`).
 - Rank structured-history compression against the **latest user ask in the full thread**, not an older compressible-prefix turn.
 - Send `Idempotency-Key` on compress API calls for safer retries with request-level billing idempotency.

--- a/packages/proxy/src/agent-plugins.js
+++ b/packages/proxy/src/agent-plugins.js
@@ -475,7 +475,7 @@ function allPlugins() {
 }
 
 function instructionBody() {
-  const inboxPath = path.join(HOME, ".supercompress", "inbox", "latest.md");
+  const inboxHint = path.join(CONFIG_DIR, "inbox", "<sessionId>", "latest.md");
   return [
     INSTRUCTION_MARKER,
     "",
@@ -483,7 +483,7 @@ function instructionBody() {
     "",
     "What to compress: tool dumps, file reads, logs, diffs, pasted blobs, scrapes, long history — anything that is not the current user question.",
     "",
-    "1. If `" + inboxPath + "` exists, Read it first — session digest (ask is unchanged).",
+    "1. If `" + inboxHint + "` exists for this session, Read it first — session digest (ask is unchanged).",
     "2. Else call MCP `compress_context` with `context`=<new dump only> and `query`=<user ask>. Prefer the returned digest.",
     "3. Hooks also auto-compress on submit + after large tool results when installed.",
     "4. If compress_context fails with account-not-linked, call `connect_account` once, then retry.",
@@ -657,6 +657,20 @@ function copyTree(src, dest) {
   return true;
 }
 
+/** Exact absolute-path compare for OpenClaw plugin load.paths (no substring matches). */
+function normalizeAbsPath(p) {
+  try {
+    return path.resolve(String(p || ""));
+  } catch {
+    return String(p || "");
+  }
+}
+
+function sameAbsPath(a, b) {
+  if (!a || !b) return false;
+  return normalizeAbsPath(a) === normalizeAbsPath(b);
+}
+
 function enableOpenClawAutoConfig(configPath, { pluginDest } = {}) {
   let data = {};
   if (fs.existsSync(configPath)) {
@@ -704,9 +718,7 @@ function enableOpenClawAutoConfig(configPath, { pluginDest } = {}) {
     data.plugins.load && typeof data.plugins.load === "object" ? data.plugins.load : {};
   const loadPaths = Array.isArray(data.plugins.load.paths) ? [...data.plugins.load.paths] : [];
   if (pluginDest) {
-    const already = loadPaths.some(
-      (p) => String(p).includes("extensions/supercompress") || String(p) === pluginDest
-    );
+    const already = loadPaths.some((p) => sameAbsPath(p, pluginDest));
     if (!already) loadPaths.push(pluginDest);
   }
   data.plugins.load.paths = loadPaths;
@@ -830,9 +842,8 @@ function removeOpenClawAutoCompressArtifacts(openclawHome = path.join(HOME, ".op
         changed = true;
       }
       if (Array.isArray(data?.plugins?.load?.paths)) {
-        const next = data.plugins.load.paths.filter(
-          (p) => !String(p).includes("extensions/supercompress")
-        );
+        const pluginDest = path.join(openclawHome, "extensions", "supercompress");
+        const next = data.plugins.load.paths.filter((p) => !sameAbsPath(p, pluginDest));
         if (next.length !== data.plugins.load.paths.length) {
           data.plugins.load.paths = next;
           changed = true;
@@ -1125,6 +1136,8 @@ module.exports = {
   parseLooseJson,
   mcpStdioEntry,
   resolveWrapSpec,
+  sameAbsPath,
+  normalizeAbsPath,
   PLUGINS_FILE,
   PLUGINS_DIR,
   instructionTargetsFromPlugins,

--- a/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
+++ b/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
@@ -5,6 +5,7 @@
  *   - only compress *new* chunks (seen hashes skipped)
  *   - append into rolling session memory
  *   - when memory gets big, compact it back down
+ * Inbox is session-scoped: inbox/<sessionId>/latest.{md,json}
  */
 const fs = require("fs");
 const os = require("os");
@@ -23,6 +24,8 @@ const SESSIONS_DIR = path.join(CONFIG_DIR, "sessions");
 const COMPACT_CHARS = Number(process.env.SUPERCOMPRESS_COMPACT_CHARS || 24000);
 /** Keep at most this many seen block hashes per session (LRU-ish trim). */
 const MAX_SEEN = Number(process.env.SUPERCOMPRESS_MAX_SEEN || 500);
+/** Hosted API hard cap — chunk above this rather than 422. */
+const API_MAX_CHARS = Number(process.env.SUPERCOMPRESS_API_MAX_CHARS || 120000);
 
 function loadApiKey() {
   const envKey = String(process.env.SUPERCOMPRESS_API_KEY || "").trim();
@@ -60,17 +63,39 @@ function splitAskAndContext(text) {
   return { ask: raw.trim(), context: "" };
 }
 
+function safeSessionSegment(sessionId) {
+  const raw = String(sessionId || "").trim();
+  if (!raw) return null;
+  return raw.replace(/[^\w.-]+/g, "_").slice(0, 80) || null;
+}
+
+/** Session-scoped inbox directory (required for writes that carry a session id). */
+function inboxDirForSession(sessionId) {
+  const safe = safeSessionSegment(sessionId);
+  if (!safe) return INBOX_DIR;
+  return path.join(INBOX_DIR, safe);
+}
+
+function inboxPaths(sessionId) {
+  const dir = inboxDirForSession(sessionId);
+  return {
+    dir,
+    latestMd: path.join(dir, "latest.md"),
+    latestJson: path.join(dir, "latest.json"),
+  };
+}
+
 function writeInbox(query, compressed, meta, extra = {}) {
-  fs.mkdirSync(INBOX_DIR, { recursive: true, mode: 0o700 });
-  const latestMd = path.join(INBOX_DIR, "latest.md");
-  const latestJson = path.join(INBOX_DIR, "latest.json");
+  const sessionId = extra.session_id || extra.sessionId || null;
+  const { dir, latestMd, latestJson } = inboxPaths(sessionId);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const body = [
     "# SuperCompress context digest",
     "",
     `Saved: ${new Date().toISOString()}`,
     meta ? `Stats: ${meta}` : "",
     extra.kind ? `Kind: ${extra.kind}` : "",
-    extra.session_id ? `Session: ${extra.session_id}` : "",
+    sessionId ? `Session: ${sessionId}` : "",
     "",
     "## User ask (never compressed)",
     "",
@@ -91,6 +116,7 @@ function writeInbox(query, compressed, meta, extra = {}) {
         compressed,
         meta,
         ...extra,
+        session_id: sessionId || extra.session_id || null,
       },
       null,
       2
@@ -100,8 +126,39 @@ function writeInbox(query, compressed, meta, extra = {}) {
   return latestMd;
 }
 
+function readInboxDigest(sessionId) {
+  const safe = safeSessionSegment(sessionId);
+  if (!safe) return "";
+  try {
+    const p = path.join(INBOX_DIR, safe, "latest.md");
+    if (!fs.existsSync(p)) return "";
+    const body = fs.readFileSync(p, "utf8").trim();
+    return body.length > 40 ? body : "";
+  } catch {
+    return "";
+  }
+}
+
 function hashText(text) {
   return crypto.createHash("sha256").update(String(text || "")).digest("hex").slice(0, 16);
+}
+
+function fullHash(text) {
+  return crypto.createHash("sha256").update(String(text || "")).digest("hex");
+}
+
+/** Stable Idempotency-Key so hook timeouts can safely retry without double-billing. */
+function stableIdempotencyKey({ sessionId, context, mode }) {
+  const h = crypto
+    .createHash("sha256")
+    .update(String(sessionId || ""))
+    .update("\0")
+    .update(fullHash(context))
+    .update("\0")
+    .update(String(mode || "compiler"))
+    .digest("hex")
+    .slice(0, 40);
+  return `sc_${h}`;
 }
 
 function resolveSessionId(input = {}) {
@@ -218,18 +275,25 @@ function extractNewBlocks(context, seen = {}) {
   return blocks.filter((b) => b.length >= 40 && !seen[hashText(b)]);
 }
 
-/** Compress context against a query. Query is never sent as compressible context. */
-async function compressContext(context, query, codingAgent, opts = {}) {
-  const ctx = String(context || "").trim();
-  const q = String(query || "").trim() || "Compress this context for the coding task.";
-  if (!ctx) return { compressed: "", skipped: "empty" };
-  if (ctx.length < 40) {
-    return { compressed: ctx, skipped: "too_small", original_tokens: Math.ceil(ctx.length / 4) };
+function chunkText(text, maxChars = API_MAX_CHARS) {
+  const raw = String(text || "");
+  if (raw.length <= maxChars) return [raw];
+  const chunks = [];
+  for (let i = 0; i < raw.length; i += maxChars) {
+    chunks.push(raw.slice(i, i + maxChars));
   }
-  const apiKey = loadApiKey();
-  if (!apiKey) return { compressed: ctx, skipped: "no_key" };
+  return chunks;
+}
 
-  const clipped = ctx.length > 160000 ? ctx.slice(0, 160000) : ctx;
+async function compressOnce(context, query, codingAgent, opts = {}) {
+  const apiKey = loadApiKey();
+  if (!apiKey) return { compressed: context, skipped: "no_key" };
+
+  const idempotencyKey = stableIdempotencyKey({
+    sessionId: opts.sessionId,
+    context,
+    mode: "compiler",
+  });
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 14000);
   try {
@@ -238,25 +302,28 @@ async function compressContext(context, query, codingAgent, opts = {}) {
       headers: {
         "Content-Type": "application/json",
         "X-API-Key": apiKey,
+        "Idempotency-Key": idempotencyKey,
       },
       body: JSON.stringify({
-        context: clipped,
-        query: q,
+        context,
+        query,
         mode: "compiler",
         coding_agent: codingAgent || "Cursor",
         source: opts.source || "cursor-hook",
         session_id: opts.sessionId || null,
+        request_id: idempotencyKey,
+        idempotency_key: idempotencyKey,
       }),
       signal: controller.signal,
     });
-    if (!res.ok) return { compressed: ctx, skipped: `http_${res.status}` };
+    if (!res.ok) return { compressed: context, skipped: `http_${res.status}` };
     const body = await res.json();
     const compressed =
       body.compressed_text ||
       body.compressed_context ||
       body.compressed ||
-      ctx;
-    const inTok = body.original_tokens || Math.round(clipped.length / 4);
+      context;
+    const inTok = body.original_tokens || Math.round(context.length / 4);
     const outTok = body.kept_tokens || body.compressed_tokens || Math.round(compressed.length / 4);
     const pct =
       body.tokens_saved_pct != null
@@ -272,13 +339,72 @@ async function compressContext(context, query, codingAgent, opts = {}) {
       compressed_tokens: outTok,
       savings_pct: pct,
       latency_ms: body.latency_ms || null,
+      request_id: idempotencyKey,
     };
   } catch (err) {
-    if (err?.name === "AbortError") return { compressed: ctx, skipped: "timeout" };
-    return { compressed: ctx, skipped: "error" };
+    if (err?.name === "AbortError") return { compressed: context, skipped: "timeout" };
+    return { compressed: context, skipped: "error" };
   } finally {
     clearTimeout(timer);
   }
+}
+
+/** Compress context against a query. Query is never sent as compressible context. */
+async function compressContext(context, query, codingAgent, opts = {}) {
+  const ctx = String(context || "").trim();
+  const q = String(query || "").trim() || "Compress this context for the coding task.";
+  if (!ctx) return { compressed: "", skipped: "empty" };
+  if (ctx.length < 40) {
+    return { compressed: ctx, skipped: "too_small", original_tokens: Math.ceil(ctx.length / 4) };
+  }
+  const apiKey = loadApiKey();
+  if (!apiKey) return { compressed: ctx, skipped: "no_key" };
+
+  const chunks = chunkText(ctx, API_MAX_CHARS);
+  if (chunks.length === 1) {
+    return compressOnce(chunks[0], q, codingAgent, opts);
+  }
+
+  const parts = [];
+  let totalIn = 0;
+  let totalOut = 0;
+  let lastSkip = null;
+  for (let i = 0; i < chunks.length; i++) {
+    const partQuery = `${q} (part ${i + 1}/${chunks.length})`;
+    const r = await compressOnce(chunks[i], partQuery, codingAgent, {
+      ...opts,
+      // Distinct keys per chunk so retries stay bound to that slice.
+      sessionId: `${opts.sessionId || "default"}:chunk${i}`,
+    });
+    if (
+      !r.compressed ||
+      r.skipped === "no_key" ||
+      r.skipped === "timeout" ||
+      r.skipped === "error" ||
+      String(r.skipped || "").startsWith("http_")
+    ) {
+      lastSkip = r.skipped || "error";
+      // Keep raw chunk so we do not drop context on partial failure.
+      parts.push(chunks[i]);
+      totalIn += Math.round(chunks[i].length / 4);
+      totalOut += Math.round(chunks[i].length / 4);
+      continue;
+    }
+    parts.push(r.compressed);
+    totalIn += r.original_tokens || Math.round(chunks[i].length / 4);
+    totalOut += r.compressed_tokens || Math.round(r.compressed.length / 4);
+  }
+  const compressed = parts.join("\n\n");
+  const pct = totalIn > 0 ? Math.round(((totalIn - totalOut) / totalIn) * 100) : 0;
+  return {
+    compressed,
+    original_tokens: totalIn,
+    compressed_tokens: totalOut,
+    savings_pct: pct,
+    skipped: lastSkip && parts.every((p, i) => p === chunks[i]) ? lastSkip : null,
+    chunked: true,
+    chunks: chunks.length,
+  };
 }
 
 /**
@@ -350,27 +476,22 @@ async function compressIncremental({ context, query, codingAgent, sessionId, kin
   let compacted = false;
   let compactMeta = null;
   if (state.memory.length >= COMPACT_CHARS) {
-    const compactQuery =
-      `${query || "coding task"} | Compact this session memory. ` +
-      "Keep decisions, file paths, errors, APIs, open TODOs, and key code. Drop chatter and duplicates.";
-    const compactResult = await compressContext(state.memory, compactQuery, codingAgent, {
-      source: kind === "mcp" ? "mcp" : kind || "cursor-hook",
-      sessionId: sid,
+    const compactResult = await compactSessionMemory(sid, query, {
+      codingAgent,
+      kind,
+      persistInbox: false,
+      state,
     });
-    if (compactResult.compressed && !String(compactResult.skipped || "").startsWith("http_")) {
-      state.memory = [
-        `# Session compact · ${new Date().toISOString().slice(0, 19)}`,
-        "",
-        compactResult.compressed.trim(),
-      ].join("\n");
-      state.compacted_at = new Date().toISOString();
+    if (compactResult.compacted) {
       compacted = true;
       compactMeta = compactResult;
-      markSeen(state, hashText(state.memory));
+    } else {
+      // Compact failed — still persist the appended delta memory.
+      saveSession(sid, state);
     }
+  } else {
+    saveSession(sid, state);
   }
-
-  saveSession(sid, state);
 
   const inTok = deltaResult.original_tokens || 0;
   const outTok = Math.round(state.memory.length / 4);
@@ -389,6 +510,70 @@ async function compressIncremental({ context, query, codingAgent, sessionId, kin
   };
 }
 
+/**
+ * Compact existing session memory (used by OpenClaw compact:before).
+ * Unlike compressIncremental(""), this always runs COMPACT against memory.
+ */
+async function compactSessionMemory(sessionId, query, opts = {}) {
+  const sid = sessionId || "default";
+  const state = opts.state || loadSession(sid);
+  const memory = String(state.memory || "").trim();
+  if (memory.length < 80) {
+    return {
+      compressed: memory,
+      skipped: "too_small",
+      session_id: sid,
+      compacted: false,
+    };
+  }
+
+  const codingAgent = opts.codingAgent || "OpenClaw";
+  const compactQuery =
+    `${query || "coding task"} | Compact this session memory. ` +
+    "Keep decisions, file paths, errors, APIs, open TODOs, and key code. Drop chatter and duplicates.";
+  const compactResult = await compressContext(memory, compactQuery, codingAgent, {
+    source: opts.kind === "mcp" ? "mcp" : opts.kind || "openclaw:compact",
+    sessionId: sid,
+  });
+
+  if (
+    !compactResult.compressed ||
+    compactResult.skipped === "no_key" ||
+    compactResult.skipped === "timeout" ||
+    compactResult.skipped === "error" ||
+    String(compactResult.skipped || "").startsWith("http_")
+  ) {
+    return { ...compactResult, session_id: sid, compacted: false };
+  }
+
+  state.memory = [
+    `# Session compact · ${new Date().toISOString().slice(0, 19)}`,
+    "",
+    compactResult.compressed.trim(),
+  ].join("\n");
+  state.compacted_at = new Date().toISOString();
+  markSeen(state, hashText(state.memory));
+  saveSession(sid, state);
+
+  const meta = `${compactResult.original_tokens || "?"}→${
+    compactResult.compressed_tokens || Math.round(state.memory.length / 4)
+  } (−${compactResult.savings_pct || 0}%)`;
+  if (opts.persistInbox !== false) {
+    writeInbox(query || "compact session memory", state.memory, meta, {
+      kind: opts.kind || "openclaw-compact",
+      session_id: sid,
+      compacted: true,
+    });
+  }
+
+  return {
+    ...compactResult,
+    compressed: state.memory,
+    session_id: sid,
+    compacted: true,
+  };
+}
+
 // Back-compat alias (old name) — still means context compress
 async function compressPrompt(context, codingAgent) {
   return compressContext(context, "Compress this context for the coding agent.", codingAgent);
@@ -397,8 +582,11 @@ async function compressPrompt(context, codingAgent) {
 module.exports = {
   compressContext,
   compressIncremental,
+  compactSessionMemory,
   compressPrompt,
   writeInbox,
+  readInboxDigest,
+  inboxPaths,
   loadApiKey,
   splitAskAndContext,
   resolveSessionId,
@@ -406,9 +594,13 @@ module.exports = {
   saveSession,
   extractNewBlocks,
   hashText,
+  stableIdempotencyKey,
+  chunkText,
+  CONFIG_DIR,
   INBOX_DIR,
   SESSIONS_DIR,
   COMPACT_CHARS,
+  API_MAX_CHARS,
 };
 
 if (require.main === module) {

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/HOOK.md
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/HOOK.md
@@ -1,6 +1,6 @@
 ---
 name: supercompress-bootstrap
-description: "Inject SuperCompress inbox digest into agent bootstrap context when present."
+description: "Inject this session's SuperCompress inbox digest into agent bootstrap context when present."
 metadata:
   {
     "openclaw":
@@ -14,7 +14,7 @@ metadata:
 
 # SuperCompress bootstrap
 
-On `agent:bootstrap`, if `~/.supercompress/inbox/latest.md` exists, inject it as a bootstrap file named `SUPERCOMPRESS.md` so the agent prefers the session digest over re-pasting raw dumps.
+On `agent:bootstrap`, if this session's inbox digest exists (`$SUPERCOMPRESS_CONFIG_DIR/inbox/<sessionId>/latest.md`), inject it as a bootstrap file named `SUPERCOMPRESS.md` so the agent prefers the session digest over re-pasting raw dumps. No session id → no inject (avoids cross-session leaks).
 
 Enable with:
 

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/handler.js
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-bootstrap/handler.js
@@ -1,13 +1,31 @@
 /**
- * OpenClaw internal hook — inject SuperCompress inbox into bootstrap files.
+ * OpenClaw internal hook — inject SuperCompress *session* inbox into bootstrap.
  * Fail-open. ESM (OpenClaw hook loader).
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
-const INBOX = path.join(os.homedir(), ".supercompress", "inbox", "latest.md");
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 const BOOTSTRAP_NAME = "SUPERCOMPRESS.md";
+
+function loadLib() {
+  const candidates = [
+    path.join(__dirname, "compress-prompt-lib.js"),
+    path.join(__dirname, "..", "..", "extensions", "supercompress", "compress-prompt-lib.js"),
+    path.join(__dirname, "..", "..", "..", "cursor-hooks", "compress-prompt-lib.js"),
+  ];
+  for (const p of candidates) {
+    try {
+      return require(p);
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
 
 function normalizeEntry(entry) {
   if (!entry) return null;
@@ -16,10 +34,33 @@ function normalizeEntry(entry) {
   return null;
 }
 
+function resolveSessionId(event, lib) {
+  if (lib?.resolveSessionId) {
+    return lib.resolveSessionId({
+      sessionId: event?.context?.sessionId || event?.sessionId,
+      session_id: event?.context?.sessionKey || event?.sessionKey,
+      conversationId: event?.context?.conversationId,
+    });
+  }
+  const raw =
+    event?.context?.sessionId ||
+    event?.sessionKey ||
+    event?.context?.sessionKey ||
+    process.env.SUPERCOMPRESS_SESSION_ID ||
+    "";
+  return String(raw || "").replace(/[^\w.-]+/g, "_").slice(0, 80);
+}
+
 const handler = async (event) => {
   try {
     if (event?.type !== "agent" || event?.action !== "bootstrap") return;
-    if (!fs.existsSync(INBOX)) return;
+    const lib = loadLib();
+    const sessionId = resolveSessionId(event, lib);
+    if (!sessionId) return;
+
+    const digest = lib?.readInboxDigest ? lib.readInboxDigest(sessionId) : "";
+    if (!digest) return;
+
     const files = event.context?.bootstrapFiles;
     if (!Array.isArray(files)) return;
 
@@ -31,18 +72,18 @@ const handler = async (event) => {
     });
     if (already) return;
 
-    let content = "";
-    try {
-      content = fs.readFileSync(INBOX, "utf8");
-    } catch {
-      return;
-    }
-    if (!content.trim()) return;
+    const inboxPath = lib?.inboxPaths
+      ? lib.inboxPaths(sessionId).latestMd
+      : path.join(
+          lib?.INBOX_DIR || path.join(require("node:os").homedir(), ".supercompress", "inbox"),
+          sessionId,
+          "latest.md"
+        );
 
     files.push({
       name: BOOTSTRAP_NAME,
-      path: INBOX,
-      content,
+      path: inboxPath,
+      content: digest,
     });
   } catch (err) {
     console.warn(

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/HOOK.md
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/HOOK.md
@@ -1,6 +1,6 @@
 ---
 name: supercompress-compact
-description: "Before OpenClaw session compaction, nudge to prefer SuperCompress digests and refresh inbox when possible."
+description: "Before OpenClaw session compaction, compact SuperCompress session memory and refresh the session inbox."
 metadata:
   {
     "openclaw":
@@ -15,7 +15,7 @@ metadata:
 
 # SuperCompress compact
 
-On `session:compact:before`, remind the chat to prefer SuperCompress digests and fire-and-forget a background compact of rolling session memory (via shared compress-prompt-lib).
+On `session:compact:before`, remind the chat to prefer SuperCompress digests and fire-and-forget `compactSessionMemory(sessionId)` (real compact of rolling session memory + session-scoped inbox write).
 
 Enable with:
 

--- a/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/handler.js
+++ b/packages/proxy/src/openclaw-hooks/hooks/supercompress-compact/handler.js
@@ -1,6 +1,6 @@
 /**
  * OpenClaw internal hook — session compact:before.
- * Nudges the chat + fire-and-forget session memory compact.
+ * Runs a real session-memory compact (not empty-context compressIncremental).
  * Fail-open. ESM.
  */
 import { createRequire } from "node:module";
@@ -14,7 +14,6 @@ function loadLib() {
   const candidates = [
     path.join(__dirname, "compress-prompt-lib.js"),
     path.join(__dirname, "..", "..", "extensions", "supercompress", "compress-prompt-lib.js"),
-    // Dev / package-relative fallback when hooks live next to cursor-hooks
     path.join(__dirname, "..", "..", "..", "cursor-hooks", "compress-prompt-lib.js"),
   ];
   for (const p of candidates) {
@@ -31,30 +30,35 @@ const handler = async (event) => {
   try {
     if (event?.type !== "session" || event?.action !== "compact:before") return;
 
+    const lib = loadLib();
+    const sessionId = lib?.resolveSessionId
+      ? lib.resolveSessionId({
+          sessionId: event.context?.sessionId || event.sessionId,
+          session_id: event.sessionKey || event.context?.sessionKey,
+        })
+      : String(
+          event.context?.sessionId ||
+            event.sessionKey ||
+            event.context?.sessionKey ||
+            "openclaw"
+        )
+          .replace(/[^\w.-]+/g, "_")
+          .slice(0, 80);
+
     if (Array.isArray(event.messages)) {
       event.messages.push(
-        "🗜️ SuperCompress: prefer ~/.supercompress/inbox/latest.md digests over raw dumps while context is compacted."
+        `🗜️ SuperCompress: prefer session inbox digests (inbox/${sessionId}/latest.md) over raw dumps while context is compacted.`
       );
     }
 
-    const lib = loadLib();
-    if (!lib?.compressIncremental) return;
-
-    const sessionId = String(
-      event.context?.sessionId ||
-        event.sessionKey ||
-        event.context?.sessionKey ||
-        "openclaw"
-    ).replace(/[^\w.-]+/g, "_").slice(0, 80);
+    if (!lib?.compactSessionMemory) return;
 
     // Fire-and-forget — do not block compaction.
     void lib
-      .compressIncremental({
-        context: "",
-        query: "Compact OpenClaw session memory before native compaction.",
+      .compactSessionMemory(sessionId, "Compact OpenClaw session memory before native compaction.", {
         codingAgent: "OpenClaw",
-        sessionId,
         kind: "openclaw:compact",
+        persistInbox: true,
       })
       .catch(() => {});
   } catch (err) {

--- a/packages/proxy/src/openclaw-hooks/plugin/index.js
+++ b/packages/proxy/src/openclaw-hooks/plugin/index.js
@@ -2,13 +2,11 @@
  * SuperCompress OpenClaw plugin — Headroom-parity auto-compress.
  *
  * - after_tool_call: compress large tool results into session inbox (async)
- * - before_prompt_build: prepend inbox digest so the model prefers digests
+ * - before_prompt_build: prepend *that session's* inbox digest
  *
  * Uses a local definePluginEntry stub (same pattern as community plugins) so
  * we do not need openclaw as a hard dependency at install time.
  */
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -17,8 +15,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
 const MIN_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MIN_CHARS || 400);
+/** Accept large dumps; shared lib chunks to the hosted 120k API limit. */
 const MAX_IN = Number(process.env.SUPERCOMPRESS_HOOK_MAX_CHARS || 180000);
-const INBOX_MD = path.join(os.homedir(), ".supercompress", "inbox", "latest.md");
 
 function definePluginEntry(options) {
   return options;
@@ -66,7 +64,14 @@ function extractText(value) {
   return String(value);
 }
 
-function resolveSessionId(event = {}, ctx = {}) {
+function resolveSessionId(event = {}, ctx = {}, lib = null) {
+  if (lib?.resolveSessionId) {
+    return lib.resolveSessionId({
+      sessionId: event.sessionId || ctx.sessionId,
+      session_id: event.sessionKey || ctx.sessionKey,
+      conversationId: event.conversationId || ctx.conversationId,
+    });
+  }
   const raw =
     event.sessionId ||
     ctx.sessionId ||
@@ -75,16 +80,6 @@ function resolveSessionId(event = {}, ctx = {}) {
     process.env.SUPERCOMPRESS_SESSION_ID ||
     "openclaw";
   return String(raw).replace(/[^\w.-]+/g, "_").slice(0, 80);
-}
-
-function readInboxDigest() {
-  try {
-    if (!fs.existsSync(INBOX_MD)) return "";
-    const body = fs.readFileSync(INBOX_MD, "utf8").trim();
-    return body.length > 40 ? body : "";
-  } catch {
-    return "";
-  }
 }
 
 export default definePluginEntry({
@@ -136,7 +131,7 @@ export default definePluginEntry({
         const lib = loadLib();
         if (!lib?.compressIncremental || !lib?.writeInbox) return;
 
-        const sessionId = resolveSessionId(event, ctx);
+        const sessionId = resolveSessionId(event, ctx, lib);
         const query =
           `Compress new ${toolName || "tool"} output for the current OpenClaw task. ` +
           "Preserve code, paths, errors, numbers, and decisions.";
@@ -168,8 +163,12 @@ export default definePluginEntry({
 
     safeOn(
       "before_prompt_build",
-      async () => {
-        const digest = readInboxDigest();
+      async (event, ctx) => {
+        const lib = loadLib();
+        const sessionId = resolveSessionId(event || {}, ctx || {}, lib);
+        const digest = lib?.readInboxDigest
+          ? lib.readInboxDigest(sessionId)
+          : "";
         if (!digest) return;
         return {
           prependContext: [

--- a/packages/proxy/src/openclaw-hooks/skills/supercompress/SKILL.md
+++ b/packages/proxy/src/openclaw-hooks/skills/supercompress/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: supercompress
-description: "Always-on context compression for OpenClaw. Compress bulky tool dumps / files / logs via MCP compress_context; never compress the user's ask. Prefer ~/.supercompress/inbox/latest.md digests."
+description: "Always-on context compression for OpenClaw. Compress bulky tool dumps / files / logs via MCP compress_context; never compress the user's ask. Prefer session-scoped inbox/<sessionId>/latest.md digests."
 ---
 
 # SuperCompress (OpenClaw)
 
 **Auto (Headroom-parity):** compress every *new* bulky context dump; when rolling session memory gets large, compact it. Never compress the user's ask/query. Skip already-seen chunks.
+
+Inbox digests are **session-scoped** under `$SUPERCOMPRESS_CONFIG_DIR/inbox/<sessionId>/` (default `~/.supercompress/inbox/<sessionId>/`) so sessions never cross-contaminate.
 
 ## When to use
 
@@ -13,13 +15,14 @@ After large tool results, file reads, diffs, logs, scrapes, or pasted blobs — 
 
 ## How
 
-1. If `~/.supercompress/inbox/latest.md` exists, **Read it first** — session digest (ask is unchanged).
+1. If `inbox/<sessionId>/latest.md` exists for this session, **Read it first** — session digest (ask is unchanged).
 2. Else call MCP `compress_context` with `context`=<new dump only> and `query`=<user ask>. Prefer the returned digest over raw dumps.
-3. The SuperCompress OpenClaw plugin also auto-compresses large tool results into the inbox when installed.
+3. The SuperCompress OpenClaw plugin also auto-compresses large tool results into the **session** inbox when installed.
 4. If `compress_context` fails with account-not-linked, call `connect_account` once, then retry.
 
 ## Do not
 
 - Compress the user's question / instructions.
 - Re-paste raw tool dumps after a digest exists.
+- Read another session's inbox file.
 - Require provider API-key proxy mode — normal login is fine.

--- a/packages/proxy/test/agent-plugins.js
+++ b/packages/proxy/test/agent-plugins.js
@@ -61,15 +61,73 @@ if (!ocCfg.mcp?.servers?.supercompress?.env?.SUPERCOMPRESS_CONFIG_DIR) {
 }
 const agentsOc = fs.readFileSync(path.join(ocHome, "AGENTS.md"), "utf8");
 if (!/compress_context/.test(agentsOc)) throw new Error("openclaw AGENTS.md missing instructions");
+if (!/inbox\\/<sessionId>\\/latest\\.md/.test(agentsOc)) {
+  throw new Error("openclaw AGENTS.md missing session-scoped inbox path");
+}
+
+// Exact plugin path match: unrelated .../extensions/supercompress-backup must survive uninstall
+const backupPath = path.join(ocHome, "extensions", "supercompress-backup");
+fs.mkdirSync(backupPath, { recursive: true });
+fs.writeFileSync(path.join(backupPath, "marker.txt"), "keep");
+const cfgBeforeUninstall = JSON.parse(fs.readFileSync(path.join(ocHome, "openclaw.json"), "utf8"));
+cfgBeforeUninstall.plugins.load.paths.push(backupPath);
+fs.writeFileSync(path.join(ocHome, "openclaw.json"), JSON.stringify(cfgBeforeUninstall, null, 2));
+if (!ap.sameAbsPath(ocAuto.pluginDest, path.join(ocHome, "extensions", "supercompress"))) {
+  throw new Error("sameAbsPath failed for installed plugin dest");
+}
+if (ap.sameAbsPath(ocAuto.pluginDest, backupPath)) {
+  throw new Error("sameAbsPath incorrectly matched backup path");
+}
 
 const ocRemoved = ap.removeOpenClawAutoCompressArtifacts(ocHome);
 if (!ocRemoved.length) throw new Error("openclaw uninstall removed nothing");
 if (fs.existsSync(path.join(ocHome, "skills", "supercompress"))) {
   throw new Error("openclaw skill still present after uninstall");
 }
+if (!fs.existsSync(path.join(backupPath, "marker.txt"))) {
+  throw new Error("uninstall deleted unrelated extensions/supercompress-backup");
+}
 const ocAfter = JSON.parse(fs.readFileSync(path.join(ocHome, "openclaw.json"), "utf8"));
 if (ocAfter.mcp?.servers?.supercompress) throw new Error("openclaw mcp still present after uninstall");
 if (ocAfter.plugins?.entries?.supercompress) throw new Error("openclaw plugin entry still present");
+if (!(ocAfter.plugins?.load?.paths || []).includes(backupPath)) {
+  throw new Error("uninstall stripped unrelated plugin load path");
+}
+
+// Session-scoped inbox + compactSessionMemory smoke (no network)
+const lib = require(${JSON.stringify(path.join(ROOT, "src/cursor-hooks/compress-prompt-lib.js"))});
+const inboxA = lib.writeInbox("ask A", "digest A", "1→1", { session_id: "sessA", kind: "test" });
+const inboxB = lib.writeInbox("ask B", "digest B", "1→1", { session_id: "sessB", kind: "test" });
+if (inboxA === inboxB) throw new Error("session inboxes must not share a path");
+if (!inboxA.includes(${JSON.stringify(path.sep + "sessA" + path.sep)})) {
+  throw new Error("sessA inbox path wrong: " + inboxA);
+}
+if (lib.readInboxDigest("sessA").includes("digest B")) {
+  throw new Error("cross-session inbox leak");
+}
+if (!lib.readInboxDigest("sessA").includes("digest A")) {
+  throw new Error("sessA digest missing");
+}
+if (typeof lib.compactSessionMemory !== "function") {
+  throw new Error("compactSessionMemory missing");
+}
+if (lib.chunkText("x".repeat(250000), 120000).length !== 3) {
+  throw new Error("chunkText should split above API max");
+}
+const idKey = lib.stableIdempotencyKey({ sessionId: "s1", context: "abc", mode: "compiler" });
+if (!/^sc_[a-f0-9]{40}$/.test(idKey)) throw new Error("bad stable idempotency key: " + idKey);
+
+// Plugin source must not hardcode ~/.supercompress/inbox/latest.md
+const pluginAsset = fs.readFileSync(
+  path.join(${JSON.stringify(ROOT)}, "src/openclaw-hooks/plugin/index.js"),
+  "utf8"
+);
+if (pluginAsset.includes(".supercompress/inbox/latest.md")) {
+  throw new Error("OpenClaw plugin still hardcodes global inbox/latest.md");
+}
+if (!/readInboxDigest/.test(pluginAsset)) {
+  throw new Error("OpenClaw plugin must use session readInboxDigest");
+}
 
 // Custom plugin: no --config → defaults, always installs, writes AGENTS.md
 const { plugin } = ap.addCustomPlugin({

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -229,14 +229,17 @@
         <div class="cl-body">
           <h3>API / billing</h3>
           <ul>
+            <li><strong>Fingerprint-bound Idempotency-Key</strong> — reuse with a different compress payload returns <code>409 idempotency_conflict</code> (blocks free recompress / billing bypass).</li>
+            <li>Durable hourly rate-limit hits keyed by <strong>payload fingerprint</strong>, not the client-chosen request id.</li>
             <li><strong>Request-level billing idempotency</strong> (<code>Idempotency-Key</code> / <code>billing_usage/{uid}:{requestId}</code>) so billing timeouts cannot double-charge on retry.</li>
             <li>Bill before per-key analytics; auto-recharge when balance is positive but insufficient, then retry the same request id.</li>
-            <li>Transactional first-pay bonus; honest Checkout replay flags; cumulative micro-USD rounding; idempotent durable rate-limit hits.</li>
+            <li>Transactional first-pay bonus; honest Checkout replay flags; cumulative micro-USD rounding.</li>
             <li>Earlier: fail-closed usage burns, permanent Stripe credit idempotency, POST-only compress, CCR marker cleanup, billing ledger as source of truth.</li>
           </ul>
           <h3>Coding agent plugin</h3>
           <ul>
-            <li><strong>OpenClaw auto-compress</strong> parity with Hermes: setup/plugin installs MCP + <code>AGENTS.md</code> + managed skill + internal hooks + extension plugin (large tool dumps → inbox).</li>
+            <li><strong>OpenClaw auto-compress</strong> parity with Hermes: setup/plugin installs MCP + <code>AGENTS.md</code> + managed skill + internal hooks + extension plugin.</li>
+            <li><strong>Session-scoped inbox</strong> (<code>inbox/&lt;sessionId&gt;/latest.md</code>) + <code>SUPERCOMPRESS_CONFIG_DIR</code>; exact plugin path uninstall; real <code>compactSessionMemory</code>; chunk ≤120k; stable hook idempotency keys.</li>
             <li><strong>Preserve tool-call order</strong> when splitting compressible history; rank compression against the latest user ask in the full thread.</li>
             <li>Proxy sends <code>Idempotency-Key</code> on compress API calls.</li>
             <li>See <a href="#v0.5.17">0.5.17</a> / <a href="#v0.5.16">0.5.16</a> for the latest published npm fixes.</li>


### PR DESCRIPTION
## Summary
- **P0 billing:** bind `Idempotency-Key` to a server SHA-256 of the compress payload; reuse with a different body → `409 idempotency_conflict` (not free recompress / skipped wallet burn).
- **P0 rate limit:** durable hourly hit ids use the payload fingerprint, not the client-chosen request id.
- **P1 OpenClaw privacy:** session-scoped `inbox/<sessionId>/latest.md`; bootstrap/plugin only read that session; honor `SUPERCOMPRESS_CONFIG_DIR`.
- **P1 uninstall:** exact absolute path compare for plugin `load.paths` (no substring deletes of `extensions/supercompress-*`).
- **OpenClaw compact / size / hooks:** real `compactSessionMemory()`, chunk dumps ≤120k, stable hook `Idempotency-Key` = hash(session + content + mode).

## Test plan
- [x] `node api/_lib/billing-ledger.test.js` (fingerprint + conflict cases)
- [x] `node packages/proxy/test/agent-plugins.js` (session inbox isolation, exact path uninstall, plugin asset checks)
- [x] `node packages/proxy/test/smoke.js` / `uninstall-clean.js`
- [ ] CI green on this PR
- [ ] Optional: restart OpenClaw gateway and confirm skill/hooks/plugin load (manual)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR binds billing replays to payload fingerprints and adds session-scoped OpenClaw inboxes, chunked compression, real session compaction, and exact plugin-path cleanup. Major changes:
- Adds SHA-256 request fingerprinting to billing and durable rate limiting.
- Scopes OpenClaw digest storage and reads by session.
- Adds chunked hook compression, stable retry keys, and session-memory compaction.
- Tightens OpenClaw plugin installation and uninstall path matching.

<h3>Confidence Score: 2/5</h3>

The PR is not safe to merge until distinct identical requests count toward the durable hourly limit and hook idempotency keys cover the query.

Payload-only durable hit IDs permit hourly-limit bypass, while query-blind hook keys conflict with the server fingerprint and cause valid repeated compression work to fall back to raw context.

**Files Needing Attention:** api/v1/compress.js; packages/proxy/src/cursor-hooks/compress-prompt-lib.js

<details open><summary><h3>Security Review</h3></summary>

The durable hourly rate limiter deduplicates by payload alone, allowing independently submitted identical requests to consume only one durable slot.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/v1/compress.js | Integrates payload fingerprints into rate limiting and billing, but payload-only durable hit IDs collapse distinct identical requests. |
| api/_lib/billing-ledger.js | Adds fingerprint-bound billing usage rows and explicit 409 conflicts with legacy-row compatibility. |
| packages/proxy/src/cursor-hooks/compress-prompt-lib.js | Adds session inboxes, chunking, compaction, and retry keys, but key generation omits the query covered by the server fingerprint. |
| packages/proxy/src/openclaw-hooks/plugin/index.js | Routes tool-output writes and prompt digest reads through session-scoped helpers. |
| packages/proxy/src/agent-plugins.js | Replaces substring plugin-path matching with normalized exact absolute-path equality. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant H as Hook client
  participant API as Compress API
  participant RL as Durable rate limiter
  participant B as Billing ledger
  H->>API: body + Idempotency-Key
  API->>API: Compute payload fingerprint
  API->>RL: Check IP bucket using fingerprint
  RL-->>API: Allow / reject
  API->>API: Compress payload
  API->>B: Burn usage using key + fingerprint
  B-->>API: Applied / replay / conflict
  API-->>H: Compressed result or error
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing,openclaw): bind idempotency ..."](https://github.com/supercompress/supercompress/commit/efe180f8bef55ae5db2b8ec78e6b4edd200d8a02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52087377)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->