### PR TITLE
Guard prod domains and smoke www+api after deploys

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,23 @@
+name: Production smoke
+# Catch DEPLOYMENT_NOT_FOUND / API host detach / 5xx before users do.
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/prod-smoke.sh"
+      - "scripts/ensure-prod-domains.sh"
+      - "api/**"
+      - "vercel.json"
+      - ".github/workflows/prod-smoke.yml"
+
+jobs:
+  http-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Production HTTP smoke
+        run: bash scripts/prod-smoke.sh

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "deploy:prod": "bash scripts/deploy-prod.sh",
     "launch:check": "bash scripts/hard-launch-check.sh",
+    "prod:smoke": "bash scripts/prod-smoke.sh",
+    "prod:domains": "bash scripts/ensure-prod-domains.sh",
     "release:check": "bash scripts/release-check.sh",
     "mcp": "node mcp/server.js",
     "check:version": "node scripts/check-versions.js"

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -18,3 +18,8 @@ fi
 npm ci --omit=optional --ignore-scripts --no-audit --no-fund
 npm run release:check
 vercel deploy --prod --yes
+
+# Critical: api.supercompress.dev (and siblings) must stay aliased or the API
+# returns DEPLOYMENT_NOT_FOUND under wildcard DNS — total outage class.
+bash scripts/ensure-prod-domains.sh
+bash scripts/prod-smoke.sh

--- a/scripts/ensure-prod-domains.sh
+++ b/scripts/ensure-prod-domains.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Keep critical SuperCompress hostnames attached to the Vercel production
+# deployment. Missing aliases (esp. api.supercompress.dev) cause edge
+# DEPLOYMENT_NOT_FOUND / 100% API outages under the wildcard DNS.
+set -euo pipefail
+
+cd "$(cd "$(dirname "$0")/.." && pwd)"
+
+PROJECT_JSON=".vercel/project.json"
+if [[ ! -f "$PROJECT_JSON" ]]; then
+  echo "Missing $PROJECT_JSON — run vercel link in this repo first." >&2
+  exit 1
+fi
+
+# Prefer local CLI login on developer machines; VERCEL_TOKEN for CI.
+if [[ -n "${VERCEL_AUTH_JSON:-}" && -f "${VERCEL_AUTH_JSON}" ]]; then
+  AUTH_JSON="$VERCEL_AUTH_JSON"
+elif [[ -f "$HOME/Library/Application Support/com.vercel.cli/auth.json" ]]; then
+  AUTH_JSON="$HOME/Library/Application Support/com.vercel.cli/auth.json"
+elif [[ -f "$HOME/.local/share/com.vercel.cli/auth.json" ]]; then
+  AUTH_JSON="$HOME/.local/share/com.vercel.cli/auth.json"
+else
+  AUTH_JSON=""
+fi
+if [[ -n "$AUTH_JSON" ]]; then
+  export VERCEL_TOKEN="$(python3 -c "import json; print(json.load(open(r'''$AUTH_JSON'''))['token'])")"
+elif [[ -z "${VERCEL_TOKEN:-}" ]]; then
+  echo "Missing Vercel auth — set VERCEL_TOKEN or run: vercel login" >&2
+  exit 1
+fi
+
+export SUPERCOMPRESS_VERCEL_PROJECT_JSON="$PROJECT_JSON"
+# Collect broken hosts (if any) for CLI repair.
+BROKEN_FILE="$(mktemp)"
+export BROKEN_FILE
+python3 <<'PY'
+import json, os, sys, urllib.error, urllib.request
+
+REQUIRED = [
+    "www.supercompress.dev",
+    "docs.supercompress.dev",
+    "api.supercompress.dev",
+    "supercompress.dev",
+]
+ALIAS_HOSTS = [
+    "api.supercompress.dev",
+    "docs.supercompress.dev",
+    "www.supercompress.dev",
+]
+
+proj = json.load(open(os.environ["SUPERCOMPRESS_VERCEL_PROJECT_JSON"]))
+org_id = proj["orgId"]
+project_id = proj["projectId"]
+token = os.environ["VERCEL_TOKEN"]
+
+
+def api(method, path, body=None):
+    url = f"https://api.vercel.com{path}"
+    sep = "&" if "?" in path else "?"
+    if "teamId=" not in path:
+        url = f"{url}{sep}teamId={org_id}"
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode() or "{}"
+            return resp.status, json.loads(raw)
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            payload = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            payload = {"raw": raw}
+        return e.code, payload
+
+
+print(f"Checking production domains for project {project_id}...")
+code, domain_payload = api("GET", f"/v1/projects/{project_id}/domains")
+if code != 200:
+    print(f"FAIL listing domains HTTP {code}: {domain_payload}", file=sys.stderr)
+    sys.exit(1)
+
+names = {d.get("name") for d in domain_payload.get("domains", [])}
+missing = [h for h in REQUIRED if h not in names]
+if missing:
+    print(f"Missing on project (will add via CLI): {' '.join(missing)}")
+    open(os.environ["BROKEN_FILE"], "a").write("\n".join(f"missing:{h}" for h in missing) + "\n")
+else:
+    print("All required domains are attached to the project.")
+
+code, deps = api(
+    "GET",
+    f"/v6/deployments?projectId={project_id}&target=production&limit=1&state=READY",
+)
+rows = (deps or {}).get("deployments") or []
+if code != 200 or not rows:
+    print(f"FAIL resolving production deployment HTTP {code}: {deps}", file=sys.stderr)
+    sys.exit(1)
+deployment = rows[0]
+prod_url = "https://" + deployment["url"]
+print(f"Production deployment: {prod_url}")
+open(os.environ["BROKEN_FILE"], "a").write(f"prod_url:{prod_url}\n")
+
+broken = []
+for host in ALIAS_HOSTS:
+    req = urllib.request.Request(f"https://{host}/", method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=25) as resp:
+            print(f"  edge {host} → HTTP {resp.status}")
+    except urllib.error.HTTPError as e:
+        err = e.headers.get("x-vercel-error") if e.headers else None
+        if err == "DEPLOYMENT_NOT_FOUND":
+            print(f"  BROKEN {host} → DEPLOYMENT_NOT_FOUND")
+            broken.append(host)
+        else:
+            print(f"  edge {host} → HTTP {e.code}")
+    except Exception as e:
+        print(f"  BROKEN {host} → {e}")
+        broken.append(host)
+
+if broken:
+    open(os.environ["BROKEN_FILE"], "a").write("\n".join(f"broken:{h}" for h in broken) + "\n")
+    print(f"Will repair broken aliases: {' '.join(broken)}")
+else:
+    print("All edge hosts healthy — no alias repair needed.")
+PY
+
+PROD_URL="$(awk -F: '/^prod_url:/ {print substr($0,10); exit}' "$BROKEN_FILE")"
+MISSING=()
+BROKEN=()
+while IFS= read -r line; do
+  case "$line" in
+    missing:*) MISSING+=("${line#missing:}") ;;
+    broken:*) BROKEN+=("${line#broken:}") ;;
+  esac
+done < "$BROKEN_FILE"
+rm -f "$BROKEN_FILE"
+
+if ((${#MISSING[@]})) || ((${#BROKEN[@]})); then
+  if ! command -v vercel >/dev/null 2>&1; then
+    echo "Need Vercel CLI to repair domains/aliases." >&2
+    exit 1
+  fi
+fi
+
+if ((${#MISSING[@]})); then
+  echo "Adding missing domains via CLI..."
+  for host in "${MISSING[@]}"; do
+    vercel domains add "$host"
+  done
+fi
+
+if ((${#BROKEN[@]})); then
+  echo "Repairing broken aliases → ${PROD_URL}"
+  for host in "${BROKEN[@]}"; do
+    vercel alias set "$PROD_URL" "$host"
+    echo "  repaired $host"
+  done
+fi
+
+# Final edge gate — never leave DEPLOYMENT_NOT_FOUND uncaught.
+fail=0
+for host in www.supercompress.dev api.supercompress.dev docs.supercompress.dev; do
+  headers="$(mktemp)"
+  code="$(curl -sS -D "$headers" -o /dev/null --max-time 25 -w '%{http_code}' "https://${host}/" || echo 000)"
+  if grep -qi 'x-vercel-error:[[:space:]]*DEPLOYMENT_NOT_FOUND' "$headers"; then
+    echo "FAIL $host still returns DEPLOYMENT_NOT_FOUND" >&2
+    fail=1
+  elif [[ "$code" == "000" ]]; then
+    echo "FAIL $host unreachable" >&2
+    fail=1
+  else
+    echo "  final $host → HTTP $code"
+  fi
+  rm -f "$headers"
+done
+
+if ((fail)); then
+  exit 1
+fi
+
+echo "Production domains OK."

--- a/scripts/hard-launch-check.sh
+++ b/scripts/hard-launch-check.sh
@@ -4,20 +4,16 @@ set -euo pipefail
 cd "$(cd "$(dirname "$0")/.." && pwd)"
 
 npm run release:check
+bash scripts/ensure-prod-domains.sh
+bash scripts/prod-smoke.sh
 
-live_url="${SUPERCOMPRESS_LIVE_URL:-https://supercompress.dev}"
+live_url="${SUPERCOMPRESS_LIVE_URL:-https://www.supercompress.dev}"
 homepage="$(curl -fsSL --max-time 20 "$live_url/")"
 docs="$(curl -fsSL --max-time 20 "$live_url/docs/coding-agents")"
-auth_status="$(curl -fsSL --max-time 20 "$live_url/api/auth-status")"
 
 grep -q 'id="coding-agents"' <<<"$homepage"
 grep -Eq 'npm install (-g )?supercompress-proxy' <<<"$homepage"
 grep -q 'supercompress setup' <<<"$homepage"
 grep -q 'supercompress-proxy' <<<"$docs"
-grep -q '"storage":"firestore"' <<<"$auth_status"
-
-status="$(curl -L -sS --max-time 20 -o /tmp/supercompress-launch-api-response -w '%{http_code}' -X POST "$live_url/api/v1/compress" -H 'content-type: application/json' --data '{"context":"launch smoke","query":"launch"}')"
-[[ "$status" == "401" ]]
-grep -q 'Missing or invalid API key' /tmp/supercompress-launch-api-response
 
 echo "hard launch checks passed for $live_url"

--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Production smoke: static pages + API hosts (www + api) must stay healthy.
+# Exits non-zero on any failure. Safe to run anytime / post-deploy.
+set -euo pipefail
+
+cd "$(cd "$(dirname "$0")/.." && pwd)"
+
+WWW="${SUPERCOMPRESS_WWW_URL:-https://www.supercompress.dev}"
+API="${SUPERCOMPRESS_API_HOST:-https://api.supercompress.dev}"
+DOCS="${SUPERCOMPRESS_DOCS_URL:-https://docs.supercompress.dev}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+check() {
+  local name="$1" expect="$2" url="$3"
+  shift 3
+  local body="$TMP/body"
+  local code
+  code="$(curl -sS -L --max-time 45 -o "$body" -w '%{http_code}' "$@" "$url" || echo 000)"
+  if [[ "$code" != "$expect" ]]; then
+    echo "FAIL $name — expected HTTP $expect, got $code ($url)"
+    head -c 240 "$body" 2>/dev/null | tr '\n' ' '; echo
+    fail=$((fail + 1))
+    return 1
+  fi
+  # Guard the exact outage class we hit: edge has no deployment
+  if grep -qi 'DEPLOYMENT_NOT_FOUND' "$body" 2>/dev/null; then
+    echo "FAIL $name — DEPLOYMENT_NOT_FOUND ($url)"
+    fail=$((fail + 1))
+    return 1
+  fi
+  echo "PASS $name ($code)"
+  pass=$((pass + 1))
+}
+
+expect_body() {
+  local name="$1" needle="$2" file="$3"
+  if ! grep -q "$needle" "$file"; then
+    echo "FAIL $name — response missing '$needle'"
+    fail=$((fail + 1))
+    return 1
+  fi
+}
+
+echo "=== SuperCompress production smoke ==="
+echo "www=$WWW"
+echo "api=$API"
+echo "docs=$DOCS"
+echo
+
+# Domains / edge
+check "www home" 200 "$WWW/"
+check "api health" 200 "$API/api/health"
+check "www health" 200 "$WWW/api/health"
+expect_body "www health body" '"ok":true' "$TMP/body"
+check "docs root" 200 "$DOCS/" 
+
+# Marketing / product surfaces
+check "dashboard" 200 "$WWW/dashboard"
+check "analytics" 200 "$WWW/analytics"
+check "token-compression" 200 "$WWW/token-compression"
+
+# Account / auth plumbing (unauthenticated shapes)
+check "account ops" 200 "$WWW/api/account"
+expect_body "account ops body" '"ok":true' "$TMP/body"
+check "api account ops" 200 "$API/api/account"
+check "auth-status" 200 "$WWW/api/auth-status"
+expect_body "auth-status firestore" '"storage":"firestore"' "$TMP/body"
+check "firebase-config" 200 "$WWW/api/firebase-config"
+expect_body "firebase-config key" 'apiKey' "$TMP/body"
+check "usage requires auth" 200 "$WWW/api/usage"
+expect_body "usage auth" 'auth' "$TMP/body"
+check "billing requires auth" 200 "$WWW/api/billing"
+
+# Compress entrypoints (must reject missing key, never 5xx / DEPLOYMENT_NOT_FOUND)
+COMPRESS_JSON='{"context":"production smoke context for supercompress","query":"smoke"}'
+for host_label in www api; do
+  base="$WWW"
+  [[ "$host_label" == api ]] && base="$API"
+  for path in /api/v1/compress /v1/compress /api/compress; do
+    check "${host_label} POST ${path}" 401 "$base$path" \
+      -X POST -H 'content-type: application/json' --data "$COMPRESS_JSON"
+    expect_body "${host_label} ${path} body" 'API key' "$TMP/body"
+  done
+done
+
+# GET compress must be method-not-allowed (not 5xx)
+check "www GET compress" 405 "$WWW/api/v1/compress"
+check "api GET compress" 405 "$API/api/v1/compress"
+
+# Optional authenticated compress (if local key present)
+KEY=""
+CFG="${SUPERCOMPRESS_CONFIG_DIR:-$HOME/.supercompress}/config.json"
+if [[ -f "$CFG" ]]; then
+  KEY="$(python3 -c "import json; print(json.load(open('$CFG')).get('api_key') or '')" 2>/dev/null || true)"
+fi
+if [[ -n "${SUPERCOMPRESS_API_KEY:-}" ]]; then
+  KEY="$SUPERCOMPRESS_API_KEY"
+fi
+
+if [[ -n "$KEY" ]]; then
+  echo
+  echo "=== Authenticated compress ==="
+  for host_label in www api; do
+    base="$WWW"
+    [[ "$host_label" == api ]] && base="$API"
+    body="$TMP/auth-$host_label"
+    code="$(curl -sS --max-time 60 -o "$body" -w '%{http_code}' \
+      -X POST "$base/api/v1/compress" \
+      -H "X-API-Key: $KEY" \
+      -H 'content-type: application/json' \
+      --data "$COMPRESS_JSON" || echo 000)"
+    if [[ "$code" != "200" ]]; then
+      echo "FAIL auth compress on $host_label — HTTP $code"
+      head -c 300 "$body"; echo
+      fail=$((fail + 1))
+    else
+      echo "PASS auth compress on $host_label (200)"
+      pass=$((pass + 1))
+    fi
+  done
+else
+  echo
+  echo "SKIP authenticated compress (no SUPERCOMPRESS_API_KEY / ~/.supercompress/config.json)"
+fi
+
+echo
+echo "=== Result: $pass passed, $fail failed ==="
+if ((fail > 0)); then
+  exit 1
+fi
+echo "production smoke OK"


### PR DESCRIPTION
## Summary
- Add `ensure-prod-domains` so `api.supercompress.dev` (and www/docs) stay attached to the production deployment — prevents `DEPLOYMENT_NOT_FOUND` outages under wildcard DNS
- Add `prod-smoke` HTTP matrix covering www + api health, account, auth-status, and compress entrypoints
- Wire both into `deploy:prod` / `launch:check`, plus a 15-minute GitHub Actions production smoke workflow

## Test plan
- [x] `npm run prod:domains` — domains OK, edge healthy
- [x] `npm run prod:smoke` — 21/21 passed
- [ ] Merge + `npm run deploy:prod` (or confirm Vercel production promote)
- [ ] Confirm `https://api.supercompress.dev/api/health` stays 200 after deploy

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated production smoke testing for the website, API, documentation, authentication, and compression workflows.
  - Added production-domain validation and repair checks to help ensure expected domains remain available.

- **Improvements**
  - Production deployments now automatically verify domain configuration and run post-deployment health checks.
  - Scheduled and on-demand monitoring helps detect availability, routing, and response issues sooner.
  - Launch checks now include comprehensive domain and smoke-test validation before confirming production readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds production-domain repair and a recurring HTTP smoke matrix, then wires both checks into production deployment and launch validation.
- Adds Vercel project-domain inspection and alias repair for the production hosts.
- Adds unauthenticated and optional authenticated checks across www, API, and docs surfaces.
- Adds a scheduled and push-triggered GitHub Actions smoke workflow.
- Extends production deployment and hard-launch scripts to run the new guards.

<h3>Confidence Score: 4/5</h3>

The smoke runner should be fixed before merging because its first failed request aborts the remaining production checks, while the mutable workflow action reference is a non-blocking hardening concern.

The new matrix records failures internally but returns nonzero from each failed check under `set -e`, preventing later endpoints and the aggregate result from being evaluated.

**Files Needing Attention:** scripts/prod-smoke.sh, .github/workflows/prod-smoke.yml

<details open><summary><h3>Security Review</h3></summary>

The new workflow uses a mutable checkout action tag. Pinning it to a full commit SHA would prevent an upstream tag move from silently changing code executed in the workflow context.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/prod-smoke.sh | Adds broad production HTTP coverage, but `set -e` causes the matrix to terminate on its first failed `check`. |
| scripts/ensure-prod-domains.sh | Adds Vercel domain inspection, repair, and final edge validation with fixed production hostnames. |
| scripts/deploy-prod.sh | Runs domain repair and production smoke validation immediately after a successful production deployment. |
| scripts/hard-launch-check.sh | Reuses the new production guards and switches direct page checks to the canonical www host. |
| .github/workflows/prod-smoke.yml | Adds recurring and change-triggered production smoke checks, with a non-blocking mutable-action pinning concern. |
| package.json | Exposes the new domain and smoke scripts through npm commands. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Operator
    participant Deploy as deploy-prod.sh
    participant Vercel
    participant Domains as ensure-prod-domains.sh
    participant Smoke as prod-smoke.sh
    Operator->>Deploy: npm run deploy:prod
    Deploy->>Deploy: install and release checks
    Deploy->>Vercel: vercel deploy --prod
    Vercel-->>Deploy: production deployment
    Deploy->>Domains: inspect and repair domains
    Domains->>Vercel: list domains and READY deployment
    Domains->>Vercel: add domains / repair aliases
    Deploy->>Smoke: run HTTP matrix
    Smoke->>Vercel: check www, API, and docs routes
    Smoke-->>Operator: pass or failure
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Guard production domains and smoke www+a..."](https://github.com/supercompress/supercompress/commit/df668cb86c75744de95f6f6e21abc27a891814bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52204024)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->