### PR TITLE
Use execFileSync for launchctl service commands

### DIFF
--- a/packages/proxy/src/service.js
+++ b/packages/proxy/src/service.js
@@ -9,7 +9,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
+const { execSync, execFileSync } = require("child_process");
 const os = require("os");
 
 const HOME = os.homedir();
@@ -112,22 +112,23 @@ function registerService(configDir, configPath) {
       fs.writeFileSync(plistPath, plistContent);
       fs.chmodSync(plistPath, 0o644);
 
-      // Load the service
+    // Load the service
       try {
-        execSync(`launchctl load ${plistPath}`, { stdio: "ignore" });
+        execFileSync("launchctl", ["load", plistPath], { stdio: "ignore" });
       } catch (loadErr) {
         // Try unloading first (in case it's already loaded)
         try {
-          execSync(`launchctl unload ${plistPath}`, { stdio: "ignore" });
+          execFileSync("launchctl", ["unload", plistPath], { stdio: "ignore" });
         } catch {}
+        
         try {
-          execSync(`launchctl load ${plistPath}`, { stdio: "ignore" });
+          execFileSync("launchctl", ["load", plistPath], { stdio: "ignore" });
         } catch (e2) {
           console.error(`  ⚠ Could not load launchd service: ${e2.message}`);
           return false;
         }
       }
-
+      
       return true;
     } else if (platform === "linux") {
       // ── Linux: systemd user unit ──


### PR DESCRIPTION
## Summary

Replace shell-interpolated `launchctl` commands with `execFileSync()` and explicit argument arrays.

## Problem

The macOS service setup currently constructs commands by inserting `plistPath` into a shell string:

```js
execSync(`launchctl load ${plistPath}`, { stdio: "ignore" });
```

If the path contains spaces or shell-sensitive characters, it may be split or interpreted incorrectly.

## Changes

* Import `execFileSync` from `child_process`.
* Execute `launchctl load` using an argument array.
* Execute `launchctl unload` using an argument array.
* Apply the change to the initial load and retry logic.

For example:

```js
execFileSync("launchctl", ["load", plistPath], { stdio: "ignore" });
```

## Result

`launchctl` now receives the plist path as one complete argument, allowing service setup to work reliably with paths containing spaces. This also avoids unnecessary shell interpretation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces shell-interpolated macOS `launchctl` registration commands with `execFileSync` argument arrays, ensuring plist paths are passed as single arguments and avoiding shell interpretation.
- Adds the `execFileSync` import from `child_process`.
- Updates initial service loading and unload/reload retry commands.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified in the changed service-registration path.

The new process invocation is supported by the repository’s runtime requirements, preserves existing success and failure handling, and correctly passes plist paths containing spaces or shell-sensitive characters as single arguments.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/service.js | Replaces three shell-based `launchctl` calls with direct executable invocation and explicit argument arrays without changing registration control flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Use execFileSync for launchctl service c..."](https://github.com/supercompress/supercompress/commit/d925b28bd0bce260c6806d907f8ef8aeee45107a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52375801)</sub>

<!-- /greptile_comment -->