### PR TITLE
Ship /analytics with dither charts and meter fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           node --check packages/proxy/src/server.js
       - name: Billing ledger unit tests
         run: node api/_lib/billing-ledger.test.js
+      - name: Analytics aggregation unit tests
+        run: node web/assets/js/analytics-data.test.js
       - name: Proxy package tests
         run: |
           cd packages/proxy

--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -623,11 +623,20 @@ async function reconcileKeyUsageGap(ownerUid, keys, usageMap, accountUsage) {
   const gapReqs = Math.max(0, (accountUsage.requests || 0) - sumReqs);
   const gapOut = Math.max(0, (accountUsage.tokens_out || 0) - sumOut);
   const gapSaved = Math.max(0, (accountUsage.tokens_saved || 0) - sumSaved);
-  const day = `reconcile-${accountUsage.month || new Date().toISOString().slice(0, 7)}`;
+  // ISO day so analytics charts can plot the gap. Once-per-month via reconciled flag.
+  const day = new Date().toISOString().slice(0, 10);
+  const month = String(accountUsage.month || day.slice(0, 7));
 
   const next = { ...(usageMap || {}) };
   const prev = next[target.id] || emptyKeySnap();
   const byDay = { ...(prev.by_day || {}) };
+  const alreadyReconciled = Object.entries(byDay).some(([k, v]) => {
+    if (!v || !v.reconciled) return false;
+    if (k === `reconcile-${month}`) return true;
+    return String(k).startsWith(`${month}-`);
+  });
+  if (alreadyReconciled) return usageMap;
+
   byDay[day] = {
     key_id: target.id,
     requests: (byDay[day]?.requests || 0) + gapReqs,
@@ -655,8 +664,12 @@ async function reconcileKeyUsageGap(ownerUid, keys, usageMap, accountUsage) {
         const keysMap = data.keys && typeof data.keys === "object" ? { ...data.keys } : {};
         const prevRec = keysMap[target.id] || {};
         const prevDays = { ...(prevRec.by_day || {}) };
-        if (prevDays[day]?.reconciled) {
-          // Already reconciled this month — don't double-apply.
+        const txAlready = Object.entries(prevDays).some(([k, v]) => {
+          if (!v || !v.reconciled) return false;
+          if (k === `reconcile-${month}`) return true;
+          return String(k).startsWith(`${month}-`);
+        });
+        if (txAlready) {
           return;
         }
         prevDays[day] = {

--- a/api/account.js
+++ b/api/account.js
@@ -366,6 +366,15 @@ async function handleUsage(req, res) {
       agentTotal.tokens_saved
     );
 
+    // Always expose the same maxed meter as totals — clients (CLI, analytics)
+    // must not see account_usage:null while total_* is non-zero.
+    const account_usage = {
+      month,
+      requests: total_requests,
+      tokens_in: total_tokens_in,
+      tokens_out: total_tokens_out,
+      tokens_saved: total_tokens_saved,
+    };
     return json(res, 200, {
       owner_uid: ownerUid,
       total_requests,
@@ -374,7 +383,8 @@ async function handleUsage(req, res) {
       total_tokens_saved,
       coding_agent_usage: normalizeAgentUsage(usage),
       coding_agent_totals: agentTotal,
-      account_usage: ledgerMatchesMonth
+      account_usage,
+      ledger_usage: ledgerMatchesMonth
         ? {
             month,
             requests: Number(ledger.requests || 0),

--- a/api/keys.js
+++ b/api/keys.js
@@ -20,7 +20,29 @@ module.exports = async (req, res) => {
       try {
         agent_plugin = await loadAgentPluginLink(user.uid);
       } catch (_) {}
-      return json(res, 200, { ...keys, coding_agent_usage, agent_plugin });
+      // Prefer max(ledger/claims, coding-agent totals) so analytics KPIs never
+      // under-report when the billing ledger lags agent metering.
+      let account_usage = keys.account_usage || null;
+      const agentTotals = Object.values(coding_agent_usage || {}).reduce(
+        (acc, snap) => ({
+          requests: acc.requests + (snap.requests || 0),
+          tokens_in: acc.tokens_in + (snap.tokens_in || 0),
+          tokens_out: acc.tokens_out + (snap.tokens_out || 0),
+          tokens_saved: acc.tokens_saved + (snap.tokens_saved || 0),
+        }),
+        { requests: 0, tokens_in: 0, tokens_out: 0, tokens_saved: 0 }
+      );
+      if (agentTotals.tokens_in > 0 || agentTotals.requests > 0) {
+        const month = new Date().toISOString().slice(0, 7);
+        account_usage = {
+          month: (account_usage && account_usage.month) || month,
+          requests: Math.max(Number(account_usage?.requests || 0), agentTotals.requests),
+          tokens_in: Math.max(Number(account_usage?.tokens_in || 0), agentTotals.tokens_in),
+          tokens_out: Math.max(Number(account_usage?.tokens_out || 0), agentTotals.tokens_out),
+          tokens_saved: Math.max(Number(account_usage?.tokens_saved || 0), agentTotals.tokens_saved),
+        };
+      }
+      return json(res, 200, { ...keys, account_usage, coding_agent_usage, agent_plugin });
     }
 
     if (req.method === "POST") {

--- a/vercel.json
+++ b/vercel.json
@@ -1229,6 +1229,10 @@
       "destination": "/dashboard.html"
     },
     {
+      "source": "/analytics",
+      "destination": "/analytics.html"
+    },
+    {
       "source": "/playground",
       "destination": "/playground.html"
     },

--- a/web/analytics.html
+++ b/web/analytics.html
@@ -1,0 +1,685 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SuperCompress · Analytics</title>
+  <meta name="description" content="Token savings analytics — daily charts, coding agents, and API key breakdown for your SuperCompress account." />
+  <meta name="robots" content="noindex" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preload" href="https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/Geist-Regular.woff2" as="font" type="font/woff2" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet" />
+  <style>
+    @font-face {
+      font-family: "Geist";
+      src: url("https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/Geist-Regular.woff2") format("woff2");
+      font-weight: 400;
+      font-style: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: "Geist";
+      src: url("https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/Geist-Medium.woff2") format("woff2");
+      font-weight: 500;
+      font-style: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: "Geist";
+      src: url("https://cdn.jsdelivr.net/npm/geist@1.3.1/dist/fonts/geist-sans/Geist-Medium.woff2") format("woff2");
+      font-weight: 600;
+      font-style: normal;
+      font-display: swap;
+    }
+
+    :root {
+      --brand: #0566ff;
+      --brand-soft: #eef4ff;
+      --brand-ink: #0039a6;
+      --ink: #171717;
+      --muted: #5c5a55;
+      --faint: #9a9892;
+      --line: #e6e7eb;
+      --paper: #f4f5f8;
+      --card: #ffffff;
+      --serif: "Platypi", "EB Garamond", Georgia, serif;
+      --sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      --shadow: 0 1px 2px rgba(23, 23, 23, 0.04);
+      --radius: 14px;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; min-height: 100%; }
+    body {
+      font-family: var(--sans);
+      color: var(--ink);
+      background:
+        radial-gradient(1200px 600px at 8% -10%, rgba(5, 102, 255, 0.10), transparent 55%),
+        radial-gradient(900px 500px at 100% 0%, rgba(5, 102, 255, 0.06), transparent 50%),
+        linear-gradient(180deg, #f7f8fb 0%, var(--paper) 40%, #eef0f4 100%);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      opacity: 0.03;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Crect width='1' height='1' fill='%23000000'/%3E%3Crect x='4' y='4' width='1' height='1' fill='%23000000'/%3E%3C/svg%3E");
+      background-size: 8px 8px;
+      z-index: 0;
+    }
+
+    .wrap {
+      position: relative;
+      z-index: 1;
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 36px 24px 80px;
+    }
+
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 36px;
+      animation: rise 0.55s ease both;
+    }
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      text-decoration: none;
+      color: var(--ink);
+    }
+    .brand img { width: 28px; height: 28px; display: block; }
+    .brand-name {
+      font-family: var(--serif);
+      font-size: 20px;
+      font-weight: 500;
+      letter-spacing: -0.02em;
+    }
+    .brand-name span { color: var(--brand); }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 11px;
+      border-radius: 999px;
+      background: var(--brand-soft);
+      color: var(--brand);
+      font-family: var(--sans);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+    .pill::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--brand);
+      box-shadow: 0 0 0 3px rgba(5, 102, 255, 0.18);
+    }
+    .pill--live {
+      background: #e8f7ee;
+      color: #0f7a3a;
+    }
+    .pill--live::before {
+      background: #16a34a;
+      box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.18);
+    }
+    .pill--demo {
+      background: #f4f1ea;
+      color: #7a6a4a;
+    }
+    .pill--demo::before {
+      background: #c4a574;
+      box-shadow: 0 0 0 3px rgba(196, 165, 116, 0.22);
+    }
+    .auth-bar {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 10px;
+      margin: -8px 0 20px;
+      animation: rise 0.55s 0.04s ease both;
+    }
+    .auth-bar button {
+      font-family: var(--sans);
+      font-size: 13px;
+      font-weight: 600;
+      padding: 8px 14px;
+      border-radius: 10px;
+      border: 0.5px solid var(--line);
+      background: var(--card);
+      color: var(--ink);
+      cursor: pointer;
+      box-shadow: var(--shadow);
+    }
+    .auth-bar button.primary {
+      background: var(--brand);
+      border-color: var(--brand);
+      color: #fff;
+    }
+    .auth-bar .auth-note {
+      font-size: 12.5px;
+      color: var(--muted);
+    }
+    .hero h1 .bayer,
+    .hero p .bayer {
+      color: var(--brand);
+      font-style: italic;
+      font-weight: 400;
+    }
+
+    .hero {
+      margin-bottom: 28px;
+      animation: rise 0.65s 0.05s ease both;
+    }
+    .eyebrow {
+      margin: 0 0 10px;
+      font-family: var(--sans);
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--brand);
+    }
+    .hero h1 {
+      margin: 0;
+      font-family: var(--serif);
+      font-weight: 300;
+      font-size: clamp(36px, 5vw, 52px);
+      line-height: 1.05;
+      letter-spacing: -0.03em;
+    }
+    .hero p {
+      margin: 12px 0 0;
+      max-width: 46ch;
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.55;
+      color: var(--muted);
+    }
+
+    /* ── KPI strip — dither wash only, no mini charts ── */
+    .kpi-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .kpi {
+      position: relative;
+      min-height: 132px;
+      padding: 18px 18px 16px;
+      border: 0.5px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--card);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      isolation: isolate;
+      animation: rise 0.7s ease both;
+    }
+    .kpi:nth-child(1) { animation-delay: 0.08s; }
+    .kpi:nth-child(2) { animation-delay: 0.12s; }
+    .kpi:nth-child(3) { animation-delay: 0.16s; }
+    .kpi:nth-child(4) { animation-delay: 0.2s; }
+    .kpi--cut {
+      border-color: rgba(5, 102, 255, 0.28);
+      background:
+        linear-gradient(165deg, rgba(5, 102, 255, 0.08), transparent 58%),
+        var(--card);
+    }
+    .kpi--cut .kpi-n { color: var(--brand); }
+    .kpi-wash {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      opacity: 1;
+      mask-image: linear-gradient(115deg, transparent 18%, #000 72%);
+      -webkit-mask-image: linear-gradient(115deg, transparent 18%, #000 72%);
+    }
+    .kpi-wash canvas,
+    .dk-wash-canvas {
+      position: absolute !important;
+      inset: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      display: block;
+    }
+    .kpi-body {
+      position: relative;
+      z-index: 1;
+    }
+    .kpi-l {
+      display: block;
+      font-family: var(--sans);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+    .kpi-n {
+      display: block;
+      margin-top: 12px;
+      font-family: var(--serif);
+      font-size: clamp(30px, 3.5vw, 38px);
+      font-weight: 300;
+      letter-spacing: -0.03em;
+      line-height: 1;
+      font-variant-numeric: tabular-nums;
+    }
+    .kpi-s {
+      display: block;
+      margin-top: 12px;
+      max-width: 18ch;
+      font-family: var(--sans);
+      font-size: 12.5px;
+      line-height: 1.35;
+      color: var(--muted);
+    }
+
+    .charts {
+      display: grid;
+      grid-template-columns: 1.15fr 0.85fr;
+      gap: 14px;
+      animation: rise 0.75s 0.18s ease both;
+    }
+    .panel {
+      padding: 18px 18px 16px;
+      border: 0.5px solid var(--line);
+      border-radius: 16px;
+      background: var(--card);
+      box-shadow: var(--shadow);
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+    .panel--wide { grid-column: 1 / -1; }
+    .panel-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 12px;
+      margin-bottom: 14px;
+    }
+    .panel-head h2 {
+      margin: 0;
+      font-family: var(--serif);
+      font-size: 18px;
+      font-weight: 400;
+      letter-spacing: -0.02em;
+    }
+    .panel-head p {
+      margin: 4px 0 0;
+      font-family: var(--sans);
+      font-size: 12.5px;
+      color: var(--muted);
+    }
+    .chip {
+      flex-shrink: 0;
+      padding: 4px 9px;
+      border-radius: 999px;
+      background: var(--brand-soft);
+      color: var(--brand-ink);
+      font-family: var(--sans);
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    .chip--cut {
+      background: var(--brand-soft);
+      color: var(--brand-ink);
+    }
+
+    .chart-well {
+      position: relative;
+      width: 100%;
+      height: 260px;
+      border-radius: 12px;
+      overflow: hidden;
+      isolation: isolate;
+      contain: paint;
+      background:
+        radial-gradient(90% 80% at 0% 0%, rgba(5, 102, 255, 0.07), transparent 55%),
+        radial-gradient(70% 60% at 100% 100%, rgba(5, 102, 255, 0.05), transparent 50%),
+        #f7f8fb;
+      border: 0.5px solid rgba(5, 102, 255, 0.06);
+      transition: box-shadow 0.2s ease;
+    }
+    .chart-well.dk-hovering {
+      box-shadow: inset 0 0 0 1px rgba(5, 102, 255, 0.18);
+    }
+    .dk-tip {
+      position: absolute;
+      z-index: 5;
+      min-width: 118px;
+      max-width: 220px;
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(15, 23, 42, 0.92);
+      color: #f8fafc;
+      font-family: var(--sans);
+      font-size: 12px;
+      line-height: 1.35;
+      pointer-events: none;
+      opacity: 0;
+      transform: translateY(0);
+      transition: opacity 0.12s ease;
+      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+      backdrop-filter: blur(8px);
+    }
+    .dk-tip strong {
+      display: block;
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(148, 163, 184, 0.95);
+      margin-bottom: 4px;
+    }
+    .dk-tip span {
+      display: block;
+      color: rgba(226, 232, 240, 0.92);
+      margin-bottom: 2px;
+    }
+    .dk-tip em {
+      display: block;
+      font-style: normal;
+      font-family: var(--serif);
+      font-size: 18px;
+      font-weight: 400;
+      letter-spacing: -0.02em;
+      color: #fff;
+    }
+    .chart-well--lg { height: 300px; }
+    .chart-well--sm { height: 168px; }
+    .dk-chart {
+      position: relative;
+      width: 100%;
+      overflow: hidden;
+    }
+    .dk-chart canvas {
+      position: absolute;
+      inset: 0;
+      width: 100% !important;
+      height: 100% !important;
+      display: block;
+    }
+    .chart-well.dk-chart { height: 260px; }
+    .chart-well--lg.dk-chart { height: 300px; }
+    .chart-well--sm.dk-chart { height: 168px; }
+
+    /* Ranked agent / key rows — no pie chart */
+    .rank-list {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+    .rank-row {
+      display: grid;
+      grid-template-columns: 28px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      border-radius: 12px;
+      background: #f7f8fb;
+      border: 0.5px solid rgba(5, 102, 255, 0.06);
+      animation: rise 0.55s ease both;
+      transition: transform 0.18s ease, background 0.18s ease;
+    }
+    .rank-row:hover {
+      background: #f0f4ff;
+      transform: translateY(-1px);
+    }
+    .rank-row:nth-child(1) { animation-delay: 0.22s; }
+    .rank-row:nth-child(2) { animation-delay: 0.28s; }
+    .rank-row:nth-child(3) { animation-delay: 0.34s; }
+    .rank-row:nth-child(4) { animation-delay: 0.4s; }
+    .rank-idx {
+      width: 28px;
+      height: 28px;
+      border-radius: 8px;
+      display: grid;
+      place-items: center;
+      font-family: var(--serif);
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--brand);
+      background: var(--brand-soft);
+    }
+    .rank-main { min-width: 0; }
+    .rank-name {
+      margin: 0;
+      font-family: var(--sans);
+      font-size: 14px;
+      font-weight: 500;
+      letter-spacing: -0.01em;
+      color: var(--ink);
+    }
+    .rank-meta {
+      margin: 2px 0 8px;
+      font-family: var(--sans);
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .rank-track {
+      position: relative;
+      height: 8px;
+      border-radius: 999px;
+      background: rgba(5, 102, 255, 0.08);
+      overflow: hidden;
+    }
+    .rank-fill {
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: 0;
+      border-radius: inherit;
+      background:
+        repeating-linear-gradient(
+          -45deg,
+          rgba(5, 102, 255, 0.95),
+          rgba(5, 102, 255, 0.95) 1px,
+          rgba(94, 156, 255, 0.55) 1px,
+          rgba(94, 156, 255, 0.55) 3px
+        );
+      transition: width 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+    }
+    .rank-val {
+      font-family: var(--serif);
+      font-size: 20px;
+      font-weight: 300;
+      letter-spacing: -0.02em;
+      color: var(--ink);
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .rank-val small {
+      display: block;
+      margin-top: 2px;
+      font-family: var(--sans);
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--muted);
+      letter-spacing: 0.02em;
+      text-align: right;
+    }
+
+    .key-list .rank-row {
+      grid-template-columns: minmax(0, 1fr) auto;
+    }
+    .key-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--brand);
+      box-shadow: 0 0 0 3px rgba(5, 102, 255, 0.14);
+      display: inline-block;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+    .key-list .rank-name {
+      display: flex;
+      align-items: center;
+    }
+
+    .footnote {
+      margin-top: 22px;
+      font-family: var(--sans);
+      font-size: 12px;
+      color: var(--faint);
+      text-align: center;
+      animation: rise 0.8s 0.25s ease both;
+    }
+    .footnote code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      color: var(--muted);
+    }
+
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to { opacity: 1; transform: none; }
+    }
+
+    @media (max-width: 900px) {
+      .kpi-grid { grid-template-columns: repeat(2, 1fr); }
+      .charts { grid-template-columns: 1fr; }
+      .panel--wide { grid-column: auto; }
+    }
+    @media (max-width: 520px) {
+      .kpi-grid { grid-template-columns: 1fr; }
+      .topbar { flex-wrap: wrap; }
+      .rank-row { grid-template-columns: 28px minmax(0, 1fr); }
+      .rank-val { grid-column: 2; justify-self: start; }
+      .key-list .rank-row { grid-template-columns: minmax(0, 1fr); }
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="topbar">
+      <a class="brand" href="/">
+        <img src="/assets/img/logo-chevrons.png" alt="" width="28" height="28" />
+        <span class="brand-name">Super<span>Compress</span></span>
+      </a>
+      <div style="display:flex;align-items:center;gap:12px;">
+        <a href="/dashboard" style="font-family:var(--sans);font-size:13px;font-weight:600;color:var(--muted);text-decoration:none;">Dashboard</a>
+        <span class="pill pill--demo" id="data-pill">Loading…</span>
+      </div>
+    </header>
+
+    <div class="auth-bar" id="auth-bar">
+      <span class="auth-note" id="auth-note">Sign in to load your real usage.</span>
+      <button type="button" class="primary" id="btn-signin">Sign in with Google</button>
+    </div>
+
+    <section class="hero">
+      <p class="eyebrow">Dashboard analytics</p>
+      <h1>See what you cut.</h1>
+      <p>
+        Token savings, <span class="bayer">in Bayer</span> — real meter from your keys and coding agents, last 30 days.
+      </p>
+    </section>
+
+    <div class="kpi-grid">
+      <article class="kpi kpi--cut">
+        <div class="kpi-wash" id="wash-cut" aria-hidden="true"></div>
+        <div class="kpi-body">
+          <span class="kpi-l">Cut</span>
+          <strong class="kpi-n" id="kpi-cut">0%</strong>
+          <span class="kpi-s" id="kpi-cut-sub">—</span>
+        </div>
+      </article>
+      <article class="kpi">
+        <div class="kpi-wash" id="wash-saved" aria-hidden="true"></div>
+        <div class="kpi-body">
+          <span class="kpi-l">Saved</span>
+          <strong class="kpi-n" id="kpi-saved">0</strong>
+          <span class="kpi-s">this month · billing meter</span>
+        </div>
+      </article>
+      <article class="kpi">
+        <div class="kpi-wash" id="wash-in" aria-hidden="true"></div>
+        <div class="kpi-body">
+          <span class="kpi-l">Input</span>
+          <strong class="kpi-n" id="kpi-in">0</strong>
+          <span class="kpi-s">tokens compressed in</span>
+        </div>
+      </article>
+      <article class="kpi">
+        <div class="kpi-wash" id="wash-req" aria-hidden="true"></div>
+        <div class="kpi-body">
+          <span class="kpi-l">Requests</span>
+          <strong class="kpi-n" id="kpi-req">0</strong>
+          <span class="kpi-s" id="kpi-req-sub">—</span>
+        </div>
+      </article>
+    </div>
+
+    <div class="charts">
+      <section class="panel panel--wide">
+        <header class="panel-head">
+          <div>
+            <h2>Tokens saved</h2>
+            <p>Daily · last 30 days · hover a day</p>
+          </div>
+          <span class="chip chip--cut" id="chip-delta">—</span>
+        </header>
+        <div class="chart-well chart-well--lg" id="area"></div>
+      </section>
+
+      <section class="panel">
+        <header class="panel-head">
+          <div>
+            <h2>Requests</h2>
+            <p>Compress calls · last 30 days</p>
+          </div>
+          <span class="chip">30 days</span>
+        </header>
+        <div class="chart-well" id="bars"></div>
+      </section>
+
+      <section class="panel">
+        <header class="panel-head">
+          <div>
+            <h2>By coding agent</h2>
+            <p>Share of tokens saved</p>
+          </div>
+        </header>
+        <ol class="rank-list" id="agents"></ol>
+      </section>
+
+      <section class="panel panel--wide">
+        <header class="panel-head">
+          <div>
+            <h2>Key breakdown</h2>
+            <p>Tokens saved per API key</p>
+          </div>
+        </header>
+        <ul class="rank-list key-list" id="keys"></ul>
+      </section>
+    </div>
+
+    <p class="footnote">
+      Signed-in usage from your SuperCompress account · last 30 days
+    </p>
+  </div>
+
+    <script src="/assets/js/dither-kit-lite.js?v=10"></script>
+  <script src="/assets/js/analytics-data.js?v=1"></script>
+  <script src="/assets/js/analytics-page.js?v=2"></script>
+
+</body>
+</html>

--- a/web/assets/js/analytics-data.js
+++ b/web/assets/js/analytics-data.js
@@ -1,0 +1,292 @@
+/**
+ * Pure analytics aggregation for /analytics (and unit tests).
+ * Browser: window.SCAnalyticsData
+ * Node: module.exports
+ */
+(function (root) {
+  "use strict";
+
+  const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+  function dayKeys(n = 30) {
+    const out = [];
+    for (let i = n - 1; i >= 0; i--) {
+      const d = new Date();
+      d.setHours(12, 0, 0, 0);
+      d.setDate(d.getDate() - i);
+      out.push(d.toISOString().slice(0, 10));
+    }
+    return out;
+  }
+
+  function labelDay(iso) {
+    const d = new Date(iso + "T12:00:00");
+    return {
+      short: `${d.getMonth() + 1}/${d.getDate()}`,
+      full: d.toLocaleDateString(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      }),
+    };
+  }
+
+  function emptyDay() {
+    return { tokens_saved: 0, tokens_in: 0, requests: 0 };
+  }
+
+  /** Ignore reconcile-* and other non-ISO day keys so charts stay honest. */
+  function isChartDay(day) {
+    return ISO_DAY.test(String(day || ""));
+  }
+
+  function sumAgents(codingAgentUsage) {
+    let tokens_in = 0;
+    let tokens_saved = 0;
+    let tokens_out = 0;
+    let requests = 0;
+    for (const a of Object.values(codingAgentUsage || {})) {
+      tokens_in += Number(a.tokens_in || 0);
+      tokens_saved += Number(a.tokens_saved || 0);
+      tokens_out += Number(a.tokens_out || 0);
+      requests += Number(a.requests || 0);
+    }
+    return { tokens_in, tokens_saved, tokens_out, requests };
+  }
+
+  function sumKeys(usage) {
+    let tokens_in = 0;
+    let tokens_saved = 0;
+    let tokens_out = 0;
+    let requests = 0;
+    for (const snap of Object.values(usage || {})) {
+      tokens_in += Number(snap.total_tokens_in || 0);
+      tokens_saved += Number(snap.total_tokens_saved || 0);
+      tokens_out += Number(snap.total_tokens_out || 0);
+      requests += Number(snap.total_requests || 0);
+    }
+    return { tokens_in, tokens_saved, tokens_out, requests };
+  }
+
+  /**
+   * Build chart + KPI bundle from /api/keys payload (or demo shape).
+   */
+  function aggregateUsage(payload) {
+    const keys = dayKeys(30);
+    const byDay = Object.fromEntries(keys.map((k) => [k, emptyDay()]));
+    const usage = payload.usage || {};
+    const keyRows = [];
+
+    for (const k of payload.keys || []) {
+      const snap = usage[k.id] || {};
+      keyRows.push({
+        label: k.name || k.prefix || "Key",
+        value: Number(snap.total_tokens_saved || 0),
+      });
+      for (const [day, rec] of Object.entries(snap.by_day || {})) {
+        if (!isChartDay(day) || !byDay[day]) continue;
+        byDay[day].tokens_saved += Number(rec.tokens_saved || 0);
+        byDay[day].tokens_in += Number(rec.tokens_in || 0);
+        byDay[day].requests += Number(rec.requests || 0);
+      }
+    }
+
+    const agents = Object.entries(payload.coding_agent_usage || {})
+      .map(([label, a]) => ({
+        label,
+        value: Number(a.tokens_saved || 0),
+        color: "brand",
+      }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 6);
+
+    const daySaved = Object.values(byDay).reduce((s, d) => s + d.tokens_saved, 0);
+    if (!agents.length && daySaved > 0) {
+      agents.push({ label: "API / other", value: daySaved, color: "orange" });
+    }
+
+    const keyTotal = keyRows.reduce((s, k) => s + k.value, 0);
+    const keysOut = keyTotal
+      ? keyRows.sort((a, b) => b.value - a.value).slice(0, 8)
+      : [];
+
+    return {
+      live: true,
+      byDay,
+      keys: keysOut,
+      agents,
+      account: payload.account_usage || null,
+      keyTotals: sumKeys(usage),
+      agentTotals: sumAgents(payload.coding_agent_usage),
+    };
+  }
+
+  function demoBundle() {
+    const keys = dayKeys(30);
+    const byDay = {};
+    keys.forEach((iso, i) => {
+      const base = 18000 + Math.sin(i / 2.2) * 7000 + i * 1400;
+      const spike = i > 22 ? 1.55 : i > 14 ? 1.2 : 1;
+      const saved = Math.max(0, Math.round(base * spike));
+      const tin = Math.round(saved / 0.55);
+      byDay[iso] = {
+        tokens_saved: saved,
+        tokens_in: tin,
+        requests: Math.max(
+          0,
+          Math.round(28 + Math.sin(i / 1.8) * 16 + i * 1.35 + (i > 22 ? 18 : 0))
+        ),
+      };
+    });
+    return {
+      live: false,
+      byDay,
+      keys: [
+        { label: "Production", value: 0.71 },
+        { label: "Coding Agent", value: 0.22 },
+        { label: "Dev", value: 0.07 },
+      ],
+      agents: [
+        { label: "Cursor", value: 0.62, color: "brand" },
+        { label: "Codex", value: 0.22, color: "sky" },
+        { label: "API / other", value: 0.16, color: "orange" },
+      ],
+      account: null,
+      keyTotals: null,
+      agentTotals: null,
+    };
+  }
+
+  function meterFromBundle(bundle) {
+    const keys = dayKeys(30);
+    let daySaved = 0;
+    let dayIn = 0;
+    let dayReq = 0;
+    for (const iso of keys) {
+      const d = bundle.byDay[iso] || emptyDay();
+      daySaved += d.tokens_saved;
+      dayIn += d.tokens_in;
+      dayReq += d.requests;
+    }
+
+    const acct = bundle.account || {};
+    const keyT = bundle.keyTotals || {};
+    const agentT = bundle.agentTotals || {};
+
+    const saved = Math.max(
+      daySaved,
+      Number(acct.tokens_saved || 0),
+      Number(keyT.tokens_saved || 0),
+      Number(agentT.tokens_saved || 0)
+    );
+    const tin = Math.max(
+      dayIn,
+      Number(acct.tokens_in || 0),
+      Number(keyT.tokens_in || 0),
+      Number(agentT.tokens_in || 0)
+    );
+    const req = Math.max(
+      dayReq,
+      Number(acct.requests || 0),
+      Number(keyT.requests || 0),
+      Number(agentT.requests || 0)
+    );
+
+    // If we only have month totals (no ISO by_day), park them on today so the chart isn't blank.
+    if (daySaved === 0 && dayReq === 0 && (saved > 0 || req > 0)) {
+      const today = keys[keys.length - 1];
+      const ratio = tin > 0 ? saved / tin : 0.55;
+      bundle.byDay[today] = {
+        tokens_saved: saved,
+        tokens_in: tin || Math.round(saved / Math.max(ratio, 0.01)),
+        requests: req || 1,
+      };
+      return meterFromBundle({ ...bundle, account: null, keyTotals: null, agentTotals: null });
+    }
+
+    return { saved, tin, req, daySaved, dayIn, dayReq };
+  }
+
+  function bundleToSeries(bundle) {
+    const keys = dayKeys(30);
+    const meter = meterFromBundle(bundle);
+    const areaData = keys.map((iso) => {
+      const L = labelDay(iso);
+      return { x: L.full, y: bundle.byDay[iso]?.tokens_saved || 0, iso };
+    });
+    const reqs = keys.map((iso) => {
+      const L = labelDay(iso);
+      return {
+        label: L.short,
+        full: L.full,
+        value: bundle.byDay[iso]?.requests || 0,
+      };
+    });
+
+    const saved = meter.saved;
+    const tin = meter.tin;
+    const cut = tin > 0 ? Math.round((saved / tin) * 100) : 0;
+    const half = Math.floor(keys.length / 2);
+    const first = areaData.slice(0, half).reduce((s, d) => s + d.y, 0);
+    const second = areaData.slice(half).reduce((s, d) => s + d.y, 0);
+    let deltaLabel = "—";
+    if (first > 0) {
+      const pct = Math.round(((second - first) / first) * 100);
+      deltaLabel = `${pct >= 0 ? "+" : ""}${pct}% vs prior`;
+    } else if (second > 0) {
+      deltaLabel = meter.daySaved === 0 && saved > 0 ? "month total · daily starts next call" : "new activity";
+    }
+
+    const agents = (bundle.agents || []).map((a) =>
+      typeof a.value === "number" && a.value <= 1 && saved
+        ? { ...a, value: Math.round(saved * a.value) }
+        : a
+    );
+    const keyRows = (bundle.keys || []).map((k) =>
+      typeof k.value === "number" && k.value <= 1 && saved
+        ? { ...k, value: Math.round(saved * k.value) }
+        : k
+    );
+
+    return {
+      live: !!bundle.live,
+      areaData,
+      reqs,
+      totalSaved: saved,
+      totalIn: tin,
+      totalReq: meter.req,
+      cut,
+      activeDays: reqs.filter((r) => r.value > 0).length,
+      deltaLabel,
+      agents,
+      keys: keyRows,
+      synthesizedDay: meter.daySaved === 0 && saved > 0,
+    };
+  }
+
+  function escapeHtml(s) {
+    return String(s ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  const api = {
+    dayKeys,
+    labelDay,
+    isChartDay,
+    aggregateUsage,
+    demoBundle,
+    bundleToSeries,
+    escapeHtml,
+    sumAgents,
+    sumKeys,
+  };
+
+  root.SCAnalyticsData = api;
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/web/assets/js/analytics-data.test.js
+++ b/web/assets/js/analytics-data.test.js
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for analytics aggregation (no Firebase / DOM).
+ * Run: node web/assets/js/analytics-data.test.js
+ */
+const assert = require("assert");
+const {
+  isChartDay,
+  aggregateUsage,
+  bundleToSeries,
+  demoBundle,
+  escapeHtml,
+} = require("./analytics-data.js");
+
+assert.strictEqual(isChartDay("2026-08-11"), true);
+assert.strictEqual(isChartDay("reconcile-2026-08"), false);
+assert.strictEqual(isChartDay(""), false);
+
+const demo = bundleToSeries(demoBundle());
+assert.ok(demo.totalSaved > 0, "demo has savings");
+assert.ok(demo.cut > 0 && demo.cut <= 100, "demo cut pct");
+assert.strictEqual(demo.live, false);
+assert.ok(demo.areaData.length === 30);
+
+// Live payload with only agent totals (no by_day) must still fill KPIs + chart.
+const agentOnly = aggregateUsage({
+  keys: [{ id: "k1", name: "Coding agent", prefix: "sc_live_x" }],
+  usage: {
+    k1: {
+      total_requests: 0,
+      total_tokens_in: 0,
+      total_tokens_saved: 0,
+      by_day: {
+        "reconcile-2026-08": { tokens_saved: 99999, tokens_in: 1, requests: 1 },
+      },
+    },
+  },
+  coding_agent_usage: {
+    cursor: { requests: 12, tokens_in: 12639, tokens_saved: 6452, tokens_out: 6187 },
+  },
+  account_usage: null,
+});
+const series = bundleToSeries(agentOnly);
+assert.strictEqual(series.live, true);
+assert.strictEqual(series.totalSaved, 6452);
+assert.strictEqual(series.totalIn, 12639);
+assert.strictEqual(series.totalReq, 12);
+assert.ok(series.cut >= 50 && series.cut <= 52, `cut=${series.cut}`);
+assert.ok(
+  series.areaData.some((d) => d.y > 0),
+  "synthesizes a chart day when by_day empty / non-ISO only"
+);
+assert.ok(
+  !series.areaData.some((d) => d.y === 99999),
+  "ignores reconcile-* by_day keys"
+);
+assert.strictEqual(series.agents[0].label, "cursor");
+
+// XSS escape
+assert.strictEqual(escapeHtml(`<img src=x onerror=alert(1)>`), `&lt;img src=x onerror=alert(1)&gt;`);
+
+// Key + account max
+const withKeys = aggregateUsage({
+  keys: [{ id: "k1", name: "Production" }],
+  usage: {
+    k1: {
+      total_requests: 3,
+      total_tokens_in: 1000,
+      total_tokens_saved: 400,
+      by_day: {
+        [new Date().toISOString().slice(0, 10)]: {
+          tokens_saved: 400,
+          tokens_in: 1000,
+          requests: 3,
+        },
+      },
+    },
+  },
+  coding_agent_usage: {},
+  account_usage: { month: "2026-08", requests: 10, tokens_in: 5000, tokens_saved: 2000, tokens_out: 3000 },
+});
+const s2 = bundleToSeries(withKeys);
+assert.strictEqual(s2.totalSaved, 2000);
+assert.strictEqual(s2.totalIn, 5000);
+assert.strictEqual(s2.totalReq, 10);
+
+console.log("analytics-data.test.js: ok");

--- a/web/assets/js/analytics-page.js
+++ b/web/assets/js/analytics-page.js
@@ -1,0 +1,289 @@
+/**
+ * /analytics page boot — Firebase auth + dither charts.
+ */
+(function () {
+  "use strict";
+
+  const DATA = window.SCAnalyticsData;
+  const DK = window.DitherKitLite;
+  // Same-origin in prod; point at live API when serving static HTML locally.
+  const API_BASE =
+    /^(localhost|127\.0\.0\.1)$/i.test(location.hostname) || location.protocol === "file:"
+      ? "https://www.supercompress.dev"
+      : "";
+  const $ = (id) => document.getElementById(id);
+
+  const washes = [
+    ["wash-cut", { color: "brand", intensity: 0.88 }],
+    ["wash-saved", { color: "brand", intensity: 0.62 }],
+    ["wash-in", { color: "sky", intensity: 0.58 }],
+    ["wash-req", { color: "sky", intensity: 0.55 }],
+  ];
+
+  function animateNumber(el, to, { suffix = "", compact = false, duration = 900 } = {}) {
+    if (!el || !DK) {
+      if (el) el.textContent = (compact ? String(Math.round(to)) : String(Math.round(to))) + suffix;
+      return;
+    }
+    const t0 = performance.now();
+    const ease = (t) => 1 - Math.pow(1 - t, 3);
+    const frame = (now) => {
+      const p = Math.min(1, (now - t0) / duration);
+      const v = to * ease(p);
+      el.textContent = (compact ? DK.formatCompact(v) : String(Math.round(v))) + suffix;
+      if (p < 1) requestAnimationFrame(frame);
+    };
+    requestAnimationFrame(frame);
+  }
+
+  function paint(series) {
+    const pill = $("data-pill");
+    if (pill) {
+      pill.className = series.live ? "pill pill--live" : "pill pill--demo";
+      pill.textContent = series.live ? "Live · your account" : "Demo · sign in for live";
+    }
+
+    if ($("kpi-cut-sub")) {
+      $("kpi-cut-sub").textContent = `${DK.formatCompact(series.totalSaved)} saved · ${DK.formatCompact(series.totalIn)} in`;
+    }
+    if ($("kpi-req-sub")) {
+      $("kpi-req-sub").textContent = `${series.activeDays} active day${series.activeDays === 1 ? "" : "s"}`;
+    }
+    if ($("chip-delta")) {
+      $("chip-delta").textContent = series.deltaLabel;
+    }
+
+    animateNumber($("kpi-cut"), series.cut, { suffix: "%" });
+    animateNumber($("kpi-saved"), series.totalSaved, { compact: true });
+    animateNumber($("kpi-in"), series.totalIn, { compact: true });
+    animateNumber($("kpi-req"), series.totalReq, { compact: true });
+
+    for (const [id, opts] of washes) {
+      const el = $(id);
+      if (!el) continue;
+      DK.renderDitherWash(el, opts);
+      DK.startDitherWashLoop(el, opts);
+    }
+
+    const areaMax = Math.max(1, ...series.areaData.map((d) => d.y));
+    const reqMax = Math.max(1, ...series.reqs.map((r) => r.value));
+    const areaEl = $("area");
+    const barsEl = $("bars");
+    if (areaEl) DK.stopChartDitherLoop(areaEl);
+    if (barsEl) DK.stopChartDitherLoop(barsEl);
+
+    const areaOpts = {
+      color: "brand",
+      variant: "gradient",
+      bloom: "aura",
+      unit: "tokens",
+      tooltipTitle: "Tokens saved",
+      yMax: areaMax,
+      empty: !series.areaData.some((d) => d.y > 0),
+      emptyLabel: series.live ? "No daily savings yet" : "No data",
+    };
+    DK.animateChart((p) => {
+      DK.renderAreaChart(areaEl, {
+        ...areaOpts,
+        data: series.areaData.map((d) => ({ x: d.x, y: d.y * p })),
+        interactive: false,
+      });
+      if (p > 0.98) {
+        DK.renderAreaChart(areaEl, {
+          ...areaOpts,
+          data: series.areaData,
+          interactive: true,
+        });
+        DK.startChartDitherLoop(areaEl, {
+          kind: "area",
+          ...areaOpts,
+          data: series.areaData,
+          interactive: true,
+        });
+      }
+    }, 1100);
+
+    DK.animateChart((p) => {
+      const done = p > 0.98;
+      const barOpts = {
+        data: series.reqs.map((r) => ({ label: r.label, value: r.value, full: r.full })),
+        orientation: "vertical",
+        color: "brand",
+        variant: "gradient",
+        bloom: "aura",
+        maxBars: 30,
+        progress: done ? 1 : p,
+        yMax: reqMax,
+        unit: "requests",
+        tooltipTitle: "Requests",
+        interactive: done,
+        empty: !series.reqs.some((r) => r.value > 0),
+        emptyLabel: series.live ? "No requests yet" : "No data",
+      };
+      DK.renderBarChart(barsEl, barOpts);
+      if (done) {
+        DK.startChartDitherLoop(barsEl, { kind: "bar", ...barOpts, progress: 1, interactive: true });
+      }
+    }, 1100);
+
+    const esc = DATA.escapeHtml;
+    const agentTotal = series.agents.reduce((s, a) => s + a.value, 0) || 1;
+    if ($("agents")) {
+      $("agents").innerHTML = series.agents.length
+        ? series.agents
+            .map((a, i) => {
+              const pct = Math.round((a.value / agentTotal) * 100);
+              return `<li class="rank-row">
+                <span class="rank-idx">${i + 1}</span>
+                <div class="rank-main">
+                  <p class="rank-name">${esc(a.label)}</p>
+                  <p class="rank-meta">${DK.formatCompact(a.value)} tokens saved</p>
+                  <div class="rank-track"><span class="rank-fill" data-w="${pct}"></span></div>
+                </div>
+                <div class="rank-val">${pct}%<small>of savings</small></div>
+              </li>`;
+            })
+            .join("")
+        : `<li class="rank-row"><div class="rank-main"><p class="rank-name">No agent usage yet</p><p class="rank-meta">Install the coding agent plugin to attribute savings</p></div></li>`;
+    }
+
+    const keyTotal = series.keys.reduce((s, k) => s + k.value, 0) || 1;
+    if ($("keys")) {
+      $("keys").innerHTML = series.keys.length
+        ? series.keys
+            .map((k) => {
+              const pct = Math.round((k.value / keyTotal) * 100);
+              return `<li class="rank-row">
+                <div class="rank-main">
+                  <p class="rank-name"><span class="key-dot"></span>${esc(k.label)}</p>
+                  <p class="rank-meta">${pct}% of monthly savings</p>
+                  <div class="rank-track"><span class="rank-fill" data-w="${pct}"></span></div>
+                </div>
+                <div class="rank-val">${DK.formatCompact(k.value)}<small>tokens</small></div>
+              </li>`;
+            })
+            .join("")
+        : `<li class="rank-row"><div class="rank-main"><p class="rank-name">No key breakdown yet</p><p class="rank-meta">Usage will land here after compress calls</p></div></li>`;
+    }
+
+    requestAnimationFrame(() => {
+      document.querySelectorAll(".rank-fill").forEach((el) => {
+        el.style.width = `${el.getAttribute("data-w")}%`;
+      });
+    });
+  }
+
+  async function loadFirebaseConfig() {
+    try {
+      const res = await fetch(`${API_BASE}/api/firebase-config`, { cache: "no-store" });
+      if (!res.ok) return null;
+      const cfg = await res.json();
+      if (cfg?.apiKey && cfg?.projectId && cfg?.authDomain) return cfg;
+    } catch (_) {}
+    return null;
+  }
+
+  async function fetchKeys(idToken) {
+    const res = await fetch(`${API_BASE}/api/keys?fresh=1&_=${Date.now()}`, {
+      headers: { Authorization: `Bearer ${idToken}` },
+      cache: "no-store",
+    });
+    if (!res.ok) throw new Error(`keys ${res.status}`);
+    return res.json();
+  }
+
+  function setAuthUi(user) {
+    const note = $("auth-note");
+    const btn = $("btn-signin");
+    if (!note || !btn) return;
+    if (user) {
+      note.textContent = user.email || "Signed in";
+      btn.textContent = "Sign out";
+      btn.classList.remove("primary");
+      btn.dataset.mode = "out";
+    } else {
+      note.textContent = "Sign in to load your real usage.";
+      btn.textContent = "Sign in with Google";
+      btn.classList.add("primary");
+      btn.dataset.mode = "in";
+    }
+  }
+
+  async function boot() {
+    if (!DATA?.bundleToSeries || !DK?.animateChart) {
+      console.error("Analytics deps missing — hard-refresh.");
+      if ($("auth-note")) $("auth-note").textContent = "Charts failed to load — hard-refresh.";
+      return;
+    }
+
+    paint(DATA.bundleToSeries(DATA.demoBundle()));
+
+    const { initializeApp } = await import("https://www.gstatic.com/firebasejs/11.0.2/firebase-app.js");
+    const {
+      getAuth,
+      GoogleAuthProvider,
+      signInWithPopup,
+      onAuthStateChanged,
+      signOut,
+      setPersistence,
+      browserLocalPersistence,
+    } = await import("https://www.gstatic.com/firebasejs/11.0.2/firebase-auth.js");
+
+    const cfg = await loadFirebaseConfig();
+    if (!cfg) {
+      if ($("auth-note")) $("auth-note").textContent = "Firebase config unavailable — showing demo data.";
+      return;
+    }
+
+    const app = initializeApp(cfg);
+    const auth = getAuth(app);
+    await setPersistence(auth, browserLocalPersistence);
+    const provider = new GoogleAuthProvider();
+
+    if ($("btn-signin")) {
+      $("btn-signin").onclick = async () => {
+        try {
+          if ($("btn-signin").dataset.mode === "out") {
+            await signOut(auth);
+            return;
+          }
+          await signInWithPopup(auth, provider);
+        } catch (err) {
+          console.error(err);
+          if ($("auth-note")) $("auth-note").textContent = err?.message || "Sign-in failed";
+        }
+      };
+    }
+
+    onAuthStateChanged(auth, async (user) => {
+      setAuthUi(user);
+      if (!user) {
+        paint(DATA.bundleToSeries(DATA.demoBundle()));
+        return;
+      }
+      try {
+        if ($("data-pill")) $("data-pill").textContent = "Live · loading…";
+        const token = await user.getIdToken(true);
+        const payload = await fetchKeys(token);
+        paint(DATA.bundleToSeries(DATA.aggregateUsage(payload)));
+      } catch (err) {
+        console.error(err);
+        if ($("auth-note")) $("auth-note").textContent = "Could not load usage — showing demo.";
+        paint(DATA.bundleToSeries(DATA.demoBundle()));
+      }
+    });
+
+    window.addEventListener("resize", () => {
+      for (const [id, opts] of washes) {
+        const el = $(id);
+        if (el) DK.renderDitherWash(el, opts);
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -1385,9 +1385,8 @@ function updateStats() {
 
 /**
  * Month totals for KPIs.
- * Auth `sc_usage` (accountUsage) is the billing source of truth — per-key store
- * can lag or under-count when store writes flake, so never prefer a smaller
- * key-sum over the account meter.
+ * Prefer account meter (billing ledger / maxed claims) when present; otherwise
+ * max(key usage, coding-agent usage) so agent-only traffic still fills KPIs.
  */
 function usageTotals() {
   let keyReqs = 0;
@@ -1401,6 +1400,17 @@ function usageTotals() {
     keyTout += snap.total_tokens_out || 0;
   }
 
+  let agentReqs = 0;
+  let agentSaved = 0;
+  let agentTin = 0;
+  let agentTout = 0;
+  for (const snap of Object.values(codingAgentUsage || {})) {
+    agentReqs += snap.requests || 0;
+    agentSaved += snap.tokens_saved || 0;
+    agentTin += snap.tokens_in || 0;
+    agentTout += snap.tokens_out || 0;
+  }
+
   const acctTin = accountUsage?.tokens_in || 0;
   const acctReqs = accountUsage?.requests || 0;
   const acctSaved = accountUsage?.tokens_saved || 0;
@@ -1409,10 +1419,10 @@ function usageTotals() {
   // Prefer account meter whenever it has traffic (matches Billing / PAYG).
   if (acctTin > 0 || acctReqs > 0) {
     return {
-      reqs: acctReqs || keyReqs,
-      saved: acctSaved,
-      tin: acctTin,
-      tout: acctTout,
+      reqs: Math.max(acctReqs, keyReqs, agentReqs),
+      saved: Math.max(acctSaved, keySaved, agentSaved),
+      tin: Math.max(acctTin, keyTin, agentTin),
+      tout: Math.max(acctTout, keyTout, agentTout),
       fromAccount: true,
       keyReqs,
       keyTin,
@@ -1422,10 +1432,10 @@ function usageTotals() {
   }
 
   return {
-    reqs: keyReqs,
-    saved: keySaved,
-    tin: keyTin,
-    tout: keyTout,
+    reqs: Math.max(keyReqs, agentReqs),
+    saved: Math.max(keySaved, agentSaved),
+    tin: Math.max(keyTin, agentTin),
+    tout: Math.max(keyTout, agentTout),
     fromAccount: false,
     keyReqs,
     keyTin,
@@ -1471,7 +1481,7 @@ function renderKeysSummary() {
   );
 }
 
-/** KPI cards on API keys panel (charts live only in local/analytics-preview.html). */
+/** KPI cards on API keys panel (full charts on /analytics). */
 function renderAnalytics() {
   renderKeysSummary();
 }

--- a/web/assets/js/dither-kit-lite.js
+++ b/web/assets/js/dither-kit-lite.js
@@ -70,15 +70,21 @@
       return;
     }
     const bias = (variant === "dotted" ? 0.12 : 0) + (stacked ? 0.2 : 0) - sparse;
+    const phase = Number(opts.phase) || 0;
+    // Slow Bayer drift — keeps charts alive after the intro grow-in.
+    const ox = Math.floor(phase * 2.4) & 3;
+    const oy = Math.floor(phase * 1.3) & 3;
+    const shimmer = 0.04 * Math.sin(phase * 1.7 + x * 0.11);
     for (let y = t; y < f; y++) {
       let density = (y - t) / depth;
       if (stacked) density = 0.5 + 0.5 * density;
       if (variant === "hatched" && ((x + y) & 3) >= 2) continue;
+      const thresh = BAYER[(y + oy) & 3][(x + ox) & 3];
       const lit =
         variant === "solid" ||
-        density > BAYER[y & 3][x & 3] - 0.1 * intensity - bias;
+        density > thresh - 0.1 * intensity - bias + shimmer;
       if (variant === "dotted" && !lit) continue;
-      const k = (0.3 + density * 0.7) * (1 + 0.22 * intensity);
+      const k = (0.3 + density * 0.7) * (1 + 0.22 * intensity + shimmer * 0.5);
       const alpha = clamp01((lit ? k : k * OFF_TIER) * dim);
       octx.fillStyle = rgb(seed.fill, 1, alpha);
       octx.fillRect(x, y, 1, 1);
@@ -204,7 +210,7 @@
     }
 
     const values = rows.map((r) => Number(r.y) || 0);
-    const max = Math.max(1, ...values);
+    const max = Math.max(1, options.yMax != null ? Number(options.yMax) : 0, ...values);
     const { cols, rows: bRows } = backingSize(plotW, plotH);
     const off = document.createElement("canvas");
     off.width = cols;
@@ -216,6 +222,7 @@
       return Math.max(0, Math.min(bRows - 1, Math.round(t * (bRows - 1))));
     });
 
+    const phase = Number(options.phase) || 0;
     for (let c = 0; c < cols; c++) {
       const t = cols === 1 ? 0 : c / (cols - 1);
       const idx = t * (tops.length - 1);
@@ -226,8 +233,11 @@
       paintColumn(octx, c, top, bRows, seed, {
         variant,
         dim: 1,
+        intensity: 0.12 + 0.08 * Math.sin(phase + c * 0.09),
+        phase,
       });
     }
+    host._dkLastPaint = { kind: "area", options: { ...options } };
 
     // subtle baseline
     ctx.strokeStyle = ink(host, "faint");
@@ -267,6 +277,19 @@
     }
 
     applyBloom(bloom, crisp, bloomLevel, host);
+    if (!options.live) {
+      bindHover(host, {
+        enabled: options.interactive !== false && !options.empty,
+        title: options.tooltipTitle || "Value",
+        unit: options.unit || "",
+        points: values.map((v, i) => ({
+          x: pad.l + (values.length === 1 ? plotW / 2 : (i / (values.length - 1)) * plotW),
+          label: String(rows[i].x || ""),
+          value: v,
+        })),
+        mode: "nearest-x",
+      });
+    }
   }
 
   function normalizeBars(raw) {
@@ -277,6 +300,7 @@
         value: d.value != null ? d.value : d.y,
         color: d.color,
         variant: d.variant,
+        full: d.full,
       };
     });
   }
@@ -301,7 +325,8 @@
     };
     const plotW = Math.max(8, cssW - pad.l - pad.r);
     const plotH = Math.max(8, cssH - pad.t - pad.b);
-    const max = Math.max(1, ...data.map((d) => Number(d.value) || 0));
+    const progress = options.progress == null ? 1 : clamp01(Number(options.progress));
+    const max = Math.max(1, options.yMax != null ? Number(options.yMax) : 0, ...data.map((d) => Number(d.value) || 0));
     const empty = !!options.empty || !data.some((d) => (Number(d.value) || 0) > 0);
 
     if (!data.length || empty) {
@@ -322,7 +347,7 @@
     data.forEach((d, i) => {
       const seed = seedOf(d.color || defaultColor || SERIES_COLORS[i % SERIES_COLORS.length]);
       const v = Number(d.value) || 0;
-      const frac = v / max;
+      const frac = (v / max) * progress;
       if (horizontal) {
         const y = pad.t + i * slot + (slot - barThick) / 2;
         const w = Math.max(2, frac * plotW);
@@ -331,11 +356,14 @@
         off.width = cols;
         off.height = rows;
         const octx = off.getContext("2d");
+        const phase = Number(options.phase) || 0;
         for (let c = 0; c < cols; c++) {
           paintColumn(octx, c, 0, rows, seed, {
             variant: d.variant || defaultVariant,
             stacked: true,
             dim: empty ? 0.4 : 1,
+            intensity: 0.1 + 0.06 * Math.sin(phase + i * 0.4 + c * 0.08),
+            phase: phase + i * 0.15,
           });
         }
         ctx.imageSmoothingEnabled = false;
@@ -357,11 +385,14 @@
         off.width = cols;
         off.height = rows;
         const octx = off.getContext("2d");
+        const phase = Number(options.phase) || 0;
         for (let c = 0; c < cols; c++) {
           paintColumn(octx, c, 0, rows, seed, {
             variant: d.variant || defaultVariant,
             stacked: true,
             dim: empty ? 0.4 : 1,
+            intensity: 0.1 + 0.06 * Math.sin(phase + i * 0.35 + c * 0.08),
+            phase: phase + i * 0.12,
           });
         }
         ctx.imageSmoothingEnabled = false;
@@ -379,6 +410,21 @@
     }
 
     applyBloom(bloom, crisp, options.bloom || "aura", host);
+    host._dkLastPaint = { kind: "bar", options: { ...options } };
+
+    if (!horizontal && !options.live) {
+      bindHover(host, {
+        enabled: options.interactive !== false && !empty && progress > 0.95,
+        title: options.tooltipTitle || "Value",
+        unit: options.unit || "",
+        points: data.map((d, i) => ({
+          x: pad.l + i * slot + slot / 2,
+          label: String(d.full || d.label || ""),
+          value: Number(d.value) || 0,
+        })),
+        mode: "nearest-x",
+      });
+    }
   }
 
   /** Donut / pie. data = [{label, value, color?}] */
@@ -477,6 +523,214 @@
     });
   }
 
+  function ensureTip(host) {
+    let tip = host.querySelector(".dk-tip");
+    if (!tip) {
+      tip = document.createElement("div");
+      tip.className = "dk-tip";
+      tip.setAttribute("role", "tooltip");
+      host.appendChild(tip);
+    }
+    if (getComputedStyle(host).position === "static") {
+      host.style.position = "relative";
+    }
+    return tip;
+  }
+
+  function bindHover(host, cfg) {
+    if (!host) return;
+    if (host._dkHoverCleanup) {
+      host._dkHoverCleanup();
+      host._dkHoverCleanup = null;
+    }
+    if (!cfg || !cfg.enabled || !cfg.points || !cfg.points.length) {
+      host.classList.remove("dk-hovering");
+      const tip = host.querySelector(".dk-tip");
+      if (tip) tip.style.opacity = "0";
+      return;
+    }
+
+    const tip = ensureTip(host);
+    const points = cfg.points;
+    const unit = cfg.unit ? ` ${cfg.unit}` : "";
+
+    const onMove = (ev) => {
+      const rect = host.getBoundingClientRect();
+      const x = ev.clientX - rect.left;
+      let best = 0;
+      let bestDist = Infinity;
+      for (let i = 0; i < points.length; i++) {
+        const d = Math.abs(points[i].x - x);
+        if (d < bestDist) {
+          bestDist = d;
+          best = i;
+        }
+      }
+      const p = points[best];
+      tip.innerHTML =
+        `<strong>${cfg.title || "Value"}</strong>` +
+        `<span>${p.label}</span>` +
+        `<em>${formatCompact(p.value)}${unit}</em>`;
+      tip.style.opacity = "1";
+      const tw = tip.offsetWidth || 120;
+      const th = tip.offsetHeight || 56;
+      let left = p.x - tw / 2;
+      left = Math.max(8, Math.min(rect.width - tw - 8, left));
+      let top = 12;
+      tip.style.left = `${left}px`;
+      tip.style.top = `${top}px`;
+      host.classList.add("dk-hovering");
+    };
+
+    const onLeave = () => {
+      tip.style.opacity = "0";
+      host.classList.remove("dk-hovering");
+    };
+
+    host.addEventListener("pointermove", onMove);
+    host.addEventListener("pointerleave", onLeave);
+    host._dkHoverCleanup = () => {
+      host.removeEventListener("pointermove", onMove);
+      host.removeEventListener("pointerleave", onLeave);
+    };
+  }
+
+  /** Ease-out grow for charts. fn(progress 0→1) called each frame. */
+  function animateChart(fn, duration = 900) {
+    if (typeof fn !== "function") return;
+    const t0 = performance.now();
+    const ease = (t) => 1 - Math.pow(1 - t, 3);
+    const frame = (now) => {
+      const p = Math.min(1, (now - t0) / Math.max(1, duration));
+      fn(ease(p));
+      if (p < 1) requestAnimationFrame(frame);
+    };
+    requestAnimationFrame(frame);
+  }
+
+  function ensureWashCanvas(el) {
+    if (!el) return null;
+    el.classList.add("dk-wash");
+    let canvas = el.querySelector("canvas.dk-wash-canvas");
+    if (!canvas) {
+      el.innerHTML = "";
+      canvas = document.createElement("canvas");
+      canvas.className = "dk-wash-canvas";
+      el.appendChild(canvas);
+    }
+    return canvas;
+  }
+
+  /** Soft Bayer field for KPI card backgrounds. */
+  function renderDitherWash(el, options = {}) {
+    const canvas = ensureWashCanvas(el);
+    if (!canvas) return;
+    const rect = el.getBoundingClientRect();
+    const cssW = Math.max(40, Math.round(rect.width || el.clientWidth || 160));
+    const cssH = Math.max(40, Math.round(rect.height || el.clientHeight || 120));
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    canvas.style.width = cssW + "px";
+    canvas.style.height = cssH + "px";
+    const ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    const seed = seedOf(options.color || "brand");
+    const intensity = clamp01(options.intensity == null ? 0.5 : options.intensity);
+    const phase = Number(options.phase) || 0;
+    const { cols, rows } = backingSize(cssW, cssH);
+    const off = document.createElement("canvas");
+    off.width = cols;
+    off.height = rows;
+    const octx = off.getContext("2d");
+
+    for (let y = 0; y < rows; y++) {
+      for (let x = 0; x < cols; x++) {
+        const nx = x / Math.max(1, cols - 1);
+        const ny = y / Math.max(1, rows - 1);
+        // soft corner bloom + slow phase drift
+        const radial = 1 - Math.min(1, Math.hypot(nx - 0.15, ny - 0.2) * 1.15);
+        const wave = 0.55 + 0.45 * Math.sin((nx + ny) * 4.2 + phase);
+        const dens = clamp01(radial * wave * (0.35 + intensity * 0.75));
+        const thresh = BAYER[y & 3][x & 3];
+        if (dens <= thresh * 0.92) continue;
+        const alpha = clamp01((dens - thresh * 0.5) * 0.55 * intensity);
+        octx.fillStyle = rgb(seed.fill, 1, alpha);
+        octx.fillRect(x, y, 1, 1);
+      }
+    }
+
+    ctx.imageSmoothingEnabled = false;
+    ctx.globalAlpha = 0.95;
+    ctx.drawImage(off, 0, 0, cssW, cssH);
+    ctx.globalAlpha = 1;
+  }
+
+  /** Continuous slow wash drift. Stores RAF handle on the element. */
+  function startDitherWashLoop(el, options = {}) {
+    if (!el) return;
+    if (el._dkWashRaf) {
+      cancelAnimationFrame(el._dkWashRaf);
+      el._dkWashRaf = 0;
+    }
+    let phase = 0;
+    let last = performance.now();
+    const tick = (now) => {
+      const dt = Math.min(48, now - last);
+      last = now;
+      phase += dt * 0.0011;
+      renderDitherWash(el, { ...options, phase });
+      el._dkWashRaf = requestAnimationFrame(tick);
+    };
+    el._dkWashRaf = requestAnimationFrame(tick);
+  }
+
+  function stopDitherWashLoop(el) {
+    if (!el || !el._dkWashRaf) return;
+    cancelAnimationFrame(el._dkWashRaf);
+    el._dkWashRaf = 0;
+  }
+
+  /** Continuous slow Bayer drift on a mounted chart (after intro animation). */
+  function startChartDitherLoop(el, options = {}) {
+    if (!el) return;
+    stopChartDitherLoop(el);
+    let phase = Number(options.phase) || 0;
+    let last = performance.now();
+    let acc = 0;
+    const kind = options.kind || el._dkLastPaint?.kind || "area";
+    const baseOpts = { ...(el._dkLastPaint?.options || {}), ...options };
+    delete baseOpts.kind;
+    const tick = (now) => {
+      const dt = Math.min(48, now - last);
+      last = now;
+      acc += dt;
+      phase += dt * 0.00085;
+      // ~20fps dither shimmer — enough motion, lighter than every paint
+      if (acc >= 50) {
+        acc = 0;
+        const opts = {
+          ...baseOpts,
+          phase,
+          live: true,
+          interactive: baseOpts.interactive !== false,
+        };
+        if (kind === "bar") renderBarChart(el, opts);
+        else renderAreaChart(el, opts);
+      }
+      el._dkChartRaf = requestAnimationFrame(tick);
+    };
+    el._dkChartRaf = requestAnimationFrame(tick);
+  }
+
+  function stopChartDitherLoop(el) {
+    if (!el || !el._dkChartRaf) return;
+    cancelAnimationFrame(el._dkChartRaf);
+    el._dkChartRaf = 0;
+  }
+
   function formatCompact(n) {
     const v = Number(n) || 0;
     if (Math.abs(v) >= 1e6) return (v / 1e6).toFixed(v >= 1e7 ? 0 : 1) + "M";
@@ -496,6 +750,12 @@
     renderBarChart,
     renderPieChart,
     renderSparkline,
+    renderDitherWash,
+    startDitherWashLoop,
+    stopDitherWashLoop,
+    startChartDitherLoop,
+    stopChartDitherLoop,
+    animateChart,
     formatCompact,
     seedOf,
   };

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -396,7 +396,7 @@
       color: var(--text-muted);
     }
 
-    /* Keys summary cards (light) — Analytics charts are local-only for now */
+    /* Keys summary cards (light) — full charts on /analytics */
     .dash-panel-actions {
       display: flex;
       align-items: center;
@@ -641,6 +641,7 @@
           <button type="button" class="dash-topnav-item active" data-panel="keys">API keys</button>
           <button type="button" class="dash-topnav-item" data-panel="agents">Coding Agents</button>
           <button type="button" class="dash-topnav-item" data-panel="billing">Billing</button>
+          <a class="dash-topnav-item dash-topnav-link" href="/analytics">Analytics</a>
           <a class="dash-topnav-item dash-topnav-link" href="https://docs.supercompress.dev" target="_blank" rel="noopener">Documentation ↗</a>
         </nav>
 


### PR DESCRIPTION
## Summary
- Ships production `/analytics` (Bayer dither charts + KPI strip) linked from the dashboard.
- Fixes analytics/dashboard meter holes: agent-only traffic under-counted KPIs, `reconcile-*` by_day keys invisible to charts, `/api/account?op=usage` returning null `account_usage` while totals were non-zero, `/api/keys` not maxing account meter with coding-agent usage.
- Completes dither-kit wash/hover/loop APIs needed by the charts; adds aggregation unit tests in CI.

## Test plan
- [x] `node web/assets/js/analytics-data.test.js`
- [x] Local visual smoke of `/analytics.html` (demo data + Firebase config from prod when on localhost)
- [x] Live `/api/account?op=usage` with API key shows agent totals (pre-deploy baseline)
- [ ] After deploy: open https://www.supercompress.dev/analytics, sign in, confirm live KPIs/charts match dashboard usage
- [ ] Dashboard → Analytics nav link works


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a signed-in `/analytics` page with dithered daily charts and updates account, key, and dashboard meters to include coding-agent usage.
- Adds analytics aggregation, rendering, authentication, routing, navigation, and CI coverage.
- Makes reconciliation gaps chart-visible using ISO daily keys.
- Maxes account and dashboard meters across ledger, key, and coding-agent totals.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until coding-agent counters are correctly scoped to the current month and reconciliation gaps stop being represented as usage from a single day.

Lifetime agent totals currently inflate monthly usage after rollover, while cumulative reconciliation gaps distort the newly shipped daily analytics charts.

**Files Needing Attention:** api/keys.js, api/account.js, api/_lib/store.js, web/assets/js/dashboard-api.js, web/assets/js/analytics-data.js

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/_lib/store.js | Makes reconciliation chart-visible under today's date, but consequently attributes a cumulative monthly gap to one day. |
| api/keys.js | Maxes current-month account usage against coding-agent counters that are stored cumulatively across months. |
| api/account.js | Exposes a non-null current-month account_usage object whose totals can inherit lifetime coding-agent usage. |
| web/assets/js/analytics-data.js | Aggregates 30-day charts and KPI fallbacks, but consumes the incorrectly month-scoped agent meter and chart-visible reconciliation spike. |
| web/assets/js/analytics-page.js | Implements Firebase-authenticated analytics loading and safely escapes API-provided list labels. |
| web/assets/js/dither-kit-lite.js | Adds animated dither washes, chart loops, and hover tooltips; current analytics tooltip labels are locally generated dates. |
| web/analytics.html | Adds the responsive analytics page structure, styling, KPI strip, charts, and authentication controls. |
| web/assets/js/dashboard-api.js | Includes coding-agent counters in monthly KPIs without accounting for their lifetime storage scope. |
| .github/workflows/ci.yml | Adds the analytics aggregation unit test to CI. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/_lib/store.js`, line 627-644 ([link](https://github.com/supercompress/supercompress/blob/ff6fcaca12db419c2c7f3bd49049f78a1ee776bd/api/_lib/store.js#L627-L644)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reconciliation distorts daily attribution**

   When the monthly account meter exceeds summed per-key usage, this code assigns the entire month-to-date gap to today's `by_day` entry, causing the new daily charts and period comparisons to show all previously missed usage as a spike on the reconciliation date.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Ship /analytics with dither charts and m..."](https://github.com/supercompress/supercompress/commit/ff6fcaca12db419c2c7f3bd49049f78a1ee776bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52099436)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->