### PR TITLE
Remove docs.supercompress.dev site footer

### DIFF
--- a/web/assets/css/docs.css
+++ b/web/assets/css/docs.css
@@ -996,29 +996,6 @@ html.js-reveal .df-reveal-stagger:not(.is-visible) > * {
   color: var(--brand);
 }
 
-.docs-site-footer {
-  border-top: 1px solid var(--line);
-  background: #0a0a0a;
-  color: #a3a3a3;
-  margin-left: calc(-1 * var(--docs-sidebar-width));
-  width: calc(100% + var(--docs-sidebar-width));
-}
-.docs-site-footer-inner {
-  max-width: var(--max);
-  margin: 0 auto;
-  padding: 28px var(--frame);
-}
-.docs-site-footer a {
-  color: #e5e5e5;
-  text-decoration: none;
-}
-.docs-site-footer a:hover {
-  color: #fff;
-  text-decoration: underline;
-}
+
 @media (max-width: 900px) {
-  .docs-site-footer {
-    margin-left: 0;
-    width: 100%;
-  }
 }

--- a/web/docs/api-reference.html
+++ b/web/docs/api-reference.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -289,12 +289,7 @@ impact = sustainability_from_tokens_saved(saved)
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-  </div>
+</div>
 <script>
     (function() {
       var s=document.getElementById('docs-sidebar'),o=document.getElementById('sidebar-overlay'),t=document.getElementById('mobile-toggle');

--- a/web/docs/architecture.html
+++ b/web/docs/architecture.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -206,12 +206,7 @@
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-  </div>
+</div>
 <script>
     (function() {
       var s=document.getElementById('docs-sidebar'),o=document.getElementById('sidebar-overlay'),t=document.getElementById('mobile-toggle');

--- a/web/docs/coding-agents.html
+++ b/web/docs/coding-agents.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -212,12 +212,7 @@
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-    </div>
+</div>
   </div>
 <script>
     (function() {

--- a/web/docs/compress-engine.html
+++ b/web/docs/compress-engine.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
   <style>
     .fn-card { margin: 1.25rem 0 1.75rem; padding-bottom: 1.25rem; border-bottom: 1px solid var(--border, #e5e7eb); }
     .fn-card h3 { margin: 0 0 0.35rem; font-size: 1.05rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
@@ -806,13 +806,7 @@ compressCCR, ccrRetrieve, ccrGetStats, simpleHash, cacheWrap</code></pre>
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-
-        <footer class="docs-site-footer">
-          <div class="docs-site-footer-inner">
-            <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-          </div>
-        </footer>
-      </div>
+</div>
     </div>
   </div>
   <script>

--- a/web/docs/environment.html
+++ b/web/docs/environment.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -179,12 +179,7 @@ impact = sustainability_from_tokens_saved(saved)
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-  </div>
+</div>
 <script>
     (function() {
       var s=document.getElementById('docs-sidebar'),o=document.getElementById('sidebar-overlay'),t=document.getElementById('mobile-toggle');

--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -20,7 +20,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -207,12 +207,7 @@
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-    </div>
+</div>
   </div>
 <script>
     (function() {

--- a/web/docs/integrations.html
+++ b/web/docs/integrations.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -281,12 +281,7 @@ app.post(<span class="str">"/api/chat"</span>, sc.handler, <span class="kw">asyn
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-  </div>
+</div>
 <script>
     (function() {
       var s=document.getElementById('docs-sidebar'),o=document.getElementById('sidebar-overlay'),t=document.getElementById('mobile-toggle');

--- a/web/docs/quickstart.html
+++ b/web/docs/quickstart.html
@@ -18,7 +18,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -209,12 +209,7 @@ out = sc.compress(context, question)
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-  </div>
+</div>
 <script>
     (function() {
       var sidebar = document.getElementById('docs-sidebar');

--- a/web/docs/usage.html
+++ b/web/docs/usage.html
@@ -16,7 +16,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="/assets/css/docs.css?v=14" />
+<link rel="stylesheet" href="/assets/css/docs.css?v=15" />
 </head>
 <body>
   <div class="docs-layout">
@@ -171,12 +171,7 @@ from supercompress import compress_context</code></pre>
             <a class="docs-signup-cta-link" href="https://docs.supercompress.dev/coding-agents">Coding agents setup</a>
           </div>
         </aside>
-<footer class="docs-site-footer">
-        <div class="docs-site-footer-inner">
-          <p><a href="https://www.supercompress.dev/">SuperCompress</a> · <a href="https://docs.supercompress.dev/">Docs</a> · <a href="https://www.supercompress.dev/dashboard?signup=1">Dashboard</a> · <a href="https://docs.supercompress.dev/coding-agents">Coding agents</a> · <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a> · MIT License</p>
-        </div>
-      </footer>
-  </div>
+</div>
 <script>
     (function() {
       var s=document.getElementById('docs-sidebar'),o=document.getElementById('sidebar-overlay'),t=document.getElementById('mobile-toggle');


### PR DESCRIPTION
## Summary
- Remove `docs-site-footer` from all `web/docs/*.html` pages
- Drop unused footer CSS from `docs.css`

## Test plan
- [ ] https://docs.supercompress.dev/ has no bottom site footer
- [ ] Signup CTA + page content footer links still render

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the global site footer from every static documentation page while preserving each page's content footer and signup CTA.
- Deletes footer markup from nine documentation pages.
- Removes the corresponding footer styles.
- Advances the documentation stylesheet cache key from `v=14` to `v=15`.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking empty media query left in the stylesheet.

Footer markup and styling are removed consistently, the remaining layout containers stay balanced, and the only accepted issue is a no-op responsive CSS block.

**Files Needing Attention:** web/assets/css/docs.css

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/assets/css/docs.css | Removes the obsolete footer styles but leaves their now-empty responsive media query behind. |
| web/docs/index.html | Removes the site footer while retaining the signup CTA and balanced layout containers, and updates the CSS cache key. |
| web/docs/compress-engine.html | Removes the site footer from the more deeply nested reference page without altering its content or scripts. |
| web/docs/coding-agents.html | Removes the footer while preserving the page-specific layout closure and signup CTA. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove the site footer from docs.superco..."](https://github.com/supercompress/supercompress/commit/1b8f4fce40e53d7a3b919d4cfd5d5161f0b23c2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52102942)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->