### PR TITLE
Fix idempotency replay, durable rate-limit, and OpenClaw/hook gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,22 +14,17 @@ Public page: https://www.supercompress.dev/changelog
 ## [Unreleased]
 
 ### Site / docs
+- Product mail campaign copy lives in private GitHub `Supercompress/email-campaigns` (not OSS); loaders read Vercel env / local mirror
 - Product mail (welcome + Sunday tip + Wednesday ship) sends from Resend on `hello@supercompress.dev`; Ideatrusa/gog drains paused offline
 - Remove weekly tip/ship campaign JSON from the OSS tree (private content dir + `WEEKLY_*_JSON` env)
 - Sync public npm pins to `supercompress-proxy@0.5.17`; extend `check-versions.js` to gate those pins
 - Remove leftover Analytics spark DOM + unused series helpers from dashboard
 - Keep user emails / outreach dumps / welcome-drain ops **out of OSS** (gitignore + CI PII gate); drain scripts live under `~/agent-bridge/private/supercompress-email/`
 
-### Python library
-- Shared `CompressResult` for local + hosted client (`supercompress.result`)
-- Honest `mode="precision"` (hosted API when keyed; otherwise raises)
-- Validate `budget_ratio` in `(0, 1]`; empty context returns `noop`
-- Stop appending the user query onto local `compressed_text`
-- Remove import-time warning when no API key is set
-- Fix OpenAI / LangChain / Anthropic integration examples and middleware contracts
-- `serve` extra installs FastAPI + Uvicorn (not Flask/Gunicorn); add `py.typed`
-
 ### API / dashboard
+- Idempotent compress: replay stored response for same Idempotency-Key + fingerprint (no free recompute)
+- Durable IP rate limit counts each client key (not payload fingerprint alone)
+- Billing idempotency ignores `X-Request-Id` (tracing ≠ Idempotency-Key)
 - Durable per-key usage metering + dashboard KPI preference for billing meter
 - Remove dead store Auth-stub helpers; CCR uses Firestore (docs match)
 - Fix demo CO₂ grams over-count (`×1000` bug)

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -8,7 +8,7 @@
  * Firestore:
  *   billing/{uid}                    — monthly usage + wallet balance
  *   billing_credits/{creditKey}      — permanent Stripe session / PI idempotency
- *   billing_usage/{uid}:{requestId}  — per-request usage burn idempotency
+ *   billing_usage/{uid}:{requestId}  — per-request usage burn + compress response replay
  *   billing_bonus/{uid}:first_pay    — one-time first-pay bonus create-once
  */
 const { initFirebaseAdmin } = require("./auth");
@@ -337,6 +337,48 @@ function sanitizeRequestId(raw) {
  * returns idempotency_conflict (409) instead of already:true.
  * Throws paywall / billing_unavailable — never silently under-charges.
  */
+/** Cap stored replay payloads (Firestore 1 MiB doc limit; leave headroom). */
+const MAX_REPLAY_TEXT_CHARS = 400_000;
+
+function sanitizeReplayResponse(response) {
+  if (!response || typeof response !== "object") return null;
+  const text = String(response.compressed_text || "").slice(0, MAX_REPLAY_TEXT_CHARS);
+  if (!text) return null;
+  return {
+    compressed_text: text,
+    original_tokens: Number(response.original_tokens) || 0,
+    kept_tokens: Number(response.kept_tokens) || 0,
+    tokens_saved: Number(response.tokens_saved) || 0,
+    tokens_saved_pct: Number(response.tokens_saved_pct) || 0,
+    kv_savings_pct: Number(response.kv_savings_pct) || 0,
+    mode: response.mode || null,
+    policy_name: response.policy_name || null,
+    keep_ratio: response.keep_ratio ?? null,
+    coding_agent: response.coding_agent || null,
+    source: response.source || null,
+    cache_prefix_applied: Boolean(response.cache_prefix_applied),
+    ccr: response.ccr || null,
+    latency_ms: Number(response.latency_ms) || 0,
+  };
+}
+
+/**
+ * Lookup a prior compress billing row for Idempotency-Key replay.
+ * @returns {Promise<object|null>}
+ */
+async function lookupUsageReplay(uid, requestId) {
+  const rid = sanitizeRequestId(requestId);
+  if (!uid || !rid || !initFirebaseAdmin()) return null;
+  try {
+    const snap = await db().collection("billing_usage").doc(`${uid}:${rid}`).get();
+    if (!snap.exists) return null;
+    return snap.data() || null;
+  } catch (err) {
+    console.warn("lookupUsageReplay failed:", err?.message || err);
+    return null;
+  }
+}
+
 async function applyUsageAndBurn({
   uid,
   tokensIn,
@@ -345,6 +387,7 @@ async function applyUsageAndBurn({
   claims = {},
   requestId,
   fingerprint,
+  response = null,
 }) {
   if (!uid) throw new Error("uid required");
   const rid = sanitizeRequestId(requestId);
@@ -352,6 +395,7 @@ async function applyUsageAndBurn({
     throw billingError("billing_unavailable", "Billing request id required");
   }
   const fp = String(fingerprint || "").trim() || null;
+  const replay = sanitizeReplayResponse(response);
   if (!initFirebaseAdmin()) {
     throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
@@ -372,12 +416,17 @@ async function applyUsageAndBurn({
         tokensOut,
         tokensSaved,
       });
+      // Backfill response on legacy rows that billed before replay storage existed.
+      if (replay && !prev.response) {
+        tx.set(usageRef, { response: replay }, { merge: true });
+      }
       return {
         burned_micros: Number(prev.burned_micros || 0),
         ledger,
         already: true,
         request_id: rid,
         fingerprint: prev.fingerprint || fp || null,
+        response: prev.response || replay || null,
       };
     }
 
@@ -394,10 +443,17 @@ async function applyUsageAndBurn({
         tokens_saved: Number(tokensSaved) || 0,
         burned_micros: planned.burned_micros,
         created_at: new Date().toISOString(),
+        ...(replay ? { response: replay } : {}),
       },
       { merge: false }
     );
-    return { ...planned, already: false, request_id: rid, fingerprint: fp };
+    return {
+      ...planned,
+      already: false,
+      request_id: rid,
+      fingerprint: fp,
+      response: replay,
+    };
   });
 
   if (!result.already) {
@@ -584,6 +640,8 @@ async function markTokensReported(uid, tokensReported, claims = {}) {
 module.exports = {
   loadLedger,
   applyUsageAndBurn,
+  lookupUsageReplay,
+  sanitizeReplayResponse,
   creditBalance,
   acquireRechargeLock,
   markTokensReported,

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -401,6 +401,7 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
       claims: ownerClaims,
       requestId,
       fingerprint,
+      response: opts.response || null,
     });
   } catch (err) {
     // Positive-but-insufficient balance: recharge once, retry same request id.
@@ -428,6 +429,7 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
             claims: owner.customClaims || ownerClaims,
             requestId,
             fingerprint,
+            response: opts.response || null,
           });
         } else {
           throw err;

--- a/api/_lib/mail.js
+++ b/api/_lib/mail.js
@@ -4,10 +4,12 @@
  *   WELCOME_FROM_EMAIL (default hello@supercompress.dev on verified Resend domain)
  *   WELCOME_REPLY_TO (default founder Gmail)
  *
- * Campaign copy is NOT in the OSS tree. Load order:
- *   1. WEEKLY_TIPS_JSON / WEEKLY_SHIP_JSON env (Vercel)
+ * Campaign copy is NOT in the OSS tree. Canonical private repo:
+ *   https://github.com/Supercompress/email-campaigns
+ * Load order:
+ *   1. WEEKLY_TIPS_JSON / WEEKLY_SHIP_JSON env (Vercel; sync from that repo)
  *   2. SUPERCOMPRESS_EMAIL_CONTENT_DIR/{weekly-tips,weekly-ship}.json
- *   3. ~/agent-bridge/private/supercompress-email/content/ (local ops)
+ *   3. ~/agent-bridge/private/supercompress-email/content/ (local mirror)
  *   4. Minimal fallback seed + CHANGELOG-derived ship bullets
  */
 

--- a/api/_lib/rate-limit-durable.js
+++ b/api/_lib/rate-limit-durable.js
@@ -8,10 +8,9 @@
  * For authenticated paid endpoints, callers should treat backend !== "firestore"
  * as fail-closed (reject) so multi-instance fans-out cannot bypass the ceiling.
  *
- * Optional requestId makes increments idempotent for *true* retries. Callers
- * MUST pass a server-calculated operation fingerprint (e.g. SHA-256 of the
- * billing-relevant payload) — never a client-supplied Idempotency-Key alone,
- * or distinct requests can share one hit and evade the durable ceiling.
+ * Optional requestId makes increments idempotent for *true* retries that share
+ * the same client Idempotency-Key. Do not pass a payload fingerprint alone —
+ * identical bodies with different keys must each consume a rate-limit slot.
  */
 const crypto = require("crypto");
 const admin = require("firebase-admin");

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -22,10 +22,25 @@ const crypto = require("crypto");
 const {
   sanitizeRequestId,
   computeCompressFingerprint,
+  lookupUsageReplay,
+  assertUsageIdempotencyMatch,
 } = require("../_lib/billing-ledger");
 
 const V1_RPM = 90; // per API key (in-memory fast path)
 const V1_IP_HOURLY = 600; // durable per-IP ceiling (stops stolen-key / fan-out abuse)
+
+/**
+ * Client Idempotency-Key only — never X-Request-Id (tracing ≠ billing semantics).
+ */
+function resolveClientIdempotencyKey(req, body) {
+  return (
+    sanitizeRequestId(req.headers["idempotency-key"]) ||
+    sanitizeRequestId(req.headers["x-idempotency-key"]) ||
+    sanitizeRequestId(body?.idempotency_key) ||
+    sanitizeRequestId(body?.request_id) ||
+    null
+  );
+}
 
 /**
  * Free accounts hard-stop at the monthly free allowance (1M).
@@ -141,19 +156,6 @@ function stripRetrieveMarkers(text) {
     .trim();
 }
 
-function resolveRequestId(req, body) {
-  const header =
-    req.headers["idempotency-key"] ||
-    req.headers["x-idempotency-key"] ||
-    req.headers["x-request-id"];
-  return (
-    sanitizeRequestId(header) ||
-    sanitizeRequestId(body?.idempotency_key) ||
-    sanitizeRequestId(body?.request_id) ||
-    crypto.randomUUID()
-  );
-}
-
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
   // Compression is POST-only — never accept API keys or context in query strings.
@@ -179,9 +181,9 @@ module.exports = async (req, res) => {
 
     // Parse body early so Idempotency-Key can come from JSON when header omitted.
     const body = readBody(req);
-    requestId = resolveRequestId(req, body);
-    // Bind durable rate-limit + billing idempotency to a server-side payload
-    // fingerprint — never to a client-chosen key alone (abuse / free compress).
+    const clientIdem = resolveClientIdempotencyKey(req, body);
+    requestId = clientIdem || crypto.randomUUID();
+    // Bind billing idempotency to a server-side payload fingerprint.
     const fingerprint = computeCompressFingerprint(body);
 
     // ── Rate limit: fast per-key + durable per-IP hourly ceiling ──
@@ -200,8 +202,9 @@ module.exports = async (req, res) => {
       rl = await withTimeout(
         enforceRateLimits(
           [{ key: `v1ip:h:${ip}`, max: V1_IP_HOURLY, windowMs: 60 * 60_000 }],
-          // Hit id = payload fingerprint (same retry OK; different body always counts).
-          { requestId: fingerprint }
+          // True retries share a client Idempotency-Key. Never use payload
+          // fingerprint alone — identical bodies with different keys must each count.
+          { requestId: clientIdem || undefined }
         ),
         2000,
         "rate_limit"
@@ -256,6 +259,40 @@ module.exports = async (req, res) => {
     const authenticated = await withTimeout(authenticateKey(raw), 8000, "authenticate");
     await withTimeout(enforceUsageLimit(authenticated.owner), 10000, "usage_limit");
 
+    // Replay stored response for the same Idempotency-Key + payload (no recompute).
+    if (clientIdem) {
+      const prev = await withTimeout(
+        lookupUsageReplay(authenticated.ownerUid, clientIdem),
+        3000,
+        "idempotency_lookup"
+      );
+      if (prev) {
+        try {
+          assertUsageIdempotencyMatch(prev, {
+            fingerprint,
+            tokensIn: prev.tokens_in,
+            tokensOut: prev.tokens_out,
+            tokensSaved: prev.tokens_saved,
+          });
+        } catch (err) {
+          throw err;
+        }
+        if (prev.response?.compressed_text) {
+          res.setHeader("Idempotency-Key", requestId);
+          return jsonWithRateLimit(
+            res,
+            200,
+            {
+              ...prev.response,
+              request_id: requestId,
+              idempotent_replay: true,
+            },
+            rl
+          );
+        }
+      }
+    }
+
     if (mode === "fixed" && (budgetRatio < 0.05 || budgetRatio > 1)) {
       const err = new Error("invalid budget_ratio");
       err.status = 422;
@@ -269,28 +306,6 @@ module.exports = async (req, res) => {
     const latencyMs = Math.max(0, Date.now() - compressStarted);
 
     const remainingMs = () => HARD_BUDGET_MS - (Date.now() - requestStarted);
-    // Billing is fail-closed: never return compressed text without a durable charge/quota write.
-    try {
-      await withTimeout(
-        recordUsage(authenticated.user, authenticated.owner, result, {
-          requestId,
-          fingerprint,
-        }),
-        Math.max(1500, Math.min(12000, remainingMs() - 2000)),
-        "record_usage"
-      );
-    } catch (err) {
-      if (err.paywall || err.status === 402) throw err;
-      const e = new Error(
-        err.code === "timeout"
-          ? "Billing timed out — compression not delivered. Retry with the same Idempotency-Key."
-          : "Billing unavailable — compression not delivered. Retry with the same Idempotency-Key."
-      );
-      e.status = err.status || 503;
-      e.code = err.code || "billing_unavailable";
-      e.requestId = requestId;
-      throw e;
-    }
 
     // Infer source when client omitted it (agent key name / coding_agent).
     const inferredSource =
@@ -421,8 +436,7 @@ module.exports = async (req, res) => {
       ? wrapCompressedForCache(rawText, query).wrapped
       : rawText;
 
-    res.setHeader("Idempotency-Key", requestId);
-    return jsonWithRateLimit(res, 200, {
+    const responseBody = {
       compressed_text: finalText,
       original_tokens: result.original_tokens,
       kept_tokens: result.kept_tokens,
@@ -449,7 +463,35 @@ module.exports = async (req, res) => {
       coding_agent: coding_agent || null,
       source: inferredSource,
       request_id: requestId,
-    }, rl);
+    };
+
+    // Billing is fail-closed: never return compressed text without a durable charge/quota write.
+    // Persist responseBody so identical Idempotency-Key retries replay instead of recomputing.
+    try {
+      await withTimeout(
+        recordUsage(authenticated.user, authenticated.owner, result, {
+          requestId,
+          fingerprint,
+          response: responseBody,
+        }),
+        Math.max(1500, Math.min(12000, remainingMs() - 2000)),
+        "record_usage"
+      );
+    } catch (err) {
+      if (err.paywall || err.status === 402) throw err;
+      const e = new Error(
+        err.code === "timeout"
+          ? "Billing timed out — compression not delivered. Retry with the same Idempotency-Key."
+          : "Billing unavailable — compression not delivered. Retry with the same Idempotency-Key."
+      );
+      e.status = err.status || 503;
+      e.code = err.code || "billing_unavailable";
+      e.requestId = requestId;
+      throw e;
+    }
+
+    res.setHeader("Idempotency-Key", requestId);
+    return jsonWithRateLimit(res, 200, responseBody, rl);
   } catch (err) {
     let status = err.status || 500;
     if (err.code === "timeout" && !err.status) status = 504;

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -4,6 +4,9 @@ Versions track `supercompress-proxy` on npm. Full product notes: [CHANGELOG.md](
 
 ## [Unreleased]
 
+- Hook `Idempotency-Key` includes normalized **query** (avoids 409 when context reused for a new task).
+- Partial chunk failure no longer marks session hashes seen; OpenClaw/Cursor feed full dumps into the chunker (1.2M soft cap, not 180k hard clip).
+- OpenClaw skips inbox compress when no session/conversation id (no shared cwd fallback).
 - **OpenClaw auto-compress parity with Hermes**: setup/plugin installs MCP + `AGENTS.md` + managed skill + internal hooks + extension plugin (tool dumps → inbox); uninstall cleans them.
 - **Session-scoped inbox** (`inbox/<sessionId>/`) + `SUPERCOMPRESS_CONFIG_DIR` for OpenClaw plugin/hooks (no global `latest.md` cross-session leak).
 - Exact OpenClaw plugin path match on install/uninstall (no substring deletes).

--- a/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
+++ b/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
@@ -26,6 +26,8 @@ const COMPACT_CHARS = Number(process.env.SUPERCOMPRESS_COMPACT_CHARS || 24000);
 const MAX_SEEN = Number(process.env.SUPERCOMPRESS_MAX_SEEN || 500);
 /** Hosted API hard cap — chunk above this rather than 422. */
 const API_MAX_CHARS = Number(process.env.SUPERCOMPRESS_API_MAX_CHARS || 120000);
+/** Deliberate total cap after chunking (hooks feed full dumps; do not pre-truncate to 180k). */
+const HOOK_TOTAL_MAX_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MAX_CHARS || 1_200_000);
 
 function loadApiKey() {
   const envKey = String(process.env.SUPERCOMPRESS_API_KEY || "").trim();
@@ -148,7 +150,7 @@ function fullHash(text) {
 }
 
 /** Stable Idempotency-Key so hook timeouts can safely retry without double-billing. */
-function stableIdempotencyKey({ sessionId, context, mode }) {
+function stableIdempotencyKey({ sessionId, context, mode, query }) {
   const h = crypto
     .createHash("sha256")
     .update(String(sessionId || ""))
@@ -156,11 +158,17 @@ function stableIdempotencyKey({ sessionId, context, mode }) {
     .update(fullHash(context))
     .update("\0")
     .update(String(mode || "compiler"))
+    .update("\0")
+    .update(fullHash(String(query || "").trim().toLowerCase()))
     .digest("hex")
     .slice(0, 40);
   return `sc_${h}`;
 }
 
+/**
+ * Resolve a session bucket for inbox / memory.
+ * @param {{ fallback?: "cwd"|"ephemeral"|"none" }} [input]
+ */
 function resolveSessionId(input = {}) {
   const raw =
     input.session_id ||
@@ -171,6 +179,11 @@ function resolveSessionId(input = {}) {
     process.env.SUPERCOMPRESS_SESSION_ID ||
     "";
   if (raw) return String(raw).replace(/[^\w.-]+/g, "_").slice(0, 80);
+  const fallback = String(input.fallback || "cwd").toLowerCase();
+  if (fallback === "none") return null;
+  if (fallback === "ephemeral") {
+    return `ephemeral_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  }
   const cwd = String(input.cwd || process.env.CURSOR_PROJECT_DIR || process.cwd() || "default");
   return `cwd_${hashText(cwd)}`;
 }
@@ -293,6 +306,7 @@ async function compressOnce(context, query, codingAgent, opts = {}) {
     sessionId: opts.sessionId,
     context,
     mode: "compiler",
+    query,
   });
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 14000);
@@ -360,7 +374,9 @@ async function compressContext(context, query, codingAgent, opts = {}) {
   const apiKey = loadApiKey();
   if (!apiKey) return { compressed: ctx, skipped: "no_key" };
 
-  const chunks = chunkText(ctx, API_MAX_CHARS);
+  const bounded =
+    ctx.length > HOOK_TOTAL_MAX_CHARS ? ctx.slice(0, HOOK_TOTAL_MAX_CHARS) : ctx;
+  const chunks = chunkText(bounded, API_MAX_CHARS);
   if (chunks.length === 1) {
     return compressOnce(chunks[0], q, codingAgent, opts);
   }
@@ -369,6 +385,8 @@ async function compressContext(context, query, codingAgent, opts = {}) {
   let totalIn = 0;
   let totalOut = 0;
   let lastSkip = null;
+  let okChunks = 0;
+  let failedChunks = 0;
   for (let i = 0; i < chunks.length; i++) {
     const partQuery = `${q} (part ${i + 1}/${chunks.length})`;
     const r = await compressOnce(chunks[i], partQuery, codingAgent, {
@@ -384,26 +402,34 @@ async function compressContext(context, query, codingAgent, opts = {}) {
       String(r.skipped || "").startsWith("http_")
     ) {
       lastSkip = r.skipped || "error";
+      failedChunks += 1;
       // Keep raw chunk so we do not drop context on partial failure.
       parts.push(chunks[i]);
       totalIn += Math.round(chunks[i].length / 4);
       totalOut += Math.round(chunks[i].length / 4);
       continue;
     }
+    okChunks += 1;
     parts.push(r.compressed);
     totalIn += r.original_tokens || Math.round(chunks[i].length / 4);
     totalOut += r.compressed_tokens || Math.round(r.compressed.length / 4);
   }
   const compressed = parts.join("\n\n");
   const pct = totalIn > 0 ? Math.round(((totalIn - totalOut) / totalIn) * 100) : 0;
+  const partial = okChunks > 0 && failedChunks > 0;
+  const allFailed = okChunks === 0 && failedChunks > 0;
   return {
     compressed,
     original_tokens: totalIn,
     compressed_tokens: totalOut,
     savings_pct: pct,
-    skipped: lastSkip && parts.every((p, i) => p === chunks[i]) ? lastSkip : null,
+    // Only treat as total skip when every chunk failed — partial stays retryable upstream.
+    skipped: allFailed ? lastSkip || "error" : partial ? "partial_chunk_failure" : null,
+    partial,
     chunked: true,
     chunks: chunks.length,
+    chunks_ok: okChunks,
+    chunks_failed: failedChunks,
   };
 }
 
@@ -447,14 +473,16 @@ async function compressIncremental({ context, query, codingAgent, sessionId, kin
 
   if (
     !deltaResult.compressed ||
+    deltaResult.partial ||
     deltaResult.skipped === "empty" ||
     deltaResult.skipped === "too_small" ||
     deltaResult.skipped === "no_key" ||
     deltaResult.skipped === "timeout" ||
     deltaResult.skipped === "error" ||
+    deltaResult.skipped === "partial_chunk_failure" ||
     String(deltaResult.skipped || "").startsWith("http_")
   ) {
-    // Do not markSeen on timeout/error — temporary outages must remain retryable.
+    // Do not markSeen on timeout/error/partial — failed slices must remain retryable.
     return { ...deltaResult, session_id: sid, compacted: false, delta: "" };
   }
 

--- a/packages/proxy/src/cursor-hooks/post-tool-compress.js
+++ b/packages/proxy/src/cursor-hooks/post-tool-compress.js
@@ -15,7 +15,8 @@ const {
 } = require("./compress-prompt-lib");
 
 const MIN_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MIN_CHARS || 400);
-const MAX_IN = Number(process.env.SUPERCOMPRESS_HOOK_MAX_CHARS || 180000);
+/** Soft total cap — shared lib chunks to API 120k (do not pre-clip to 180k). */
+const MAX_IN = Number(process.env.SUPERCOMPRESS_HOOK_MAX_CHARS || 1_200_000);
 
 function extractText(toolOutput) {
   if (toolOutput == null) return "";
@@ -75,7 +76,7 @@ process.stdin.on("end", async () => {
     if (!text) text = extractText(input.response);
     if (text.length < MIN_CHARS) return empty();
 
-    const clipped = text.length > MAX_IN ? text.slice(0, MAX_IN) : text;
+    const bounded = text.length > MAX_IN ? text.slice(0, MAX_IN) : text;
     const agentHint = resolveAgentHint(input);
     const sessionId = resolveSessionId(input);
 
@@ -84,7 +85,7 @@ process.stdin.on("end", async () => {
       "Preserve code, paths, errors, numbers, and decisions.";
 
     const result = await compressIncremental({
-      context: clipped,
+      context: bounded,
       query,
       codingAgent: agentHint,
       sessionId,

--- a/packages/proxy/src/openclaw-hooks/plugin/index.js
+++ b/packages/proxy/src/openclaw-hooks/plugin/index.js
@@ -15,8 +15,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
 const MIN_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MIN_CHARS || 400);
-/** Accept large dumps; shared lib chunks to the hosted 120k API limit. */
-const MAX_IN = Number(process.env.SUPERCOMPRESS_HOOK_MAX_CHARS || 180000);
+/** Soft total cap — shared lib chunks to the hosted 120k API limit (do not pre-clip to 180k). */
+const MAX_IN = Number(process.env.SUPERCOMPRESS_HOOK_MAX_CHARS || 1_200_000);
 
 function definePluginEntry(options) {
   return options;
@@ -64,22 +64,33 @@ function extractText(value) {
   return String(value);
 }
 
+/**
+ * Prefer OpenClaw session/conversation identifiers. Never fall back to cwd —
+ * that collapses unrelated chats into one inbox when IDs are missing.
+ * @returns {string|null}
+ */
 function resolveSessionId(event = {}, ctx = {}, lib = null) {
-  if (lib?.resolveSessionId) {
-    return lib.resolveSessionId({
-      sessionId: event.sessionId || ctx.sessionId,
-      session_id: event.sessionKey || ctx.sessionKey,
-      conversationId: event.conversationId || ctx.conversationId,
-    });
+  const candidates = [
+    event.sessionId,
+    ctx.sessionId,
+    event.sessionKey,
+    ctx.sessionKey,
+    event.conversationId,
+    ctx.conversationId,
+    process.env.SUPERCOMPRESS_SESSION_ID,
+  ];
+  for (const c of candidates) {
+    if (c != null && String(c).trim()) {
+      if (lib?.resolveSessionId) {
+        return lib.resolveSessionId({
+          sessionId: c,
+          fallback: "none",
+        });
+      }
+      return String(c).replace(/[^\w.-]+/g, "_").slice(0, 80);
+    }
   }
-  const raw =
-    event.sessionId ||
-    ctx.sessionId ||
-    event.sessionKey ||
-    ctx.sessionKey ||
-    process.env.SUPERCOMPRESS_SESSION_ID ||
-    "openclaw";
-  return String(raw).replace(/[^\w.-]+/g, "_").slice(0, 80);
+  return null;
 }
 
 export default definePluginEntry({
@@ -126,18 +137,25 @@ export default definePluginEntry({
 
         let text = extractText(event?.result);
         if (text.length < MIN_CHARS) return;
-        const clipped = text.length > MAX_IN ? text.slice(0, MAX_IN) : text;
+        // Soft total bound only — shared chunker splits to API 120k; do not discard mid-dump.
+        const bounded = text.length > MAX_IN ? text.slice(0, MAX_IN) : text;
 
         const lib = loadLib();
         if (!lib?.compressIncremental || !lib?.writeInbox) return;
 
         const sessionId = resolveSessionId(event, ctx, lib);
+        if (!sessionId) {
+          logger.warn?.(
+            "[supercompress] skipping tool compress — no OpenClaw session/conversation id (refusing shared cwd inbox)"
+          );
+          return;
+        }
         const query =
           `Compress new ${toolName || "tool"} output for the current OpenClaw task. ` +
           "Preserve code, paths, errors, numbers, and decisions.";
 
         const result = await lib.compressIncremental({
-          context: clipped,
+          context: bounded,
           query,
           codingAgent: "OpenClaw",
           sessionId,
@@ -166,6 +184,7 @@ export default definePluginEntry({
       async (event, ctx) => {
         const lib = loadLib();
         const sessionId = resolveSessionId(event || {}, ctx || {}, lib);
+        if (!sessionId) return;
         const digest = lib?.readInboxDigest
           ? lib.readInboxDigest(sessionId)
           : "";

--- a/packages/proxy/test/agent-plugins.js
+++ b/packages/proxy/test/agent-plugins.js
@@ -114,8 +114,6 @@ if (typeof lib.compactSessionMemory !== "function") {
 if (lib.chunkText("x".repeat(250000), 120000).length !== 3) {
   throw new Error("chunkText should split above API max");
 }
-const idKey = lib.stableIdempotencyKey({ sessionId: "s1", context: "abc", mode: "compiler" });
-if (!/^sc_[a-f0-9]{40}$/.test(idKey)) throw new Error("bad stable idempotency key: " + idKey);
 
 // Plugin source must not hardcode ~/.supercompress/inbox/latest.md
 const pluginAsset = fs.readFileSync(
@@ -127,6 +125,33 @@ if (pluginAsset.includes(".supercompress/inbox/latest.md")) {
 }
 if (!/readInboxDigest/.test(pluginAsset)) {
   throw new Error("OpenClaw plugin must use session readInboxDigest");
+}
+
+const idKey = lib.stableIdempotencyKey({
+  sessionId: "s1",
+  context: "abc",
+  mode: "compiler",
+  query: "do the thing",
+});
+if (!/^sc_[a-f0-9]{40}$/.test(idKey)) throw new Error("bad stable idempotency key: " + idKey);
+const idKey2 = lib.stableIdempotencyKey({
+  sessionId: "s1",
+  context: "abc",
+  mode: "compiler",
+  query: "different task",
+});
+if (idKey === idKey2) throw new Error("stable idempotency key must include query");
+if (lib.resolveSessionId({ fallback: "none" }) != null) {
+  throw new Error("fallback=none must return null without session id");
+}
+if (!String(lib.resolveSessionId({ fallback: "ephemeral" }) || "").startsWith("ephemeral_")) {
+  throw new Error("fallback=ephemeral must mint ephemeral session id");
+}
+if (!/1_200_000|1200000/.test(pluginAsset) && /180000/.test(pluginAsset)) {
+  throw new Error("OpenClaw plugin still hard-clips at 180k before chunker");
+}
+if (!/no OpenClaw session/.test(pluginAsset)) {
+  throw new Error("OpenClaw plugin must refuse cwd fallback when session id missing");
 }
 
 // Custom plugin: no --config → defaults, always installs, writes AGENTS.md


### PR DESCRIPTION
## Summary
- **Replay, don’t recompute:** same `Idempotency-Key` + fingerprint returns the stored compress response (`idempotent_replay`) instead of compressing again for free.
- **Durable 600/hr:** rate-limit hit id is the client Idempotency-Key only (identical payloads with different keys each count).
- **Billing vs tracing:** ignore `X-Request-Id` for billing idempotency.
- **Hooks:** `stableIdempotencyKey` includes normalized query; partial chunk failures stay retryable; soft 1.2M total cap (chunker handles 120k); OpenClaw refuses cwd fallback when session id is missing.
- **Email campaigns:** document canonical private repo https://github.com/Supercompress/email-campaigns (already out of OSS).

Also notes: security PR #52 already merged.

## Test plan
- [x] `node packages/proxy/test/agent-plugins.js`
- [x] `node api/_lib/billing-ledger.test.js`
- [x] `node scripts/check-no-pii.js`
- [ ] After deploy: same Idempotency-Key + payload → second call returns `idempotent_replay: true` with no new burn
- [ ] After deploy: two different keys, same payload → two durable rate-limit hits

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds stored-response replay for keyed compression requests, changes durable rate-limit hit identity, and improves large-output/session handling in the proxy hooks.
- Stores sanitized compression responses alongside billing usage and replays matching keyed requests.
- Counts distinct client idempotency keys separately in the durable hourly limiter.
- Extends hook chunking to a soft 1.2M-character bound and keeps partial failures retryable.
- Prevents OpenClaw from sharing a cwd-derived inbox when no session identifier is available.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until already-paid replays bypass current billing eligibility checks and analytics are restored to post-billing ordering.

A depleted account cannot retrieve a response it already paid for, while requests that ultimately fail billing can still be recorded in activity and coding-agent analytics.

**Files Needing Attention:** api/v1/compress.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/v1/compress.js | Adds replay and relocates billing, but current quota checks can block paid replays and analytics now run before billing succeeds. |
| api/_lib/billing-ledger.js | Persists a bounded replay payload in billing usage rows and returns it on existing transactions. |
| api/_lib/rate-limit-durable.js | Documents client idempotency keys as durable hit identities while preserving transactional counting. |
| packages/proxy/src/cursor-hooks/compress-prompt-lib.js | Includes normalized query in stable keys, raises the aggregate chunk bound, and preserves retryability after partial failures. |
| packages/proxy/src/openclaw-hooks/plugin/index.js | Refuses shared fallback session storage and accepts larger tool output for downstream chunking. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Compress as /api/v1/compress
  participant Ledger as Billing ledger
  participant Analytics
  Client->>Compress: POST + Idempotency-Key
  Compress->>Ledger: Check current usage limit
  alt Current account is blocked
    Ledger-->>Compress: Quota or credits exhausted
    Compress-->>Client: 402 before replay lookup
  else Account currently allowed
    Compress->>Ledger: Lookup stored response
    alt Replay exists
      Ledger-->>Compress: Stored response
      Compress-->>Client: 200 idempotent replay
    else New request
      Compress->>Compress: Compress payload
      Compress->>Analytics: Record activity/agent usage
      Compress->>Ledger: Apply durable usage burn
      Ledger-->>Compress: Success or billing failure
      Compress-->>Client: 200 or billing error
    end
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix compress idempotency replay, rate-li..."](https://github.com/supercompress/supercompress/commit/bbbbeafaffa074a4aab06f2f3efb0d86ff80fd98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52094397)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->