### PR TITLE
Restyle SEO/guide articles on-brand

### DIFF
--- a/scripts/normalize_article_pages.py
+++ b/scripts/normalize_article_pages.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Normalize SEO / guide / blog article pages onto article-page.css."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WEB = ROOT / "web"
+
+SKIP = {
+    "index.html",
+    "dashboard.html",
+    "analytics.html",
+    "playground.html",
+    "live-demo.html",
+    "benchmarks.html",
+    "blog.html",
+    "changelog.html",
+    "affiliates.html",
+    "affiliate-creator-kit.html",
+    "founder.html",
+    "404.html",
+    "research.html",
+    "compare.html",
+    "aiscore.html",
+    "launch-kit.html",
+    "logo-dots.html",
+    "unsubscribe.html",
+}
+
+CSS_BLOCK = """<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />"""
+
+STYLE_RE = re.compile(r"\n?\s*<style\b[^>]*>.*?</style>\s*", re.S | re.I)
+LINK_RE = re.compile(
+    r'\s*<link\s+rel="stylesheet"\s+href="[^"]*(?:supercompress|landing-chrome|seo-cluster|seo-article|article-page|content-shell)\.css[^"]*"\s*/?>\s*',
+    re.I,
+)
+
+
+def should_strip_style(css: str) -> bool:
+    """Strip style blocks that are article/SEO chrome (keep rare page-specific JS/CSS)."""
+    markers = (
+        ".seo-page",
+        ".seo-kicker",
+        ".seo-lead",
+        ".seo-section",
+        ".seo-table",
+        ".seo-cta",
+        ".seo-author",
+        ".seo-nav",
+        ".guide-head",
+        ".guide-toc",
+        ".guide-body",
+        ".guide-cta",
+        ".guide-methods",
+        ".method-card",
+        ".article-prose",
+        ".post-header",
+        ".post-content",
+        ".seo-verdict",
+        ".seo-cluster",
+    )
+    hits = sum(1 for m in markers if m in css)
+    # Keep if it's mostly something else (affiliates, dashboard-ish)
+    if hits >= 2:
+        return True
+    if ".guide-head" in css or ".guide-body" in css:
+        return True
+    return False
+
+
+def ensure_css_links(html: str) -> str:
+    html = LINK_RE.sub("\n", html)
+    # Insert after favicon / before first script or remaining link, prefer after apple-touch
+    anchor = re.search(
+        r'(<link rel="apple-touch-icon"[^>]*>\s*)',
+        html,
+        re.I,
+    )
+    block = CSS_BLOCK + "\n"
+    if anchor:
+        return html[: anchor.end()] + block + html[anchor.end() :]
+    # fallback: before </head>
+    return html.replace("</head>", block + "</head>", 1)
+
+
+def strip_article_styles(html: str) -> str:
+    def repl(m: re.Match) -> str:
+        css = m.group(0)
+        if should_strip_style(css):
+            return "\n"
+        return css
+
+    return STYLE_RE.sub(repl, html)
+
+
+def convert_guide_head(html: str) -> str:
+    """Map guide-head pages into seo-page shell without destroying TOC/body."""
+    if 'class="guide-head"' not in html:
+        return html
+
+    # Normalize kicker / subtitle / meta classes inside guide-head
+    html = html.replace('<header class="guide-head">', '<main class="seo-page">')
+    # Close guide-head early if it wraps proof sections — keep structure but rename
+    # Many guides close </header> after meta; convert that to stay inside main.
+    html = re.sub(
+        r'<p class="kicker">(.*?)</p>',
+        r'<p class="seo-kicker">\1</p>',
+        html,
+        count=1,
+        flags=re.S,
+    )
+    html = re.sub(
+        r'<p class="subtitle">(.*?)</p>',
+        r'<p class="seo-lead">\1</p>',
+        html,
+        count=1,
+        flags=re.S,
+    )
+    html = re.sub(
+        r'<p class="meta">(.*?)</p>\s*</header>',
+        r'<p class="seo-author">\1</p>',
+        html,
+        count=1,
+        flags=re.S,
+    )
+    # If header still open/closed oddly, fix leftover </header> after guide-head start
+    # Already handled above when meta closes header.
+
+    # Ensure guide-body is present; if main never closed, close before footer
+    if '<main class="seo-page">' in html and "</main>" not in html.split('<main class="seo-page">', 1)[1].split("<footer", 1)[0]:
+        html = re.sub(
+            r"(</div>\s*)?(<footer\b)",
+            r"</main>\n\1\2",
+            html,
+            count=1,
+            flags=re.I,
+        )
+    return html
+
+
+def ensure_site_chrome_js(html: str) -> str:
+    if "site-chrome.js" in html:
+        html = re.sub(
+            r'/assets/js/site-chrome\.js\?v=\d+',
+            "/assets/js/site-chrome.js?v=12",
+            html,
+        )
+        return html
+    return html.replace(
+        "</body>",
+        '  <script src="/assets/js/site-chrome.js?v=12"></script>\n</body>',
+        1,
+    )
+
+
+def process(path: Path) -> str:
+    html = path.read_text(encoding="utf-8")
+    original = html
+    html = strip_article_styles(html)
+    html = ensure_css_links(html)
+    html = convert_guide_head(html)
+    html = ensure_site_chrome_js(html)
+    # Deduplicate accidental blank lines
+    html = re.sub(r"\n{3,}", "\n\n", html)
+    if html == original:
+        return "unchanged"
+    path.write_text(html, encoding="utf-8")
+    return "updated"
+
+
+def main() -> None:
+    updated = []
+    skipped = []
+    for path in sorted(WEB.glob("*.html")):
+        if path.name in SKIP:
+            skipped.append(path.name)
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        # Only touch marketing/SEO-ish pages
+        markers = (
+            "seo-page",
+            "guide-head",
+            "guide-body",
+            "article-prose",
+            "post-header",
+            "seo-section",
+            "seo-cluster",
+            "article-page.css",
+        )
+        if not any(m in text for m in markers) and "<style>" not in text:
+            skipped.append(path.name)
+            continue
+        # Skip pure product shells that happen to include style for other reasons
+        if path.name in {"coding-agent-proxy.html"} or "guide-head" in text or "seo-page" in text or "seo-section" in text or "guide-body" in text:
+            status = process(path)
+            updated.append((path.name, status))
+        elif any(m in text for m in ("seo-kicker", "seo-lead", "seo-table", "seo-cta")):
+            status = process(path)
+            updated.append((path.name, status))
+        else:
+            # Still strip if heavy seo inline
+            if re.search(r"<style>[\s\S]*?\.seo-page[\s\S]*?</style>", text):
+                status = process(path)
+                updated.append((path.name, status))
+            else:
+                skipped.append(path.name)
+
+    print("Updated:")
+    for name, status in updated:
+        print(f"  {status:9} {name}")
+    print(f"\nTouched {sum(1 for _, s in updated if s == 'updated')} files")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/agent-memory-compression.html
+++ b/web/agent-memory-compression.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/ai-search.html
+++ b/web/ai-search.html
@@ -21,10 +21,11 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <link rel="stylesheet" href="/assets/css/article-page.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/web/assets/css/article-page.css
+++ b/web/assets/css/article-page.css
@@ -1,42 +1,652 @@
-/* Long-form article prose helpers for SEO / blog-style pages. */
-.article-prose {
-  max-width: 720px;
+/**
+ * SuperCompress long-form articles / SEO guides / blog posts.
+ * Loaded after supercompress.css + landing-chrome.css.
+ * Brand: Platypi + Geist, product blue #0566ff, paper atmosphere.
+ */
+
+:root {
+  --brand: #0566ff;
+  --brand-hover: #0055df;
+  --brand-ink: #0039a6;
+  --brand-soft: #eef4ff;
+  --brand-wash: rgba(5, 102, 255, 0.08);
+  --paper: #f7f8fb;
+  --ink: #171717;
+  --muted: #5c5a55;
+  --faint: #9a9892;
+  --line: #e6e7eb;
+  --card: #ffffff;
+  --feat-blue: #eef4ff;
+}
+
+/* Soft paper field behind article chrome */
+body:has(.seo-page),
+body:has(.guide-body),
+body:has(.article-prose) {
+  background:
+    radial-gradient(1100px 520px at 12% -8%, rgba(5, 102, 255, 0.07), transparent 55%),
+    radial-gradient(900px 480px at 100% 0%, rgba(5, 102, 255, 0.04), transparent 50%),
+    linear-gradient(180deg, #fbfbf9 0%, var(--paper) 42%, #eef0f4 100%);
+  color: var(--ink);
+}
+
+/* ── Page shell ── */
+.seo-page {
+  max-width: 760px !important;
+  margin: 0 auto !important;
+  padding: 72px 24px 96px !important;
+}
+
+.seo-kicker,
+.guide-head .kicker {
+  margin: 0 0 14px !important;
+  font-family: var(--sans) !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  letter-spacing: 0.1em !important;
+  text-transform: uppercase !important;
+  text-align: center !important;
+  color: var(--brand) !important;
+}
+
+.seo-page > h1,
+.guide-head h1 {
+  max-width: 18ch !important;
+  margin: 0 auto 18px !important;
+  font-family: var(--serif) !important;
+  font-weight: 300 !important;
+  font-size: clamp(2.1rem, 4.8vw, 3.15rem) !important;
+  line-height: 1.05 !important;
+  letter-spacing: -0.03em !important;
+  text-align: center !important;
+  color: var(--ink) !important;
+}
+
+.seo-lead,
+.guide-head .subtitle {
+  max-width: 46ch !important;
+  margin: 0 auto !important;
+  font-family: var(--sans) !important;
+  font-size: 1.05rem !important;
+  line-height: 1.6 !important;
+  text-align: center !important;
+  color: var(--muted) !important;
+}
+
+.seo-author,
+.guide-head .meta,
+.seo-page > .meta {
+  margin: 18px auto 0 !important;
+  font-family: var(--sans) !important;
+  font-size: 13px !important;
+  text-align: center !important;
+  color: var(--faint) !important;
+}
+
+.seo-author strong,
+.guide-head .meta strong,
+.seo-page > .meta strong {
+  color: var(--ink) !important;
+  font-weight: 600 !important;
+}
+
+.seo-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin: 0 0 18px;
+}
+
+.seo-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border: 0.5px solid var(--line);
+  border-radius: 999px;
+  background: var(--card);
+  color: var(--muted);
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.seo-tag--accent {
+  border-color: rgba(5, 102, 255, 0.28);
+  background: var(--brand-soft);
+  color: var(--brand);
+}
+
+/* ── Topic cluster ── */
+.seo-cluster {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  gap: 8px !important;
+  justify-content: center !important;
+  max-width: 640px !important;
+  margin: 28px auto 36px !important;
+  padding: 12px !important;
+  border: 0.5px solid var(--line) !important;
+  border-radius: 14px !important;
+  background: rgba(255, 255, 255, 0.72) !important;
+  box-shadow: 0 1px 2px rgba(23, 23, 23, 0.03) !important;
+  backdrop-filter: blur(8px);
+}
+
+.seo-cluster a {
+  display: inline-flex !important;
+  align-items: center !important;
+  padding: 6px 11px !important;
+  border: 0.5px solid transparent !important;
+  border-radius: 999px !important;
+  color: var(--muted) !important;
+  font-family: var(--sans) !important;
+  font-size: 12.5px !important;
+  font-weight: 500 !important;
+  text-decoration: none !important;
+  border-bottom: none !important;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.seo-cluster a:hover,
+.seo-cluster a[aria-current="page"] {
+  background: var(--brand-soft) !important;
+  border-color: rgba(5, 102, 255, 0.22) !important;
+  color: var(--brand) !important;
+}
+
+/* ── Guide header (legacy class kept) ── */
+.guide-head {
+  max-width: 760px;
   margin: 0 auto;
+  padding: 72px 24px 8px;
+  text-align: center;
+}
+
+/* ── TOC ── */
+.guide-toc {
+  max-width: 760px;
+  margin: 8px auto 28px;
+  padding: 22px 24px;
+  border: 0.5px solid var(--line);
+  border-radius: 16px;
+  background:
+    linear-gradient(165deg, rgba(5, 102, 255, 0.06), transparent 55%),
+    var(--card);
+  box-shadow: 0 1px 2px rgba(23, 23, 23, 0.03);
+  counter-reset: toc-counter;
+}
+
+.guide-toc h2 {
+  margin: 0 0 14px;
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--brand);
+  border: 0;
+  padding: 0;
+}
+
+.guide-toc ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.guide-toc ol li {
+  counter-increment: toc-counter;
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.guide-toc ol li::before {
+  content: counter(toc-counter, decimal-leading-zero) "  ";
+  color: var(--brand);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-right: 2px;
+}
+
+.guide-toc a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.guide-toc a:hover {
+  color: var(--brand);
+  border-bottom-color: rgba(5, 102, 255, 0.35);
+}
+
+/* ── Prose / guide body ── */
+.article-prose,
+.guide-body,
+.seo-section,
+.seo-proof,
+.seo-vs-hr {
+  max-width: 760px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.article-prose,
+.guide-body {
+  padding: 8px 24px 80px;
+  font-family: var(--sans);
   font-size: 1.02rem;
-  line-height: 1.65;
-  color: var(--text-body, #374151);
+  line-height: 1.7;
+  color: var(--muted);
 }
 
-.article-prose h2 {
-  margin: 2.2em 0 0.7em;
-  font-family: var(--serif, Georgia, serif);
+.guide-body {
+  padding-top: 12px;
+}
+
+.article-prose section,
+.guide-body section,
+.seo-section {
+  margin: 0 0 48px;
+}
+
+.article-prose h2,
+.guide-body h2,
+.seo-section h2,
+.seo-proof h2,
+.seo-vs-hr h2 {
+  margin: 0 0 16px;
+  padding-bottom: 10px;
+  border-bottom: 0.5px solid var(--line);
+  font-family: var(--serif);
   font-weight: 400;
-  font-size: clamp(1.35rem, 3vw, 1.7rem);
-  color: var(--text-primary, #141412);
+  font-size: clamp(1.45rem, 3vw, 1.85rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--ink);
 }
 
-.article-prose h3 {
-  margin: 1.6em 0 0.5em;
-  font-size: 1.1rem;
-  color: var(--text-primary, #141412);
+.article-prose h3,
+.guide-body h3,
+.seo-section h3 {
+  margin: 28px 0 10px;
+  font-family: var(--sans);
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
 }
 
 .article-prose p,
-.article-prose ul,
-.article-prose ol {
+.guide-body p,
+.seo-section p,
+.seo-proof p,
+.seo-vs-hr p,
+.article-prose li,
+.guide-body li,
+.seo-section li,
+.seo-vs-hr li {
   margin: 0 0 1em;
+  color: var(--muted);
+  font-size: 15.5px;
+  line-height: 1.72;
 }
 
 .article-prose ul,
-.article-prose ol {
+.article-prose ol,
+.guide-body ul,
+.guide-body ol,
+.seo-section ul,
+.seo-section ol,
+.seo-vs-hr ul {
+  margin: 0 0 1.1em;
   padding-left: 1.25em;
 }
 
-.article-prose a {
-  color: var(--brand, #1d4ed8);
+.article-prose li,
+.guide-body li {
+  margin-bottom: 0.45em;
 }
 
-.article-prose code {
-  font-family: var(--shell-mono, ui-monospace, Menlo, monospace);
-  font-size: 0.92em;
+.article-prose strong,
+.guide-body strong,
+.seo-section strong,
+.seo-vs-hr strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.article-prose a,
+.guide-body a,
+.seo-section a,
+.seo-proof a,
+.seo-vs-hr a {
+  color: var(--brand);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(5, 102, 255, 0.25);
+}
+
+.article-prose a:hover,
+.guide-body a:hover {
+  border-bottom-color: var(--brand);
+}
+
+.article-prose code,
+.guide-body code,
+.seo-page code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  padding: 0.12em 0.4em;
+  border-radius: 5px;
+  background: #f1f2f5;
+  color: var(--ink);
+  border: 0.5px solid var(--line);
+}
+
+.article-prose pre,
+.guide-body pre,
+.seo-page pre {
+  margin: 0 0 1.25em;
+  padding: 16px 18px;
+  overflow-x: auto;
+  border: 0.5px solid var(--line);
+  border-radius: 12px;
+  background: #111318;
+  color: #e8eaef;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.article-prose pre code,
+.guide-body pre code,
+.seo-page pre code {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+}
+
+/* ── Callouts ── */
+.article-prose .callout,
+.guide-body .callout,
+.seo-verdict {
+  margin: 0 0 1.35em;
+  padding: 16px 18px;
+  border-left: 3px solid var(--brand);
+  border-radius: 0 12px 12px 0;
+  background: linear-gradient(90deg, var(--brand-wash), transparent 85%);
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+.article-prose .callout strong,
+.guide-body .callout strong,
+.seo-verdict strong {
+  color: var(--brand-ink);
+}
+
+/* ── Tables ── */
+.article-prose table,
+.guide-body table,
+.seo-table,
+.seo-proof-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: 0 0 1.35em;
+  font-size: 13.5px;
+  overflow: hidden;
+  border: 0.5px solid var(--line);
+  border-radius: 12px;
+  background: var(--card);
+}
+
+.article-prose th,
+.guide-body th,
+.seo-table th,
+.seo-proof-table th {
+  padding: 11px 14px;
+  text-align: left;
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: #f4f5f8;
+  border-bottom: 0.5px solid var(--line);
+}
+
+.article-prose td,
+.guide-body td,
+.seo-table td,
+.seo-proof-table td {
+  padding: 12px 14px;
+  border-bottom: 0.5px solid var(--line);
+  color: var(--ink);
+  vertical-align: top;
+}
+
+.article-prose tr:last-child td,
+.guide-body tr:last-child td,
+.seo-table tr:last-child td,
+.seo-proof-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.guide-body .best-row,
+.seo-table .best-row {
+  background: var(--brand-soft);
+  font-weight: 600;
+}
+
+.guide-body .best-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(5, 102, 255, 0.12);
+  color: var(--brand-ink);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.guide-body .stat-highlight {
+  display: block;
+  margin: -4px 0 18px;
+  font-size: 13px;
+  color: var(--faint);
+}
+
+/* ── Method cards ── */
+.guide-methods {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin: 0 0 24px;
+}
+
+@media (max-width: 640px) {
+  .guide-methods {
+    grid-template-columns: 1fr;
+  }
+}
+
+.method-card {
+  padding: 18px;
+  border: 0.5px solid var(--line);
+  border-radius: 14px;
+  background: var(--card);
+  box-shadow: 0 1px 2px rgba(23, 23, 23, 0.03);
+}
+
+.method-card.best {
+  border-color: rgba(5, 102, 255, 0.35);
+  background:
+    linear-gradient(165deg, rgba(5, 102, 255, 0.08), transparent 60%),
+    var(--card);
+}
+
+.method-card h4 {
+  margin: 0 0 6px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.method-card .method-score {
+  margin: 0 0 6px;
+  font-family: var(--serif);
+  font-size: 28px;
+  font-weight: 300;
+  letter-spacing: -0.03em;
+  color: var(--brand);
+  line-height: 1;
+}
+
+.method-card p {
+  margin: 0 !important;
+  font-size: 13px !important;
+  line-height: 1.5 !important;
+  color: var(--muted) !important;
+}
+
+/* ── CTA band ── */
+.guide-cta,
+.seo-cta {
+  margin: 48px 0;
+  padding: 40px 24px;
+  text-align: center;
+  border-top: 0.5px solid var(--line);
+  border-bottom: 0.5px solid var(--line);
+  background:
+    radial-gradient(600px 180px at 50% 0%, rgba(5, 102, 255, 0.1), transparent 70%),
+    #f3f5f9;
+}
+
+.guide-cta h3,
+.seo-cta h2,
+.seo-cta h3 {
+  margin: 0 0 10px;
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: clamp(1.4rem, 3vw, 1.7rem);
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  border: 0;
+  padding: 0;
+}
+
+.guide-cta p,
+.seo-cta p {
+  margin: 0 auto 18px;
+  max-width: 42ch;
+  font-size: 15px;
+  color: var(--muted);
+}
+
+.guide-cta .btn,
+.guide-cta a.btn,
+.seo-cta .btn,
+.seo-cta a.button,
+.seo-cta a.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 0 18px;
+  border-radius: 10px;
+  border: 0;
+  background: var(--brand);
+  color: #fff !important;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none !important;
+  border-bottom: 0 !important;
+  box-shadow: 0 1px 2px rgba(5, 102, 255, 0.25);
+}
+
+.guide-cta .btn:hover,
+.seo-cta .btn:hover,
+.seo-cta a.button:hover {
+  background: var(--brand-hover);
+}
+
+/* ── Proof / comparison blocks ── */
+.seo-proof,
+.seo-vs-hr {
+  margin: 0 auto 40px;
+  padding: 0 24px;
+}
+
+.seo-page .seo-proof,
+.seo-page .seo-vs-hr,
+.seo-page .guide-body,
+.seo-page .article-prose {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.seo-page .guide-toc {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.seo-nav {
+  display: none !important; /* replaced by .seo-cluster */
+}
+
+.guide-nav {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.guide-nav a {
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--brand);
+  text-decoration: none;
+}
+
+.guide-nav a:hover {
+  text-decoration: underline;
+}
+
+/* ── Responsive ── */
+@media (max-width: 720px) {
+  .seo-page {
+    padding: 56px 18px 72px !important;
+  }
+
+  .guide-head {
+    padding: 56px 18px 8px;
+  }
+
+  .article-prose,
+  .guide-body,
+  .seo-proof,
+  .seo-vs-hr {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .seo-page > h1,
+  .guide-head h1 {
+    max-width: none !important;
+  }
 }

--- a/web/assets/css/seo-cluster.css
+++ b/web/assets/css/seo-cluster.css
@@ -1,34 +1,42 @@
-/* Topic-cluster nav + SEO article chrome used by marketing pages. */
+/* Topic-cluster nav used by marketing / SEO articles.
+   Visual system lives primarily in article-page.css; this file is a fallback. */
 .seo-cluster {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 14px;
+  gap: 8px;
   justify-content: center;
-  max-width: 720px;
+  max-width: 640px;
   margin: 28px auto 36px;
-  padding: 14px 18px;
-  border: 0.5px solid var(--card-border, #e5e5e0);
-  border-radius: 4px;
-  background: var(--feat-blue, #f4f7ff);
+  padding: 12px;
+  border: 0.5px solid var(--line, #e6e7eb);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 1px 2px rgba(23, 23, 23, 0.03);
 }
 
 .seo-cluster a {
-  color: var(--brand, #1d4ed8);
-  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 11px;
+  border-radius: 999px;
+  color: var(--muted, #5c5a55);
+  font-size: 12.5px;
+  font-weight: 500;
   text-decoration: none;
-  border-bottom: 1px solid transparent;
 }
 
-.seo-cluster a:hover {
-  border-bottom-color: currentColor;
+.seo-cluster a:hover,
+.seo-cluster a[aria-current="page"] {
+  background: var(--brand-soft, #eef4ff);
+  color: var(--brand, #0566ff);
 }
 
 .seo-verdict {
   max-width: 640px;
   margin: 20px auto 8px;
   padding: 14px 16px;
-  border-left: 3px solid var(--brand, #1d4ed8);
-  background: rgba(29, 78, 216, 0.06);
+  border-left: 3px solid var(--brand, #0566ff);
+  background: linear-gradient(90deg, rgba(5, 102, 255, 0.08), transparent 85%);
   font-size: 0.98rem;
   line-height: 1.55;
 }
@@ -46,14 +54,14 @@
   font-size: 12px;
   padding: 4px 10px;
   border-radius: 999px;
-  border: 0.5px solid var(--card-border, #e5e5e0);
-  color: var(--text-muted, #6b7280);
+  border: 0.5px solid var(--line, #e6e7eb);
+  color: var(--muted, #5c5a55);
   text-decoration: none;
 }
 
 .seo-proof,
 .seo-vs-hr {
-  max-width: 720px;
+  max-width: 760px;
   margin: 0 auto 40px;
 }
 
@@ -66,6 +74,6 @@
   max-width: 420px;
   padding-left: 1.2em;
   text-align: left;
-  color: var(--text-muted, #6b7280);
+  color: var(--muted, #5c5a55);
   font-size: 14px;
 }

--- a/web/better-than-headroom.html
+++ b/web/better-than-headroom.html
@@ -24,32 +24,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=120" />
+
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 3.6rem); line-height: 1.02; letter-spacing: -.035em; max-width: 900px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; font-size: 14px; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .sc-badge { display: inline-block; background: #dbeafe; color: #1d4ed8; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
-    .hr-badge { display: inline-block; background: #f3f4f6; color: #6b7280; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
-    .win { color: #16a34a; font-weight: 600; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    .seo-verdict { margin: 28px 0; padding: 20px 22px; border: .5px solid var(--card-border); border-left: 3px solid var(--brand); background: #fff; }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/cache-aligner-prefix-stabilization.html
+++ b/web/cache-aligner-prefix-stabilization.html
@@ -22,10 +22,11 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <link rel="stylesheet" href="/assets/css/article-page.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/web/coding-agent-proxy.html
+++ b/web/coding-agent-proxy.html
@@ -20,9 +20,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/style.css?v=110" />
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<link rel="stylesheet" href="assets/css/style.css?v=110" />
+<style>
     /* ── Blog article styles ── */
     .article-page {
       background: var(--bg);

--- a/web/context-compression.html
+++ b/web/context-compression.html
@@ -24,31 +24,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-    <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-<style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
@@ -212,7 +193,6 @@ def rag_with_compression(query, retriever, llm):
     result = comp.compress(context, query)
     return llm.generate(query, result.compressed_text)</code></pre>
       </section>
-
 
 <section class="seo-section" id="tool-comparison">
     <h2>Context compression tools compared</h2>

--- a/web/cut-api-costs.html
+++ b/web/cut-api-costs.html
@@ -24,37 +24,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=115" />
+
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-    <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-<style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 900px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section ul, .seo-section ol { padding-left: 1.2em; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; font-size: 14px; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    .seo-callout { margin: 22px 0; padding: 18px 20px; border-left: 3px solid var(--brand); background: #fff; border: .5px solid var(--card-border); border-left-width: 3px; }
-    .seo-toc { background: #fff; border: .5px solid var(--card-border); padding: 18px 22px; margin: 28px 0 8px; }
-    .seo-toc p { margin: 0 0 10px; font-size: 13px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .05em; }
-    .seo-toc ol { margin: 0; padding-left: 1.2em; }
-    .seo-toc a { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
@@ -328,7 +303,6 @@ print(result.compressed_text, result.tokens_saved_pct)</pre>
 <pre>npx supercompress-proxy setup</pre>
       <p>Details: <a href="https://docs.supercompress.dev/coding-agents">coding agents guide</a>.</p>
     </section>
-
 
     <section class="seo-section" id="query-aware-stack">
       <h2>Query-aware cost stack (what Google AI often mixes up)</h2>

--- a/web/domain-preprocessors.html
+++ b/web/domain-preprocessors.html
@@ -21,10 +21,11 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <link rel="stylesheet" href="/assets/css/article-page.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/web/firecrawl-context-compression.html
+++ b/web/firecrawl-context-compression.html
@@ -18,26 +18,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=110" />
+
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 860px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-cta-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 18px; }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/headroom-api.html
+++ b/web/headroom-api.html
@@ -24,32 +24,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=120" />
+
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 3.6rem); line-height: 1.02; letter-spacing: -.035em; max-width: 900px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; font-size: 14px; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .sc-badge { display: inline-block; background: #dbeafe; color: #1d4ed8; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
-    .hr-badge { display: inline-block; background: #f3f4f6; color: #6b7280; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
-    .win { color: #16a34a; font-weight: 600; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    .seo-verdict { margin: 28px 0; padding: 20px 22px; border: .5px solid var(--card-border); border-left: 3px solid var(--brand); background: #fff; }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
@@ -193,7 +173,6 @@
   </ul>
   <p><a href="/supercompress-vs-headroom">Read the full SuperCompress vs Headroom comparison →</a></p>
 </section>
-
 
     <section class="seo-section">
       <h2>Quick comparison table</h2>

--- a/web/how-prompt-compression-works.html
+++ b/web/how-prompt-compression-works.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/llm-cost-optimization.html
+++ b/web/llm-cost-optimization.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/llm-token-compression.html
+++ b/web/llm-token-compression.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/mcp-integration.html
+++ b/web/mcp-integration.html
@@ -22,10 +22,11 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <link rel="stylesheet" href="/assets/css/article-page.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/web/open-source-token-compression.html
+++ b/web/open-source-token-compression.html
@@ -26,31 +26,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=120" />
+
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 3.6rem); line-height: 1.02; letter-spacing: -.035em; max-width: 900px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; font-size: 14px; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .sc-badge { display: inline-block; background: #dbeafe; color: #1d4ed8; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
-    .win { color: #16a34a; font-weight: 600; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    .seo-verdict { margin: 28px 0; padding: 20px 22px; border: .5px solid var(--card-border); border-left: 3px solid var(--brand); background: #fff; }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/precision-mode-compression.html
+++ b/web/precision-mode-compression.html
@@ -21,10 +21,11 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <link rel="stylesheet" href="/assets/css/article-page.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/web/prompt-compression-guide.html
+++ b/web/prompt-compression-guide.html
@@ -5,6 +5,10 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Prompt Compression Guide — The Complete Resource (2026) | SuperCompress</title>
@@ -106,7 +110,6 @@
     .btn-outline { background: transparent; border: 1px solid #2d2d44; color: #b0b0c8; }
     .btn-outline:hover { border-color: #7c3aed; color: #c4b5fd; background: rgba(124,58,237,0.08); text-decoration: none; }
   </style>
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 </head>
 <body>
 <header class="df-header">

--- a/web/prompt-compression.html
+++ b/web/prompt-compression.html
@@ -23,31 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-    <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-<style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/reduce-llm-costs.html
+++ b/web/reduce-llm-costs.html
@@ -24,37 +24,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=115" />
+
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-    <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-<style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 900px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section ul, .seo-section ol { padding-left: 1.2em; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; font-size: 14px; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    .seo-callout { margin: 22px 0; padding: 18px 20px; border-left: 3px solid var(--brand); background: #fff; border: .5px solid var(--card-border); border-left-width: 3px; }
-    .seo-toc { background: #fff; border: .5px solid var(--card-border); padding: 18px 22px; margin: 28px 0 8px; }
-    .seo-toc p { margin: 0 0 10px; font-size: 13px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .05em; }
-    .seo-toc ol { margin: 0; padding-left: 1.2em; }
-    .seo-toc a { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
@@ -328,7 +303,6 @@ print(result.compressed_text, result.tokens_saved_pct)</pre>
 <pre>npx supercompress-proxy setup</pre>
       <p>Details: <a href="https://docs.supercompress.dev/coding-agents">coding agents guide</a>.</p>
     </section>
-
 
     <section class="seo-section" id="query-aware-stack">
       <h2>Query-aware cost stack (what Google AI often mixes up)</h2>

--- a/web/reduce-openai-costs.html
+++ b/web/reduce-openai-costs.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/reversible-compression-ccr.html
+++ b/web/reversible-compression-ccr.html
@@ -21,10 +21,11 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <link rel="stylesheet" href="/assets/css/article-page.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/web/supercompress-architecture.html
+++ b/web/supercompress-architecture.html
@@ -5,6 +5,10 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SuperCompress Architecture — How Query-Aware Prompt Compression Works | SuperCompress</title>
@@ -77,7 +81,6 @@
     .flow-diagram { background: #0d0d16; border: 1px solid #1c1c2e; border-radius: 10px; padding: 20px; margin: 20px 0; font-family: 'SF Mono', monospace; font-size: 0.82rem; color: #888; line-height: 2; text-align: center; }
     .flow-diagram .arrow { color: #a78bfa; }
   </style>
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 </head>
 <body>
 <header class="df-header">

--- a/web/supercompress-vs-alternatives.html
+++ b/web/supercompress-vs-alternatives.html
@@ -5,6 +5,10 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SuperCompress vs Alternatives — Prompt Compression Compared (2026) | SuperCompress</title>
@@ -103,7 +107,6 @@
     .faq summary { font-weight: 500; color: #c8c8d8; font-size: 0.9rem; }
     .faq details p { margin-top: 10px; font-size: 0.85rem; color: #777; }
   </style>
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 </head>
 <body>
 <header class="df-header">

--- a/web/supercompress-vs-headroom.html
+++ b/web/supercompress-vs-headroom.html
@@ -24,32 +24,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=120" />
+
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 3.6rem); line-height: 1.02; letter-spacing: -.035em; max-width: 900px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; font-size: 14px; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .sc-badge { display: inline-block; background: #dbeafe; color: #1d4ed8; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
-    .hr-badge { display: inline-block; background: #f3f4f6; color: #6b7280; padding: 2px 8px; border-radius: 3px; font-size: 12px; font-weight: 600; }
-    .win { color: #16a34a; font-weight: 600; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    .seo-verdict { margin: 28px 0; padding: 20px 22px; border: .5px solid var(--card-border); border-left: 3px solid var(--brand); background: #fff; }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
@@ -181,7 +161,6 @@
   </ul>
   <p><a href="/supercompress-vs-headroom" aria-current="page">Read the full SuperCompress vs Headroom comparison →</a></p>
 </section>
-
 
     <section class="seo-section">
       <h2>Quick comparison table</h2>

--- a/web/supercompress-vs-llmlingua.html
+++ b/web/supercompress-vs-llmlingua.html
@@ -18,9 +18,8 @@
   <meta property="article:modified_time" content="2026-08-03" />
   <link rel="icon" href="/favicon-chevron.ico?v=3" sizes="any" />
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/seo-article.css?v=8" />
-  <script type="application/ld+json">
+
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
@@ -55,6 +54,10 @@
     ]
   }
   </script>
+<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 </head>
 <body>
 <header class="df-header">

--- a/web/supercompress-vs-summarization.html
+++ b/web/supercompress-vs-summarization.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/supercompress-vs-truncation.html
+++ b/web/supercompress-vs-truncation.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/token-compression.html
+++ b/web/token-compression.html
@@ -34,10 +34,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-    <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "FAQPage",
@@ -60,265 +62,6 @@
     ]
   }
   </script>
-<style>
-    .guide-head {
-      max-width: 800px;
-      margin: 0 auto;
-      padding: 60px 24px 32px;
-      text-align: center;
-    }
-    .guide-head .kicker {
-      font-size: 12px;
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--text-muted);
-      margin-bottom: 12px;
-    }
-    .guide-head h1 {
-      font-family: var(--serif);
-      font-weight: 300;
-      font-size: clamp(2rem, 5vw, 3rem);
-      line-height: 1.05;
-      letter-spacing: -0.02em;
-      margin-bottom: 16px;
-    }
-    .guide-head .subtitle {
-      font-size: 1.05rem;
-      color: var(--text-body);
-      line-height: 1.6;
-      max-width: 640px;
-      margin: 0 auto;
-    }
-    .guide-head .meta {
-      font-size: 13px;
-      color: var(--text-muted);
-      margin-top: 16px;
-    }
-    .guide-head .meta strong { color: var(--text-primary); }
-
-    .guide-toc {
-      max-width: 720px;
-      margin: 0 auto;
-      padding: 32px 24px;
-      background: var(--feat-blue);
-      border: 0.5px solid var(--card-border);
-      border-radius: 4px;
-    }
-    .guide-toc h2 {
-      font-size: 13px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--brand-dark);
-      margin-bottom: 16px;
-    }
-    .guide-toc ol {
-      list-style: none;
-      padding: 0;
-      display: grid;
-      gap: 8px;
-    }
-    .guide-toc ol li {
-      counter-increment: toc-counter;
-      font-size: 14px;
-    }
-    .guide-toc ol li::before {
-      content: counter(toc-counter) ". ";
-      color: var(--brand);
-      font-weight: 600;
-      margin-right: 4px;
-    }
-    .guide-toc ol li a {
-      color: var(--text-primary);
-      text-decoration: none;
-      border-bottom: 1px solid transparent;
-    }
-    .guide-toc ol li a:hover {
-      border-bottom-color: var(--brand);
-      color: var(--brand);
-    }
-
-    .guide-body {
-      max-width: 720px;
-      margin: 0 auto;
-      padding: 40px 24px 80px;
-    }
-    .guide-body section {
-      margin-bottom: 48px;
-    }
-    .guide-body h2 {
-      font-family: var(--serif);
-      font-weight: 300;
-      font-size: clamp(1.4rem, 3vw, 1.8rem);
-      line-height: 1.15;
-      letter-spacing: -0.01em;
-      margin-bottom: 16px;
-      padding-bottom: 8px;
-      border-bottom: 0.5px solid var(--card-border);
-    }
-    .guide-body h3 {
-      font-size: 1.15rem;
-      font-weight: 600;
-      margin-bottom: 8px;
-      margin-top: 24px;
-    }
-    .guide-body p {
-      font-size: 15px;
-      color: var(--text-body);
-      line-height: 1.7;
-      margin-bottom: 16px;
-    }
-    .guide-body ul, .guide-body ol {
-      font-size: 15px;
-      color: var(--text-body);
-      line-height: 1.7;
-      margin-bottom: 16px;
-      padding-left: 20px;
-    }
-    .guide-body li { margin-bottom: 6px; }
-    .guide-body strong { color: var(--text-primary); }
-    .guide-body code {
-      background: #f4f4f0;
-      padding: 2px 6px;
-      border-radius: 3px;
-      font-size: 13px;
-    }
-    .guide-body pre {
-      background: #f4f4f0;
-      border: 0.5px solid var(--card-border);
-      border-radius: 4px;
-      padding: 16px 20px;
-      overflow-x: auto;
-      font-size: 13px;
-      line-height: 1.6;
-      margin-bottom: 20px;
-    }
-    .guide-body .callout {
-      background: var(--feat-blue);
-      border-left: 3px solid var(--brand);
-      padding: 16px 20px;
-      border-radius: 0 4px 4px 0;
-      margin-bottom: 20px;
-      font-size: 14px;
-      color: var(--text-body);
-    }
-    .guide-body .callout strong { color: var(--brand-dark); }
-
-    .guide-body table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-bottom: 20px;
-      font-size: 14px;
-    }
-    .guide-body th {
-      background: #f9f9f6;
-      text-align: left;
-      padding: 10px 14px;
-      font-weight: 600;
-      font-size: 12px;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      color: var(--text-body);
-      border-bottom: 0.5px solid var(--card-border);
-    }
-    .guide-body td {
-      padding: 10px 14px;
-      border-bottom: 0.5px solid var(--card-border);
-    }
-    .guide-body .best-row { background: var(--feat-blue); font-weight: 600; }
-    .guide-body .best-badge {
-      display: inline-block;
-      background: #dbeafe;
-      color: #1e40af;
-      padding: 2px 8px;
-      border-radius: 999px;
-      font-size: 11px;
-      font-weight: 600;
-    }
-    .guide-body .stat-highlight {
-      display: inline-block;
-      font-size: 13px;
-      color: var(--text-muted);
-      margin-top: -8px;
-      margin-bottom: 20px;
-    }
-
-    .guide-cta {
-      text-align: center;
-      padding: 48px 24px;
-      background: var(--feat-blue);
-      border-top: 0.5px solid var(--card-border);
-      border-bottom: 0.5px solid var(--card-border);
-      margin: 48px 0;
-    }
-    .guide-cta h3 {
-      font-family: var(--serif);
-      font-weight: 300;
-      font-size: 1.5rem;
-      margin-bottom: 8px;
-    }
-    .guide-cta p {
-      font-size: 15px;
-      color: var(--text-body);
-      margin-bottom: 20px;
-      max-width: 480px;
-      margin-left: auto;
-      margin-right: auto;
-    }
-
-    .guide-methods {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 12px;
-      margin-bottom: 24px;
-    }
-    @media (max-width: 640px) {
-      .guide-methods { grid-template-columns: 1fr; }
-    }
-    .method-card {
-      border: 0.5px solid var(--card-border);
-      border-radius: 4px;
-      padding: 20px;
-      background: #fff;
-    }
-    .method-card h4 {
-      font-size: 14px;
-      font-weight: 600;
-      margin-bottom: 6px;
-    }
-    .method-card .method-score {
-      font-size: 24px;
-      font-weight: 300;
-      color: var(--brand);
-      margin-bottom: 4px;
-    }
-    .method-card p {
-      font-size: 13px !important;
-      color: var(--text-body);
-      line-height: 1.5;
-    }
-    .method-card.best {
-      border-color: var(--brand);
-      background: var(--feat-blue);
-    }
-
-    .guide-nav {
-      max-width: 720px;
-      margin: 0 auto;
-      padding: 24px;
-      display: flex;
-      justify-content: space-between;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-    .guide-nav a {
-      font-size: 14px;
-      color: var(--brand);
-      text-decoration: none;
-    }
-    .guide-nav a:hover { text-decoration: underline; }
-  </style>
 </head>
 <body>
   <div class="df-page-bg-top" aria-hidden="true"></div>
@@ -368,10 +111,10 @@
   </header>
   <div class="df-header-spacer" aria-hidden="true"></div>
 <!-- Guide Header -->
-    <header class="guide-head">
-      <p class="kicker">Definitive Resource · Updated 2026</p>
+    <main class="seo-page">
+      <p class="seo-kicker">Definitive Resource · Updated 2026</p>
       <h1>Token Compression for LLMs:<br />The Complete Guide</h1>
-      <p class="subtitle">Everything you need to know about LLM token compression — what it is, why it matters, how much it saves, and how to implement it with open-source tools. Includes benchmarks, comparison tables, and an interactive demo.</p>
+      <p class="seo-lead">Everything you need to know about LLM token compression — what it is, why it matters, how much it saves, and how to implement it with open-source tools. Includes benchmarks, comparison tables, and an interactive demo.</p>
 
 <nav class="seo-cluster" aria-label="SuperCompress topic cluster">
   <a href="/reduce-llm-costs">Reduce LLM costs</a>
@@ -410,8 +153,7 @@
   <p><a href="/supercompress-vs-headroom">Read the full SuperCompress vs Headroom comparison →</a></p>
 </section>
 
-<p class="meta">Written by <strong>Arjun Shah</strong> · Creator of <a href="/">SuperCompress</a> · <strong>~3,500 words</strong></p>
-    </header>
+<p class="seo-author">Written by <strong>Arjun Shah</strong> · Creator of <a href="/">SuperCompress</a> · <strong>~3,500 words</strong></p>
 
     <!-- Table of Contents -->
     <nav class="guide-toc" aria-label="Table of contents">
@@ -453,17 +195,17 @@
         <h2>Why Token Compression Matters</h2>
         <p>Token compression addresses three converging pressures on every LLM-powered application:</p>
 
-        <h3>💰 Cost</h3>
+        <h3>Cost</h3>
         <p>
           LLM APIs charge by the token — both input and output. If 65% of your input tokens are irrelevant to the answer, you're paying for compute that doesn't improve your results. For a typical agent making 100 calls/day, that's thousands of wasted tokens daily. At scale (1M+ calls/month), the savings from token compression reach thousands of dollars.
         </p>
 
-        <h3>⚡ Latency</h3>
+        <h3>Latency</h3>
         <p>
           LLM inference time scales with input length (especially with attention's quadratic complexity in prefill). Compressing tokens before inference means faster responses. In agent loops, where context grows with every turn, token compression keeps latency from ballooning over time.
         </p>
 
-        <h3>🌍 Environmental Impact</h3>
+        <h3>Environmental Impact</h3>
         <p>
           Every token processed by a GPU consumes electricity and cooling water. Data centers used 415 TWh globally in 2024 and are on track to double by 2030. Token compression directly reduces the compute needed per query. At 10M calls/month, SuperCompress avoids ~120 kg CO₂ and ~1,000 L of cooling water.
         </p>
@@ -730,7 +472,8 @@ class CompressionCallback(BaseCallbackHandler):
     </div>
 
     <!-- Footer -->
-    <footer class="df-footer">
+    </main>
+<footer class="df-footer">
     <div class="df-footer-inner">
       <div class="df-footer-grid">
         <div class="df-footer-brand">

--- a/web/what-is-prompt-compression.html
+++ b/web/what-is-prompt-compression.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",

--- a/web/when-to-use-compression.html
+++ b/web/when-to-use-compression.html
@@ -23,30 +23,12 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+
 <link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <style>
-    .seo-page { max-width: 920px; margin: 0 auto; padding: 72px 24px 96px; }
-    .seo-kicker { color: var(--brand); font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px; }
-    .seo-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(2.25rem, 6vw, 4.25rem); line-height: 1.02; letter-spacing: -.035em; max-width: 840px; margin: 0 0 18px; }
-    .seo-lead { font-size: clamp(1.05rem, 2vw, 1.28rem); line-height: 1.62; color: var(--text-body); max-width: 760px; }
-    .seo-nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 28px 0 52px; }
-    .seo-nav a { border: .5px solid var(--card-border); border-radius: 6px; padding: 9px 15px; color: var(--text-primary); text-decoration: none; background: #fff; font-size: 14px; }
-    .seo-nav a:hover { border-color: var(--brand); color: var(--brand); }
-    .seo-section { margin-top: 44px; }
-    .seo-section h2 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.5rem, 3vw, 2.1rem); letter-spacing: -.02em; margin: 0 0 14px; }
-    .seo-section p, .seo-section li { color: var(--text-body); line-height: 1.68; font-size: 15px; }
-    .seo-section h3 { font-size: 1.1rem; font-weight: 500; margin: 20px 0 10px; color: var(--text-primary); }
-    .seo-table { width: 100%; border-collapse: collapse; margin: 18px 0; background: #fff; border: .5px solid var(--card-border); }
-    .seo-table th, .seo-table td { text-align: left; padding: 14px; border-bottom: .5px solid var(--card-border); vertical-align: top; }
-    .seo-table th { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--text-muted); }
-    pre { overflow-x: auto; background: #0f172a; color: #e5e7eb; padding: 18px; border-radius: 6px; font-size: 13px; line-height: 1.55; }
-    .seo-cta { margin-top: 46px; padding: 28px; border-radius: 6px; background: var(--feat-blue); border: .5px solid var(--card-border); }
-    .seo-author { margin: 8px 0 24px; font-size: 13px; color: var(--text-muted); }
-    .seo-author strong { color: var(--text-primary); }
-    @media (max-width: 760px) { .seo-page { padding-top: 42px; } }
-  </style>
-  <script type="application/ld+json">
+  <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
+  <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
+<script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",


### PR DESCRIPTION
## Summary
- New shared `article-page.css` for long-form SEO/guides (product blue `#0566ff`, paper atmosphere, pill topic cluster, tables, TOC, callouts, method cards, CTAs).
- Batch-normalize ~30 article pages (including `/token-compression`) — strip heavy inline styles, unify onto `seo-page` + article CSS.
- Soften `seo-cluster.css` to match.

## Test plan
- [x] Local smoke `/token-compression.html` + `/domain-preprocessors.html`
- [ ] After deploy: https://www.supercompress.dev/token-compression
- [ ] Spot-check `/prompt-compression`, `/supercompress-vs-headroom`, `/blog` linked guides

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consolidates approximately 30 SEO and guide pages onto a shared branded article presentation.
- Adds a comprehensive long-form article stylesheet covering page shells, prose, navigation clusters, tables, callouts, cards, and CTAs.
- Replaces duplicated inline article styles and normalizes stylesheet and site-chrome references.
- Softens the fallback topic-cluster styling and adds a reusable normalization script.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking visual regression in the Headroom comparison tables.

The shared article migration preserves the primary article structure and navigation, but removing page-local CSS leaves comparison badges and winner cells without their intended visual treatment.

**Files Needing Attention:** web/supercompress-vs-headroom.html, web/headroom-api.html, web/better-than-headroom.html, and web/assets/css/article-page.css

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/normalize_article_pages.py | Adds a batch normalizer that removes article-specific inline CSS, standardizes shared asset links, converts legacy guide headers, and ensures site-chrome JavaScript is present. |
| web/assets/css/article-page.css | Expands the small prose helper into the shared visual system for SEO and guide pages; it does not preserve several comparison-specific utility classes removed from page-local CSS. |
| web/assets/css/seo-cluster.css | Updates the topic-cluster fallback to match the new rounded, muted article design. |
| web/supercompress-vs-headroom.html | Migrates the comparison page to shared article CSS while retaining badge and winner classes whose definitions were removed. |
| web/headroom-api.html | Migrates the Headroom API comparison article but leaves its comparison-specific classes without shared definitions. |
| web/token-compression.html | Removes extensive page-local styling and adopts the shared article and topic-cluster styles while preserving the long-form content structure. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[SEO and guide HTML pages] --> B[Normalization script]
  B --> C[Shared core and chrome CSS]
  B --> D[seo-cluster.css]
  B --> E[article-page.css]
  E --> F[Unified article shell]
  E --> G[Prose, tables, callouts, and CTAs]
  D --> H[Topic-cluster navigation]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Restyle SEO and guide articles onto a sh..."](https://github.com/supercompress/supercompress/commit/60b08446ac9a99cc05775ea57ee353958887dd15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52102269)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->