### PR TITLE
fix: api host must not redirect /compress

### DIFF
--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -140,10 +140,24 @@ COMPRESS_JSON='{"context":"production smoke context for supercompress","query":"
 for host_label in www api; do
   base="$WWW"
   [[ "$host_label" == api ]] && base="$API"
-  for path in /api/v1/compress /v1/compress /api/compress; do
-    check "${host_label} POST ${path}" 401 "$base$path" \
-      -X POST -H 'content-type: application/json' --data "$COMPRESS_JSON"
-    expect_body "${host_label} ${path} body" 'API key' "$TMP/body"
+  for path in /api/v1/compress /v1/compress /api/compress /compress; do
+    # Do not follow redirects — a 308 on /compress was a real outage (POST→GET).
+    body="$TMP/body"
+    code="$(curl -sS --max-time 45 -o "$body" -w '%{http_code}' \
+      -X POST -H 'content-type: application/json' --data "$COMPRESS_JSON" \
+      "$base$path" || echo 000)"
+    if [[ "$code" == "301" || "$code" == "302" || "$code" == "307" || "$code" == "308" ]]; then
+      echo "FAIL ${host_label} POST ${path} redirected ($code) — compress aliases must not bounce"
+      fail=$((fail + 1))
+    elif [[ "$code" != "401" ]]; then
+      echo "FAIL ${host_label} POST ${path} — expected HTTP 401, got $code"
+      head -c 240 "$body" 2>/dev/null | tr '\n' ' '; echo
+      fail=$((fail + 1))
+    else
+      echo "PASS ${host_label} POST ${path} ($code)"
+      pass=$((pass + 1))
+      expect_body "${host_label} ${path} body" 'API key' "$body"
+    fi
   done
 done
 

--- a/vercel.json
+++ b/vercel.json
@@ -19,14 +19,51 @@
       "permanent": true
     },
     {
-      "source": "/((?!api(?:/|$)|v1(?:/|$)|retrieve(?:/|$)|health(?:/|$)|favicon\\.ico$).*)",
-      "has": [
-        {
-          "type": "host",
-          "value": "api.supercompress.dev"
-        }
-      ],
-      "destination": "https://www.supercompress.dev/$1",
+      "source": "/dashboard",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/dashboard",
+      "permanent": true
+    },
+    {
+      "source": "/dashboard/:path*",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/dashboard/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/analytics",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/dashboard?panel=analytics",
+      "permanent": false
+    },
+    {
+      "source": "/blog",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/blog",
+      "permanent": true
+    },
+    {
+      "source": "/blog/:path*",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/blog/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/playground",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/playground",
+      "permanent": true
+    },
+    {
+      "source": "/benchmarks",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/benchmarks",
+      "permanent": true
+    },
+    {
+      "source": "/token-compression",
+      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "destination": "https://www.supercompress.dev/token-compression",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Summary
- **Outage:** catch-all `api.supercompress.dev/*` → www ran **before** `/compress` rewrite. Clients posting to `/compress` got 308; many follow as GET → hard fail.
- Replace catch-all with explicit marketing redirects (`/dashboard`, `/blog`, …).
- Smoke now asserts `/compress` on api host is **401, not a redirect** (no `-L`).

Already deployed to production; this lands the same fix on `main`.

## Test plan
- [x] `POST https://api.supercompress.dev/compress` → 401 (no Location)
- [x] `POST …/api/v1/compress` still 401
- [x] `GET https://api.supercompress.dev/dashboard` still 308 → www
- [x] `bash scripts/prod-smoke.sh` 25/25

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents compression endpoints on the API host from being caught by a marketing redirect and adds smoke coverage that checks their immediate response without following redirects.
- Replaces the API-host catch-all with explicit marketing redirects.
- Adds `/compress` to the unauthenticated alias checks and rejects redirect responses.
- The explicit redirect list omits several existing marketing routes that were covered by the removed catch-all.

<h3>Confidence Score: 4/5</h3>

The host-routing fix should not merge until the explicit redirect policy covers the existing marketing routes currently omitted from the allowlist.

Removing the catch-all protects compression requests, but requests for omitted marketing pages now fall through to unconditional rewrites and are served from the API host rather than redirected to the canonical www host.

**Files Needing Attention:** vercel.json

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| vercel.json | Replaces the problematic catch-all with explicit redirects, but the list omits existing marketing routes that consequently remain served on the API host. |
| scripts/prod-smoke.sh | Adds direct, redirect-sensitive 401 checks for all compression aliases, including /compress. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request to api.supercompress.dev] --> B{Path in explicit marketing allowlist?}
    B -->|Yes| C[Redirect to www host]
    B -->|No| D{Compression or API route?}
    D -->|Yes| E[Rewrite to API handler]
    D -->|No| F[Existing unconditional page rewrite]
    F --> G[Marketing page served on API host]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop api host catch-all from 308ing..."](https://github.com/supercompress/supercompress/commit/6143235e00156551754f69125f375de9ead271ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52419617)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->