### PR TITLE
fix: P1 billing, smoke, meter, agent publish safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           node --check packages/proxy/src/server.js
       - name: Billing ledger unit tests
         run: node api/_lib/billing-ledger.test.js
+      - name: Coding agent monthly usage unit tests
+        run: node api/_lib/coding-agent-usage.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
       - name: Proxy package tests

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -16,8 +16,10 @@ on:
 jobs:
   http-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
       - name: Production HTTP smoke
+        env:
+          SUPERCOMPRESS_API_KEY: ${{ secrets.SUPERCOMPRESS_API_KEY }}
         run: bash scripts/prod-smoke.sh

--- a/api/_lib/coding-agent-usage.js
+++ b/api/_lib/coding-agent-usage.js
@@ -1,0 +1,44 @@
+/**
+ * Month-bucket projection for coding_agent_usage docs.
+ * Kept free of Firebase so unit tests stay lightweight.
+ */
+
+/**
+ * Project agent docs onto a single billing month.
+ * Legacy docs without `months` only count if last_seen falls in that month
+ * (avoids September inheriting August lifetime totals).
+ */
+function agentUsageForMonth(agents, month) {
+  const m = String(month || new Date().toISOString().slice(0, 7));
+  const out = {};
+  for (const [name, snap] of Object.entries(agents || {})) {
+    if (!snap || typeof snap !== "object") continue;
+    let bucket = null;
+    if (snap.months && typeof snap.months === "object" && snap.months[m]) {
+      bucket = snap.months[m];
+    } else if (!snap.months) {
+      const last = String(snap.last_seen || snap.first_seen || "");
+      if (last.startsWith(m)) bucket = snap;
+    }
+    if (!bucket) continue;
+    out[name] = {
+      requests: bucket.requests || 0,
+      tokens_in: bucket.tokens_in || 0,
+      tokens_out: bucket.tokens_out || 0,
+      tokens_saved: bucket.tokens_saved || 0,
+      first_seen: bucket.first_seen || snap.first_seen || null,
+      last_seen: bucket.last_seen || snap.last_seen || null,
+      last_pct: bucket.last_pct != null ? bucket.last_pct : snap.last_pct ?? null,
+      last_query: bucket.last_query || snap.last_query || null,
+      last_source: bucket.last_source || snap.last_source || null,
+      latency_sum_ms: bucket.latency_sum_ms || 0,
+      latency_samples: bucket.latency_samples || 0,
+      last_latency_ms: bucket.last_latency_ms != null ? bucket.last_latency_ms : snap.last_latency_ms ?? null,
+      avg_latency_ms: bucket.avg_latency_ms != null ? bucket.avg_latency_ms : snap.avg_latency_ms ?? null,
+      month: m,
+    };
+  }
+  return out;
+}
+
+module.exports = { agentUsageForMonth };

--- a/api/_lib/coding-agent-usage.test.js
+++ b/api/_lib/coding-agent-usage.test.js
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for month-bucketed coding agent usage projection.
+ * Run: node api/_lib/coding-agent-usage.test.js
+ */
+const assert = require("assert");
+const { agentUsageForMonth } = require("./coding-agent-usage");
+
+const month = "2026-08";
+
+// Lifetime-only legacy doc from July must not poison August
+{
+  const out = agentUsageForMonth(
+    {
+      cursor: {
+        requests: 100,
+        tokens_in: 1_000_000,
+        tokens_saved: 500_000,
+        last_seen: "2026-07-30T12:00:00.000Z",
+      },
+    },
+    month
+  );
+  assert.deepStrictEqual(out, {});
+}
+
+// Lifetime-only legacy doc last seen in August counts for August
+{
+  const out = agentUsageForMonth(
+    {
+      cursor: {
+        requests: 3,
+        tokens_in: 300,
+        tokens_saved: 100,
+        last_seen: "2026-08-05T12:00:00.000Z",
+      },
+    },
+    month
+  );
+  assert.equal(out.cursor.tokens_in, 300);
+  assert.equal(out.cursor.month, month);
+}
+
+// Explicit month buckets — only current month
+{
+  const out = agentUsageForMonth(
+    {
+      cursor: {
+        months: {
+          "2026-07": { requests: 50, tokens_in: 9000, tokens_saved: 4000 },
+          "2026-08": { requests: 2, tokens_in: 200, tokens_saved: 80 },
+        },
+        tokens_in: 200, // top-level mirrors current write — ignore for other months
+        last_seen: "2026-08-10T00:00:00.000Z",
+      },
+    },
+    month
+  );
+  assert.equal(out.cursor.tokens_in, 200);
+  assert.equal(out.cursor.requests, 2);
+  const july = agentUsageForMonth(
+    {
+      cursor: {
+        months: {
+          "2026-07": { requests: 50, tokens_in: 9000, tokens_saved: 4000 },
+          "2026-08": { requests: 2, tokens_in: 200, tokens_saved: 80 },
+        },
+      },
+    },
+    "2026-07"
+  );
+  assert.equal(july.cursor.tokens_in, 9000);
+}
+
+console.log("coding-agent-usage.test.js: ok");

--- a/api/_lib/rate-limit-durable.js
+++ b/api/_lib/rate-limit-durable.js
@@ -8,9 +8,9 @@
  * For authenticated paid endpoints, callers should treat backend !== "firestore"
  * as fail-closed (reject) so multi-instance fans-out cannot bypass the ceiling.
  *
- * Optional requestId makes increments idempotent for *true* retries that share
- * the same client Idempotency-Key. Do not pass a payload fingerprint alone —
- * identical bodies with different keys must each consume a rate-limit slot.
+ * Optional requestId makes increments idempotent for *true* retries.
+ * Pass SHA256(idempotencyKey + ":" + payloadFingerprint) so a reused
+ * idempotency key with a different body still consumes a new slot.
  */
 const crypto = require("crypto");
 const admin = require("firebase-admin");

--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -821,13 +821,6 @@ async function trackCodingAgentUsage(ownerUid, codingAgent, stats = {}) {
 }
 
 /**
- * Project agent docs onto a single billing month.
- * Legacy docs without `months` only count if last_seen falls in that month
- * (avoids September inheriting August lifetime totals).
- */
-const { agentUsageForMonth } = require("./coding-agent-usage");
-
-/**
  * Cursor postToolUse used to default coding_agent to "Claude Code" whenever the
  * hook payload had session_id/cwd (Cursor always does). Those rows look like
  * claude_code + last_source tool_shell|tool_read|… Merge them into cursor.

--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -14,6 +14,7 @@
 
 const { initFirebaseAdmin } = require("./auth");
 const { gistConfigured, loadGistStore, saveGistStore } = require("./gist-store");
+const { agentUsageForMonth } = require("./coding-agent-usage");
 
 let /** @type {import("firebase-admin").firestore.Firestore | null} */ _db = null;
 
@@ -721,6 +722,9 @@ function publicKey(rec) {
  * Persist per-coding-agent usage in a dedicated Firestore doc so it cannot be
  * lost when the monolithic config/store document conflicts or overflows.
  * Falls back to embedding into config/store when Firestore is unavailable.
+ *
+ * Counters are month-bucketed under `months[YYYY-MM]` so month rollover cannot
+ * stamp lifetime agent totals onto the new billing month.
  */
 async function trackCodingAgentUsage(ownerUid, codingAgent, stats = {}) {
   if (!ownerUid || !codingAgent) return false;
@@ -739,8 +743,9 @@ async function trackCodingAgentUsage(ownerUid, codingAgent, stats = {}) {
     ? String(stats.source).toLowerCase().replace(/[^a-z0-9_-]/g, "_").slice(0, 32)
     : null;
   const now = new Date().toISOString();
+  const month = now.slice(0, 7);
 
-  const bump = (prev) => {
+  const bumpMonth = (prev) => {
     const next = {
       requests: (prev.requests || 0) + 1,
       tokens_in: (prev.tokens_in || 0) + tokensIn,
@@ -765,19 +770,40 @@ async function trackCodingAgentUsage(ownerUid, codingAgent, stats = {}) {
     return next;
   };
 
+  const bumpAgent = (prevAgent) => {
+    const base = prevAgent && typeof prevAgent === "object" ? prevAgent : {};
+    const months =
+      base.months && typeof base.months === "object" ? { ...base.months } : {};
+    const monthPrev = months[month] && typeof months[month] === "object" ? months[month] : {};
+    months[month] = bumpMonth(monthPrev);
+    // Keep top-level last_* for dashboards that still read them; do NOT accumulate
+    // lifetime totals into tokens_in/requests used for monthly billing merge.
+    return {
+      ...base,
+      months,
+      month,
+      requests: months[month].requests,
+      tokens_in: months[month].tokens_in,
+      tokens_out: months[month].tokens_out,
+      tokens_saved: months[month].tokens_saved,
+      first_seen: months[month].first_seen || base.first_seen || now,
+      last_seen: now,
+      last_pct: cutPct,
+      last_query: lastQuery || base.last_query || null,
+      last_source: source || base.last_source || null,
+      latency_sum_ms: months[month].latency_sum_ms,
+      latency_samples: months[month].latency_samples,
+      last_latency_ms: months[month].last_latency_ms,
+      avg_latency_ms: months[month].avg_latency_ms,
+    };
+  };
+
   if (firestoreUnavailable) {
     await mutateStore((store) => {
       if (!store.coding_agent_usage) store.coding_agent_usage = {};
       if (!store.coding_agent_usage[ownerUid]) store.coding_agent_usage[ownerUid] = {};
-      const prev = store.coding_agent_usage[ownerUid][agentName] || {
-        requests: 0,
-        tokens_in: 0,
-        tokens_out: 0,
-        tokens_saved: 0,
-        first_seen: now,
-        last_seen: now,
-      };
-      store.coding_agent_usage[ownerUid][agentName] = bump(prev);
+      const prev = store.coding_agent_usage[ownerUid][agentName] || {};
+      store.coding_agent_usage[ownerUid][agentName] = bumpAgent(prev);
       return true;
     });
     return true;
@@ -788,19 +814,18 @@ async function trackCodingAgentUsage(ownerUid, codingAgent, stats = {}) {
     const snap = await tx.get(docRef);
     const data = snap.exists && snap.data() ? snap.data() : { agents: {} };
     const agents = data.agents && typeof data.agents === "object" ? data.agents : {};
-    const prev = agents[agentName] || {
-      requests: 0,
-      tokens_in: 0,
-      tokens_out: 0,
-      tokens_saved: 0,
-      first_seen: now,
-      last_seen: now,
-    };
-    agents[agentName] = bump(prev);
+    agents[agentName] = bumpAgent(agents[agentName] || {});
     tx.set(docRef, { agents, updated_at: now }, { merge: true });
   });
   return true;
 }
+
+/**
+ * Project agent docs onto a single billing month.
+ * Legacy docs without `months` only count if last_seen falls in that month
+ * (avoids September inheriting August lifetime totals).
+ */
+const { agentUsageForMonth } = require("./coding-agent-usage");
 
 /**
  * Cursor postToolUse used to default coding_agent to "Claude Code" whenever the
@@ -848,16 +873,18 @@ function repairMisattributedCodingAgents(agents) {
   return { agents: next, changed: true };
 }
 
-async function loadCodingAgentUsage(ownerUid) {
+async function loadCodingAgentUsage(ownerUid, opts = {}) {
   if (!ownerUid) return {};
+  const month = opts.month || new Date().toISOString().slice(0, 7);
+  let agents = {};
   if (!firestoreUnavailable) {
     try {
       const docRef = db().collection("coding_agent_usage").doc(ownerUid);
       const snap = await docRef.get();
       if (snap.exists) {
-        const agents = snap.data()?.agents;
-        if (agents && typeof agents === "object") {
-          const { agents: fixed, changed } = repairMisattributedCodingAgents(agents);
+        const raw = snap.data()?.agents;
+        if (raw && typeof raw === "object") {
+          const { agents: fixed, changed } = repairMisattributedCodingAgents(raw);
           if (changed) {
             // Persist repair so dashboard stays correct without re-deriving every read.
             const now = new Date().toISOString();
@@ -865,7 +892,7 @@ async function loadCodingAgentUsage(ownerUid) {
               console.warn("store: coding_agent_usage repair persist failed:", err.message);
             });
           }
-          return fixed;
+          agents = fixed;
         }
       }
     } catch (err) {
@@ -873,9 +900,13 @@ async function loadCodingAgentUsage(ownerUid) {
       if (isFirestoreUnavailable(err)) firestoreUnavailable = true;
     }
   }
-  const store = await loadStore({ forceRemote: true });
-  const embedded = store.coding_agent_usage?.[ownerUid] || {};
-  return repairMisattributedCodingAgents(embedded).agents;
+  if (!Object.keys(agents).length) {
+    const store = await loadStore({ forceRemote: true });
+    const embedded = store.coding_agent_usage?.[ownerUid] || {};
+    agents = repairMisattributedCodingAgents(embedded).agents;
+  }
+  if (opts.allMonths) return agents;
+  return agentUsageForMonth(agents, month);
 }
 
 /**
@@ -948,6 +979,7 @@ module.exports = {
   publicKey,
   trackCodingAgentUsage,
   loadCodingAgentUsage,
+  agentUsageForMonth,
   trackKeyUsage,
   loadKeyUsage,
   mergeKeySnaps,

--- a/api/keys.js
+++ b/api/keys.js
@@ -20,8 +20,9 @@ module.exports = async (req, res) => {
       try {
         agent_plugin = await loadAgentPluginLink(user.uid);
       } catch (_) {}
-      // Prefer max(ledger/claims, coding-agent totals) so analytics KPIs never
-      // under-report when the billing ledger lags agent metering.
+      // Prefer max(ledger/claims, *current-month* coding-agent totals) so analytics
+      // KPIs never under-report when the billing ledger lags agent metering —
+      // and never stamp lifetime agent counters onto the new month.
       let account_usage = keys.account_usage || null;
       const agentTotals = Object.values(coding_agent_usage || {}).reduce(
         (acc, snap) => ({

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -197,14 +197,17 @@ module.exports = async (req, res) => {
         request_id: requestId,
       }, rlMem);
     }
+    // True retry = same Idempotency-Key AND same payload fingerprint → one durable hit.
+    // Reused idempotency key with a different body must consume another slot.
+    const rateHitId = clientIdem
+      ? crypto.createHash("sha256").update(`${clientIdem}:${fingerprint}`).digest("hex").slice(0, 40)
+      : undefined;
     let rl;
     try {
       rl = await withTimeout(
         enforceRateLimits(
           [{ key: `v1ip:h:${ip}`, max: V1_IP_HOURLY, windowMs: 60 * 60_000 }],
-          // True retries share a client Idempotency-Key. Never use payload
-          // fingerprint alone — identical bodies with different keys must each count.
-          { requestId: clientIdem || undefined }
+          { requestId: rateHitId }
         ),
         2000,
         "rate_limit"
@@ -257,9 +260,9 @@ module.exports = async (req, res) => {
     }
 
     const authenticated = await withTimeout(authenticateKey(raw), 8000, "authenticate");
-    await withTimeout(enforceUsageLimit(authenticated.owner), 10000, "usage_limit");
 
-    // Replay stored response for the same Idempotency-Key + payload (no recompute).
+    // Replay BEFORE quota/credit gates so a successfully billed request stays
+    // replayable after free quota is exhausted (and does not trigger auto-recharge).
     if (clientIdem) {
       const prev = await withTimeout(
         lookupUsageReplay(authenticated.ownerUid, clientIdem),
@@ -293,6 +296,8 @@ module.exports = async (req, res) => {
       }
     }
 
+    await withTimeout(enforceUsageLimit(authenticated.owner), 10000, "usage_limit");
+
     if (mode === "fixed" && (budgetRatio < 0.05 || budgetRatio > 1)) {
       const err = new Error("invalid budget_ratio");
       err.status = 422;
@@ -314,53 +319,6 @@ module.exports = async (req, res) => {
       (authenticated.user?.name && /coding agent|cli|mcp|plugin/i.test(authenticated.user.name)
         ? "agent"
         : "api");
-
-    // Activity log: capped previews only (never full dumps). Skip when budget is tight.
-    if (!skipLog && remainingMs() > 4000) {
-      try {
-        const { appendCompressLog } = require("../_lib/compress-log");
-        const tokensSaved = Math.max(
-          0,
-          result.tokens_saved ?? Math.max(0, (result.original_tokens || 0) - (result.kept_tokens || 0))
-        );
-        await withTimeout(appendCompressLog(authenticated.ownerUid, {
-          query,
-          original_preview: context,
-          compressed_preview: result.compressed_text,
-          tokens_in: result.original_tokens,
-          tokens_out: result.kept_tokens,
-          tokens_saved: tokensSaved,
-          tokens_saved_pct: result.tokens_saved_pct ?? result.kv_savings_pct,
-          coding_agent: coding_agent || null,
-          key_prefix: authenticated.user?.prefix || raw.slice(0, 16),
-          mode,
-          source: inferredSource,
-          session_id: session_id || null,
-          latency_ms: latencyMs,
-        }), Math.min(4000, remainingMs() - 1500), "compress_log");
-      } catch (err) {
-        console.warn("compress log skipped:", err.message);
-      }
-    }
-
-    // Track coding agent usage in a dedicated Firestore collection (more reliable
-    // than mutating the monolithic config/store document).
-    if (coding_agent && remainingMs() > 3000) {
-      try {
-        const { trackCodingAgentUsage } = require("../_lib/store");
-        const tokensSaved = Math.max(0, (result.original_tokens || 0) - (result.kept_tokens || 0));
-        await withTimeout(trackCodingAgentUsage(authenticated.ownerUid, coding_agent, {
-          original_tokens: result.original_tokens,
-          kept_tokens: result.kept_tokens,
-          tokens_saved: tokensSaved,
-          latency_ms: latencyMs,
-          query,
-          source: inferredSource,
-        }), Math.min(3000, remainingMs() - 1000), "coding_agent_usage");
-      } catch (err) {
-        console.warn("Failed to track coding agent usage:", err.message);
-      }
-    }
 
     // CacheAligner: persist block-level hashes to Blob (async, after mutateStore completes)
     // The compressCCR result (compiler+CCR mode) already has [SC-Retrieve: hash] markers
@@ -488,6 +446,52 @@ module.exports = async (req, res) => {
       e.code = err.code || "billing_unavailable";
       e.requestId = requestId;
       throw e;
+    }
+
+    // Analytics / agent meters ONLY after immutable successful billing — never credit
+    // usage for a request that was rejected by recordUsage.
+    if (!skipLog && remainingMs() > 2500) {
+      try {
+        const { appendCompressLog } = require("../_lib/compress-log");
+        const tokensSaved = Math.max(
+          0,
+          result.tokens_saved ?? Math.max(0, (result.original_tokens || 0) - (result.kept_tokens || 0))
+        );
+        await withTimeout(appendCompressLog(authenticated.ownerUid, {
+          query,
+          original_preview: context,
+          compressed_preview: finalText,
+          tokens_in: result.original_tokens,
+          tokens_out: result.kept_tokens,
+          tokens_saved: tokensSaved,
+          tokens_saved_pct: result.tokens_saved_pct ?? result.kv_savings_pct,
+          coding_agent: coding_agent || null,
+          key_prefix: authenticated.user?.prefix || raw.slice(0, 16),
+          mode,
+          source: inferredSource,
+          session_id: session_id || null,
+          latency_ms: latencyMs,
+        }), Math.min(3000, remainingMs() - 800), "compress_log");
+      } catch (err) {
+        console.warn("compress log skipped:", err.message);
+      }
+    }
+
+    if (coding_agent && remainingMs() > 2000) {
+      try {
+        const { trackCodingAgentUsage } = require("../_lib/store");
+        const tokensSaved = Math.max(0, (result.original_tokens || 0) - (result.kept_tokens || 0));
+        await withTimeout(trackCodingAgentUsage(authenticated.ownerUid, coding_agent, {
+          original_tokens: result.original_tokens,
+          kept_tokens: result.kept_tokens,
+          tokens_saved: tokensSaved,
+          latency_ms: latencyMs,
+          query,
+          source: inferredSource,
+        }), Math.min(2500, remainingMs() - 500), "coding_agent_usage");
+      } catch (err) {
+        console.warn("Failed to track coding agent usage:", err.message);
+      }
     }
 
     res.setHeader("Idempotency-Key", requestId);

--- a/packages/proxy/src/cursor-hooks/before-submit.js
+++ b/packages/proxy/src/cursor-hooks/before-submit.js
@@ -13,6 +13,7 @@ const {
   writeInbox,
   splitAskAndContext,
   resolveSessionId,
+  shouldPublishCompressedResult,
 } = require("./compress-prompt-lib");
 
 const MIN_CONTEXT_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MIN_CHARS || 400);
@@ -61,9 +62,7 @@ process.stdin.on("end", async () => {
     });
 
     if (!result.compressed) return done();
-    if (result.skipped === "no_key" || String(result.skipped || "").startsWith("http_")) {
-      return done();
-    }
+    if (!shouldPublishCompressedResult(result)) return done();
 
     const meta =
       result.skipped === "already_seen"

--- a/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
+++ b/packages/proxy/src/cursor-hooks/compress-prompt-lib.js
@@ -403,10 +403,9 @@ async function compressContext(context, query, codingAgent, opts = {}) {
     ) {
       lastSkip = r.skipped || "error";
       failedChunks += 1;
-      // Keep raw chunk so we do not drop context on partial failure.
-      parts.push(chunks[i]);
+      // Never reinject raw failed chunks into the digest — callers must skip publish
+      // on partial_chunk_failure so 120k dumps do not leak back into agent context.
       totalIn += Math.round(chunks[i].length / 4);
-      totalOut += Math.round(chunks[i].length / 4);
       continue;
     }
     okChunks += 1;
@@ -607,11 +606,27 @@ async function compressPrompt(context, codingAgent) {
   return compressContext(context, "Compress this context for the coding agent.", codingAgent);
 }
 
+/**
+ * Whether a compress result is safe to write into inbox / additional_context.
+ * Partial chunk failures must never reinject mixed raw+compressed dumps.
+ */
+function shouldPublishCompressedResult(result) {
+  if (!result || !result.compressed) return false;
+  if (result.partial || result.skipped === "partial_chunk_failure") return false;
+  if (result.skipped === "no_key" || result.skipped === "timeout" || result.skipped === "error") {
+    return false;
+  }
+  if (String(result.skipped || "").startsWith("http_")) return false;
+  if (result.paywall || result.skipped === "paywall") return false;
+  return true;
+}
+
 module.exports = {
   compressContext,
   compressIncremental,
   compactSessionMemory,
   compressPrompt,
+  shouldPublishCompressedResult,
   writeInbox,
   readInboxDigest,
   inboxPaths,

--- a/packages/proxy/src/cursor-hooks/post-tool-compress.js
+++ b/packages/proxy/src/cursor-hooks/post-tool-compress.js
@@ -12,6 +12,7 @@ const {
   compressIncremental,
   writeInbox,
   resolveSessionId,
+  shouldPublishCompressedResult,
 } = require("./compress-prompt-lib");
 
 const MIN_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MIN_CHARS || 400);
@@ -93,9 +94,7 @@ process.stdin.on("end", async () => {
     });
 
     if (!result.compressed) return empty();
-    if (result.skipped === "no_key" || String(result.skipped || "").startsWith("http_")) {
-      return empty();
-    }
+    if (!shouldPublishCompressedResult(result)) return empty();
     // Already in memory — don't spam additional_context every identical tool call
     if (result.skipped === "already_seen" && !result.delta) return empty();
 

--- a/packages/proxy/src/cursor-hooks/user-prompt-submit.js
+++ b/packages/proxy/src/cursor-hooks/user-prompt-submit.js
@@ -8,6 +8,7 @@ const {
   writeInbox,
   splitAskAndContext,
   resolveSessionId,
+  shouldPublishCompressedResult,
 } = require("./compress-prompt-lib");
 
 const MIN_CONTEXT_CHARS = Number(process.env.SUPERCOMPRESS_HOOK_MIN_CHARS || 400);
@@ -46,7 +47,7 @@ process.stdin.on("end", async () => {
       process.stdout.write("{}");
       return;
     }
-    if (result.skipped === "no_key" || String(result.skipped || "").startsWith("http_")) {
+    if (!shouldPublishCompressedResult(result)) {
       process.stdout.write("{}");
       return;
     }

--- a/packages/proxy/src/mcp.js
+++ b/packages/proxy/src/mcp.js
@@ -200,7 +200,7 @@ async function handleToolCall(name, args = {}) {
   }
 
   try {
-    const { compressIncremental, writeInbox } = require("./cursor-hooks/compress-prompt-lib");
+    const { compressIncremental, writeInbox, shouldPublishCompressedResult } = require("./cursor-hooks/compress-prompt-lib");
     const result = await compressIncremental({
       context,
       query,
@@ -227,8 +227,16 @@ async function handleToolCall(name, args = {}) {
           : `Compression failed (${result.skipped})`
       );
     }
+    if (result.partial || result.skipped === "partial_chunk_failure") {
+      return toolError(
+        "Compression partially failed (some chunks). Retry — raw failed chunks are not published into context."
+      );
+    }
     if (!result.compressed) {
       return toolError("Nothing new to compress (empty or already in session memory).");
+    }
+    if (!shouldPublishCompressedResult(result)) {
+      return toolError("Compression result is not safe to publish; retry.");
     }
     const meta =
       result.skipped === "already_seen"

--- a/packages/proxy/src/openclaw-hooks/plugin/index.js
+++ b/packages/proxy/src/openclaw-hooks/plugin/index.js
@@ -163,7 +163,14 @@ export default definePluginEntry({
         });
 
         if (!result?.compressed) return;
-        if (result.skipped === "no_key" || String(result.skipped || "").startsWith("http_")) {
+        if (typeof lib.shouldPublishCompressedResult === "function") {
+          if (!lib.shouldPublishCompressedResult(result)) return;
+        } else if (
+          result.partial ||
+          result.skipped === "partial_chunk_failure" ||
+          result.skipped === "no_key" ||
+          String(result.skipped || "").startsWith("http_")
+        ) {
           return;
         }
         if (result.skipped === "already_seen" && !result.delta) return;

--- a/scripts/ensure-prod-domains.sh
+++ b/scripts/ensure-prod-domains.sh
@@ -2,6 +2,9 @@
 # Keep critical SuperCompress hostnames attached to the Vercel production
 # deployment. Missing aliases (esp. api.supercompress.dev) cause edge
 # DEPLOYMENT_NOT_FOUND / 100% API outages under the wildcard DNS.
+#
+# Safety: never DELETE a healthy canonical domain (www). A repair script must
+# not detach production to "re-promote" ordering.
 set -euo pipefail
 
 cd "$(cd "$(dirname "$0")/.." && pwd)"
@@ -96,6 +99,15 @@ if missing:
 else:
     print("All required domains are attached to the project.")
 
+# Ensure apex redirects to www without deleting www.
+if "supercompress.dev" in names:
+    code, _ = api(
+        "PATCH",
+        f"/v9/projects/{project_id}/domains/supercompress.dev",
+        {"redirect": "www.supercompress.dev", "redirectStatusCode": 308},
+    )
+    print(f"Apex → www redirect ensure HTTP {code}")
+
 code, deps = api(
     "GET",
     f"/v6/deployments?projectId={project_id}&target=production&limit=1&state=READY",
@@ -152,46 +164,13 @@ if ((${#MISSING[@]})) || ((${#BROKEN[@]})); then
 fi
 
 if ((${#MISSING[@]})); then
-  echo "Adding missing domains via CLI..."
+  echo "Adding missing domains via CLI (never delete existing)..."
   for host in "${MISSING[@]}"; do
-    # Never add www here first if other hosts are missing — add non-www, then
-    # re-touch www last so it stays Vercel's newest (= production URL preference).
-    if [[ "$host" != "www.supercompress.dev" ]]; then
-      vercel domains add "$host"
+    if ! vercel domains add "$host"; then
+      echo "FAIL adding domain $host" >&2
+      exit 1
     fi
   done
-  # Ensure www exists and is the newest project domain (primary production URL).
-  python3 <<'PY'
-import json, os, sys, urllib.error, urllib.request
-proj = json.load(open(os.environ["SUPERCOMPRESS_VERCEL_PROJECT_JSON"]))
-org_id, project_id = proj["orgId"], proj["projectId"]
-token = os.environ["VERCEL_TOKEN"]
-
-def api(method, path, body=None):
-    url = f"https://api.vercel.com{path}"
-    url += ("&" if "?" in path else "?") + f"teamId={org_id}"
-    data = None if body is None else json.dumps(body).encode()
-    req = urllib.request.Request(url, data=data, method=method, headers={
-        "Authorization": f"Bearer {token}", "Content-Type": "application/json",
-    })
-    try:
-        with urllib.request.urlopen(req) as resp:
-            return resp.status, json.loads(resp.read().decode() or "{}")
-    except urllib.error.HTTPError as e:
-        return e.code, json.loads(e.read().decode() or "{}")
-
-print("Re-promoting www.supercompress.dev as newest project domain...")
-api("PATCH", f"/v9/projects/{project_id}/domains/supercompress.dev",
-    {"redirect": None, "redirectStatusCode": None})
-api("DELETE", f"/v9/projects/{project_id}/domains/www.supercompress.dev")
-code, _ = api("POST", f"/v10/projects/{project_id}/domains", {"name": "www.supercompress.dev"})
-if code not in (200, 201):
-    # already present is fine
-    pass
-api("PATCH", f"/v9/projects/{project_id}/domains/supercompress.dev",
-    {"redirect": "www.supercompress.dev", "redirectStatusCode": 308})
-print("www is newest domain again.")
-PY
 fi
 
 if ((${#BROKEN[@]})); then
@@ -209,14 +188,12 @@ if ((${#BROKEN[@]})); then
     fi
   done
   for host in "${ordered[@]}"; do
-    vercel alias set "$PROD_URL" "$host"
+    if ! vercel alias set "$PROD_URL" "$host"; then
+      echo "FAIL alias set $host → $PROD_URL" >&2
+      exit 1
+    fi
     echo "  repaired $host"
   done
-fi
-
-# Always finish by pointing www at production (site is the product surface).
-if [[ -n "${PROD_URL:-}" ]] && command -v vercel >/dev/null 2>&1; then
-  vercel alias set "$PROD_URL" www.supercompress.dev >/dev/null || true
 fi
 
 # Final edge gate — never leave DEPLOYMENT_NOT_FOUND uncaught.

--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -45,6 +45,46 @@ expect_body() {
   fi
 }
 
+# api.supercompress.dev/ must redirect to www (not serve marketing).
+# Retries briefly — Vercel promotion can lag a push by a few seconds.
+check_api_root_redirect() {
+  local attempts="${1:-8}"
+  local i code loc final
+  for ((i = 1; i <= attempts; i++)); do
+    code="$(curl -sS -o /dev/null --max-time 25 -w '%{http_code}' "$API/" || echo 000)"
+    loc="$(curl -sS -o /dev/null --max-time 25 -w '%{redirect_url}' "$API/" || true)"
+    final="$(curl -sS -L -o /dev/null --max-time 25 -w '%{url_effective}' "$API/" || true)"
+    # Normalize trailing slash for compare
+    local want="$WWW"
+    local want_slash="${WWW%/}/"
+    if [[ "$code" == "301" || "$code" == "308" || "$code" == "302" ]]; then
+      if [[ "$loc" == "$want" || "$loc" == "$want_slash" || "$loc" == "${want_slash%/}" ]]; then
+        echo "PASS api root redirect ($code → $loc)"
+        pass=$((pass + 1))
+        return 0
+      fi
+      if [[ "$final" == "$want" || "$final" == "$want_slash" ]]; then
+        echo "PASS api root redirect ($code → $final)"
+        pass=$((pass + 1))
+        return 0
+      fi
+      echo "FAIL api root redirect went to wrong place (HTTP $code loc=$loc final=$final)"
+      fail=$((fail + 1))
+      return 1
+    fi
+    if [[ "$final" == "$want" || "$final" == "$want_slash" ]]; then
+      echo "PASS api root → www ($code)"
+      pass=$((pass + 1))
+      return 0
+    fi
+    echo "  api root not ready yet (HTTP $code → $final), retry $i/$attempts..."
+    sleep 5
+  done
+  echo "FAIL api root should redirect to www (got HTTP $code → $final)"
+  fail=$((fail + 1))
+  return 1
+}
+
 echo "=== SuperCompress production smoke ==="
 echo "www=$WWW"
 echo "api=$API"
@@ -53,31 +93,35 @@ echo
 
 # Domains / edge
 check "www home" 200 "$WWW/"
-# api host homepage must bounce to the real site (not serve marketing itself)
-api_root_code="$(curl -sS -o /dev/null --max-time 25 -w '%{http_code}' "$API/" || echo 000)"
-api_root_final="$(curl -sS -L -o /dev/null --max-time 25 -w '%{url_effective}' "$API/" || true)"
-if [[ "$api_root_code" != "301" && "$api_root_code" != "308" ]]; then
-  # Allow 200 only if already rewritten somehow; prefer redirect to www
-  if [[ "$api_root_final" != "$WWW/" && "$api_root_final" != "${WWW}" ]]; then
-    echo "FAIL api root should redirect to www (got HTTP $api_root_code → $api_root_final)"
-    fail=$((fail + 1))
-  else
-    echo "PASS api root → www ($api_root_code)"
-    pass=$((pass + 1))
-  fi
-else
-  echo "PASS api root redirect ($api_root_code)"
-  pass=$((pass + 1))
-fi
+check_api_root_redirect 8 || true
 check "api health" 200 "$API/api/health"
 check "www health" 200 "$WWW/api/health"
 expect_body "www health body" '"ok":true' "$TMP/body"
 check "docs root" 200 "$DOCS/" 
 
-# Marketing / product surfaces
+# Marketing / product surfaces (www only — api host must not serve them)
 check "dashboard" 200 "$WWW/dashboard"
 check "analytics" 200 "$WWW/analytics"
 check "token-compression" 200 "$WWW/token-compression"
+
+# api host must bounce non-API marketing paths to www (host-wide, not just /)
+api_dash_code="$(curl -sS -o /dev/null --max-time 25 -w '%{http_code}' "$API/dashboard" || echo 000)"
+api_dash_final="$(curl -sS -L -o /dev/null --max-time 25 -w '%{url_effective}' "$API/dashboard" || true)"
+if [[ "$api_dash_code" == "301" || "$api_dash_code" == "308" || "$api_dash_code" == "302" ]]; then
+  if [[ "$api_dash_final" == "$WWW/dashboard" || "$api_dash_final" == "${WWW}/dashboard" ]]; then
+    echo "PASS api /dashboard → www ($api_dash_code)"
+    pass=$((pass + 1))
+  else
+    echo "FAIL api /dashboard redirected to $api_dash_final"
+    fail=$((fail + 1))
+  fi
+elif [[ "$api_dash_final" == "$WWW/dashboard" || "$api_dash_final" == "${WWW}/dashboard" ]]; then
+  echo "PASS api /dashboard → www ($api_dash_code)"
+  pass=$((pass + 1))
+else
+  # Soft during rollout of host-wide rule; still fail if it serves a full page without redirect intent
+  echo "WARN api /dashboard still on api host (HTTP $api_dash_code → $api_dash_final) — host-wide redirect pending deploy"
+fi
 
 # Account / auth plumbing (unauthenticated shapes)
 check "account ops" 200 "$WWW/api/account"
@@ -107,7 +151,7 @@ done
 check "www GET compress" 405 "$WWW/api/v1/compress"
 check "api GET compress" 405 "$API/api/v1/compress"
 
-# Optional authenticated compress (if local key present)
+# Authenticated compress — required when secret is injected (Actions schedule/push).
 KEY=""
 CFG="${SUPERCOMPRESS_CONFIG_DIR:-$HOME/.supercompress}/config.json"
 if [[ -f "$CFG" ]]; then
@@ -115,6 +159,21 @@ if [[ -f "$CFG" ]]; then
 fi
 if [[ -n "${SUPERCOMPRESS_API_KEY:-}" ]]; then
   KEY="$SUPERCOMPRESS_API_KEY"
+fi
+
+REQUIRE_AUTH=0
+if [[ -n "${SUPERCOMPRESS_API_KEY:-}" ]]; then
+  REQUIRE_AUTH=1
+fi
+if [[ "${REQUIRE_AUTH_COMPRESS:-}" == "1" ]]; then
+  REQUIRE_AUTH=1
+fi
+# Scheduled GitHub monitors must exercise real compress when secret is configured;
+# if the workflow forgot to inject it, fail loudly instead of silent SKIP.
+if [[ "${GITHUB_EVENT_NAME:-}" == "schedule" && -z "$KEY" ]]; then
+  echo "FAIL scheduled smoke requires SUPERCOMPRESS_API_KEY secret"
+  fail=$((fail + 1))
+  REQUIRE_AUTH=1
 fi
 
 if [[ -n "$KEY" ]]; then
@@ -133,11 +192,17 @@ if [[ -n "$KEY" ]]; then
       echo "FAIL auth compress on $host_label — HTTP $code"
       head -c 300 "$body"; echo
       fail=$((fail + 1))
+    elif ! grep -q 'compressed_text' "$body"; then
+      echo "FAIL auth compress on $host_label — missing compressed_text"
+      fail=$((fail + 1))
     else
       echo "PASS auth compress on $host_label (200)"
       pass=$((pass + 1))
     fi
   done
+elif ((REQUIRE_AUTH)); then
+  echo "FAIL authenticated compress required but no API key available"
+  fail=$((fail + 1))
 else
   echo
   echo "SKIP authenticated compress (no SUPERCOMPRESS_API_KEY / ~/.supercompress/config.json)"

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,17 @@
       "permanent": true
     },
     {
+      "source": "/((?!api(?:/|$)|v1(?:/|$)|retrieve(?:/|$)|health(?:/|$)|favicon\\.ico$).*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
+      "destination": "https://www.supercompress.dev/$1",
+      "permanent": true
+    },
+    {
       "source": "/",
       "has": [
         {


### PR DESCRIPTION
## Summary
- **Domain repair:** never DELETE/re-add `www`; only add missing domains and alias broken hosts (fail closed on alias errors).
- **Prod smoke:** verify api root redirect *destination* (not just 308), retry briefly for deploy lag, warn on api marketing paths until host-wide redirect is live, wire `SUPERCOMPRESS_API_KEY` for scheduled auth compress.
- **Compress order:** authenticate → replay → quota → compress → **billing** → analytics/agent meters.
- **Rate limit:** durable hit id = `SHA256(idempotencyKey:fingerprint)` so reused keys with different payloads still count.
- **Agent metering:** month buckets under `months[YYYY-MM]`; `/api/keys` / usage only merge **current-month** agent totals (no Sept←Aug lifetime stamp).
- **Agent hooks:** skip inbox/`additional_context` on `partial_chunk_failure`; do not reinject raw failed chunks.
- **API host:** catch-all redirect of non-API paths on `api.supercompress.dev` → www.

## Test plan
- [x] `node api/_lib/coding-agent-usage.test.js`
- [x] `packages/proxy` smoke + agent-plugins
- [x] `bash scripts/prod-smoke.sh` locally green
- [ ] CI green on PR
- [ ] After merge: smoke sees api `/dashboard` → www; confirm `SUPERCOMPRESS_API_KEY` secret exists for schedule

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens billing/replay ordering, production-domain and smoke checks, coding-agent hook publication, API-host redirects, durable rate-limit identity, and monthly agent metering.
- Moves analytics and agent meters after successful durable billing while allowing billed idempotent responses to replay before quota checks.
- Adds month-bucketed coding-agent counters and current-month projections for account and key usage.
- Prevents partial chunk failures from publishing incomplete digests through hooks or MCP.
- Makes production domain repair fail closed without deleting the canonical domain, and expands redirect/smoke coverage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the coding-agent repair preserves and merges month buckets instead of deleting and misprojecting usage data.

Monthly counters are introduced correctly, but loadCodingAgentUsage still routes them through a scalar-only legacy repair that removes the month maps, persists the damaged records, and can inflate current-month usage.

**Files Needing Attention:** api/_lib/store.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/_lib/store.js | Adds monthly agent buckets and projection, but the existing misattribution repair strips those buckets and persists lossy records. |
| api/_lib/coding-agent-usage.js | Introduces a focused current-month projection with explicit legacy-record handling. |
| api/v1/compress.js | Reorders replay, quota, billing, and telemetry and strengthens durable rate-limit identity. |
| packages/proxy/src/cursor-hooks/compress-prompt-lib.js | Drops failed raw chunks and centralizes safe publication checks for partial or failed compression. |
| scripts/ensure-prod-domains.sh | Removes destructive canonical-domain reattachment and fails closed when domain or alias repairs fail. |
| scripts/prod-smoke.sh | Expands redirect validation, deploy-lag retries, and authenticated production compression checks. |
| vercel.json | Adds an API-host catch-all redirect while excluding API and operational routes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant CompressAPI
  participant RateLimit
  participant Billing
  participant AgentMeter
  Client->>CompressAPI: POST context + idempotency key
  CompressAPI->>RateLimit: SHA256(key:fingerprint)
  CompressAPI->>Billing: Look up replay
  alt Existing billed response
    Billing-->>CompressAPI: Stored response
    CompressAPI-->>Client: Idempotent replay
  else New request
    CompressAPI->>CompressAPI: Enforce quota and compress
    CompressAPI->>Billing: Persist usage and response
    Billing-->>CompressAPI: Durable success
    CompressAPI->>AgentMeter: Record analytics and monthly agent usage
    CompressAPI-->>Client: Compressed response
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: hoist coding-agent-usage require ..."](https://github.com/supercompress/supercompress/commit/d06a654b87624faec8a497cd80ae126b40d80afa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52214815)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->