### PR TITLE
Cover analytics month-meter gap fold in unit tests

### DIFF
--- a/web/assets/js/analytics-data.test.js
+++ b/web/assets/js/analytics-data.test.js
@@ -83,4 +83,38 @@ assert.strictEqual(s2.totalSaved, 2000);
 assert.strictEqual(s2.totalIn, 5000);
 assert.strictEqual(s2.totalReq, 10);
 
+// Month meter ahead of partial by_day — chart catches up on today.
+const partial = aggregateUsage({
+  keys: [{ id: "k1", name: "Production" }],
+  usage: {
+    k1: {
+      total_requests: 10,
+      total_tokens_in: 100000,
+      total_tokens_saved: 50000,
+      by_day: {
+        [new Date().toISOString().slice(0, 10)]: {
+          tokens_saved: 10000,
+          tokens_in: 20000,
+          requests: 2,
+        },
+      },
+    },
+  },
+  coding_agent_usage: {},
+  account_usage: {
+    month: "2026-08",
+    requests: 100,
+    tokens_in: 500000,
+    tokens_saved: 250000,
+    tokens_out: 250000,
+  },
+});
+const s3 = bundleToSeries(partial);
+assert.strictEqual(s3.totalSaved, 250000);
+assert.strictEqual(
+  s3.areaData.reduce((s, d) => s + d.y, 0),
+  250000,
+  "chart area matches month meter after gap fold"
+);
+
 console.log("analytics-data.test.js: ok");


### PR DESCRIPTION
## Summary
- Adds the unit assertion for chart totals matching month meter after gap fold (logic already in #57).

## Test plan
- [x] `node web/assets/js/analytics-data.test.js`

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds regression coverage confirming that chart totals match the monthly usage meter after partial daily usage is reconciled.
- Adds a partial `by_day` usage fixture with larger account-level totals.
- Verifies both the reported saved-token total and the summed chart area equal the monthly total.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only adds deterministic regression coverage for existing analytics aggregation behavior.

The new fixture reliably exercises the numeric gap fold and its assertions correctly verify that the chart and monthly meter totals remain aligned.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/assets/js/analytics-data.test.js | Adds focused, deterministic assertions for the existing month-meter gap-fold behavior without changing production code. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Cover analytics month-meter gap fold in ..."](https://github.com/supercompress/supercompress/commit/0bf14f0bd4a8bdb815209616b9ef8ed07bc6cac6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52100814)</sub>

<!-- /greptile_comment -->