### PR TITLE
fix: never ship api-host catch-all redirects again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,7 @@ jobs:
         run: node scripts/check-no-pii.js
       - name: Version pins
         run: node scripts/check-versions.js
+      - name: API host redirect guard (no catch-all /compress 308)
+        run: |
+          node scripts/check-api-host-routes.test.js
+          node scripts/check-api-host-routes.js

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "scripts/prod-smoke.sh"
       - "scripts/ensure-prod-domains.sh"
+      - "scripts/check-api-host-routes.js"
       - "api/**"
       - "vercel.json"
       - ".github/workflows/prod-smoke.yml"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,9 @@
+## Hard bans (product)
+
+| Ban | Meaning |
+|-----|---------|
+| **No api-host catch-all redirects** | Never add `/:path*`, `/((?!api…)…)`, or any regex redirect on `api.supercompress.dev`. That 308'd `/compress` (POST→GET) and took production down. Explicit marketing paths only. After `vercel.json` edits run `node scripts/check-api-host-routes.js`. |
+
 ## Agent Bridge dashboard
 
 Control plane MCP: `agent-bridge-dashboard` (`bridge_*` tools). Skill: `agent-bridge-dashboard`.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "launch:check": "bash scripts/hard-launch-check.sh",
     "prod:smoke": "bash scripts/prod-smoke.sh",
     "prod:domains": "bash scripts/ensure-prod-domains.sh",
+    "check:api-host": "node scripts/check-api-host-routes.js",
     "release:check": "bash scripts/release-check.sh",
     "mcp": "node mcp/server.js",
     "check:version": "node scripts/check-versions.js"

--- a/scripts/check-api-host-routes.js
+++ b/scripts/check-api-host-routes.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed guard: api.supercompress.dev redirects must NEVER intercept
+ * compress / API aliases. Aug 2026 outage: a catch-all negative-lookahead
+ * redirect ran before the /compress rewrite → 308 → clients turned POST into GET.
+ *
+ * Run: node scripts/check-api-host-routes.js
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const API_HOST = "api.supercompress.dev";
+const ROOT = path.join(__dirname, "..");
+
+const EXTRA_PROTECTED = [
+  "/compress",
+  "/v1/compress",
+  "/api/compress",
+  "/api/v1/compress",
+  "/retrieve",
+  "/api/retrieve",
+  "/health",
+  "/api/health",
+  "/api/keys",
+  "/api/account",
+  "/api/usage",
+  "/api/billing",
+  "/api/billing/webhook",
+  "/api/me",
+  "/me",
+  "/api/stats",
+  "/api/firebase-config",
+  "/api/affiliates",
+  "/api/demo/compress",
+];
+
+function isApiHostRule(rule) {
+  const has = rule.has || [];
+  return has.some((h) => h && h.type === "host" && String(h.value) === API_HOST);
+}
+
+function escapeRegex(ch) {
+  return ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function vercelSourceToRegExp(source) {
+  const src = String(source || "");
+  let out = "^";
+  for (let i = 0; i < src.length; ) {
+    if (src[i] === ":") {
+      const m = src.slice(i).match(/^:([A-Za-z0-9_]+)(\*)?/);
+      if (!m) {
+        out += escapeRegex(src[i]);
+        i += 1;
+        continue;
+      }
+      out += m[2] ? ".*" : "[^/]+";
+      i += m[0].length;
+      continue;
+    }
+    out += escapeRegex(src[i]);
+    i += 1;
+  }
+  out += "$";
+  return new RegExp(out);
+}
+
+function isCatchAllOrRegex(source) {
+  const src = String(source || "");
+  if (!src || src === "/") return false;
+  if (/\(\?|\[\^|\|/.test(src)) return true; // lookahead / char-class / alternation
+  if (src === "/*" || src === "/:path*" || src === "/:path(.*)" || src === "/(.*)") return true;
+  if (/^\/:[A-Za-z0-9_]+\*$/.test(src)) return true; // /:splat*
+  // "/((?!api...).*)" style
+  if (src.includes("(?!") || src.includes("(?:")) return true;
+  return false;
+}
+
+function sourceMatchesPath(source, urlPath) {
+  const src = String(source || "");
+  const p = String(urlPath || "");
+  if (src === p) return true;
+  if (isCatchAllOrRegex(src)) {
+    if (/^\/:[A-Za-z0-9_]+\*$/.test(src) || src === "/*") return true;
+    try {
+      return new RegExp(`^${src}$`).test(p);
+    } catch {
+      // Unparseable regex on api host → treat as matching everything (fail closed).
+      return true;
+    }
+  }
+  try {
+    return vercelSourceToRegExp(src).test(p);
+  } catch {
+    return true;
+  }
+}
+
+function listApiFilesystemPaths() {
+  const apiDir = path.join(ROOT, "api");
+  const out = [];
+  function walk(dir, rel) {
+    if (!fs.existsSync(dir)) return;
+    for (const name of fs.readdirSync(dir)) {
+      if (name === "_lib" || name === "node_modules") continue;
+      const full = path.join(dir, name);
+      const nextRel = rel ? `${rel}/${name}` : name;
+      const st = fs.statSync(full);
+      if (st.isDirectory()) {
+        walk(full, nextRel);
+        continue;
+      }
+      if (!name.endsWith(".js") || name.endsWith(".test.js")) continue;
+      const route = "/" + nextRel.replace(/\.js$/, "").replace(/\[id\]/g, "x");
+      out.push(route.startsWith("/api/") ? route : `/api${route === "/index" ? "" : route}`);
+    }
+  }
+  walk(apiDir, "");
+  return out;
+}
+
+function protectedPathsFromConfig(config) {
+  const set = new Set(EXTRA_PROTECTED);
+  for (const p of listApiFilesystemPaths()) set.add(p);
+  for (const rw of config.rewrites || []) {
+    const dest = String(rw.destination || "");
+    const src = String(rw.source || "");
+    if (dest.startsWith("/api/") || dest === "/api" || dest.includes("/compress")) {
+      if (src.startsWith("/")) set.add(src);
+    }
+  }
+  // Any /api/* or /v1/* probe variants
+  for (const p of [...set]) {
+    if (p.startsWith("/api/") || p.startsWith("/v1/")) set.add(p);
+  }
+  return [...set];
+}
+
+function checkApiHostRoutes(config) {
+  const errors = [];
+  const protectedPaths = protectedPathsFromConfig(config);
+  const redirects = config.redirects || [];
+
+  for (const rule of redirects) {
+    if (!isApiHostRule(rule)) continue;
+    const source = String(rule.source || "");
+    if (isCatchAllOrRegex(source) && source !== "/") {
+      errors.push(
+        `Forbidden catch-all/regex redirect on ${API_HOST}: ${source} → ${rule.destination}. ` +
+          `This outage class 308'd /compress (POST became GET). Use explicit marketing paths only.`
+      );
+      continue;
+    }
+    for (const p of protectedPaths) {
+      if (sourceMatchesPath(source, p)) {
+        errors.push(
+          `api host redirect ${source} matches protected API path ${p} → ${rule.destination}. ` +
+            `Redirects on ${API_HOST} must not intercept compress/API aliases.`
+        );
+      }
+    }
+  }
+  return { ok: errors.length === 0, errors, protectedPaths };
+}
+
+function loadVercelJson() {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, "vercel.json"), "utf8"));
+}
+
+function main() {
+  const result = checkApiHostRoutes(loadVercelJson());
+  if (!result.ok) {
+    console.error("FAIL api-host route guard:");
+    for (const e of result.errors) console.error(" -", e);
+    process.exit(1);
+  }
+  console.log(
+    `ok api-host route guard (${result.protectedPaths.length} protected paths, no catch-all intercepts)`
+  );
+}
+
+module.exports = {
+  checkApiHostRoutes,
+  sourceMatchesPath,
+  isCatchAllOrRegex,
+  vercelSourceToRegExp,
+  API_HOST,
+  EXTRA_PROTECTED,
+};
+
+if (require.main === module) main();

--- a/scripts/check-api-host-routes.test.js
+++ b/scripts/check-api-host-routes.test.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Run: node scripts/check-api-host-routes.test.js
+ */
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const {
+  checkApiHostRoutes,
+  sourceMatchesPath,
+  isCatchAllOrRegex,
+} = require("./check-api-host-routes");
+
+const OUTAGE_CATCHALL =
+  "/((?!api(?:/|$)|v1(?:/|$)|retrieve(?:/|$)|health(?:/|$)|favicon\\.ico$).*)";
+
+assert.equal(isCatchAllOrRegex("/"), false);
+assert.equal(isCatchAllOrRegex("/dashboard"), false);
+assert.equal(isCatchAllOrRegex("/dashboard/:path*"), false);
+assert.equal(isCatchAllOrRegex("/:path*"), true);
+assert.equal(isCatchAllOrRegex(OUTAGE_CATCHALL), true);
+
+assert.equal(sourceMatchesPath("/compress", "/compress"), true);
+assert.equal(sourceMatchesPath("/dashboard", "/compress"), false);
+assert.equal(sourceMatchesPath("/dashboard/:path*", "/compress"), false);
+assert.equal(sourceMatchesPath("/:path*", "/compress"), true);
+assert.equal(sourceMatchesPath(OUTAGE_CATCHALL, "/compress"), true);
+assert.equal(sourceMatchesPath(OUTAGE_CATCHALL, "/api/v1/compress"), false);
+
+const production = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "vercel.json"), "utf8")
+);
+const live = checkApiHostRoutes(production);
+assert.equal(live.ok, true, live.errors.join("\n"));
+
+const withOutage = {
+  ...production,
+  redirects: [
+    {
+      source: OUTAGE_CATCHALL,
+      has: [{ type: "host", value: "api.supercompress.dev" }],
+      destination: "https://www.supercompress.dev/$1",
+      permanent: true,
+    },
+    ...(production.redirects || []),
+  ],
+};
+const bad = checkApiHostRoutes(withOutage);
+assert.equal(bad.ok, false);
+assert.ok(bad.errors.some((e) => /catch-all|compress/i.test(e)));
+
+const compressRedirect = {
+  redirects: [
+    {
+      source: "/compress",
+      has: [{ type: "host", value: "api.supercompress.dev" }],
+      destination: "https://www.supercompress.dev/compress",
+      permanent: true,
+    },
+  ],
+  rewrites: [{ source: "/compress", destination: "/api/v1/compress" }],
+};
+const bad2 = checkApiHostRoutes(compressRedirect);
+assert.equal(bad2.ok, false);
+assert.ok(bad2.errors.some((e) => e.includes("/compress")));
+
+console.log("check-api-host-routes.test.js: ok");

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -17,6 +17,7 @@ fi
 
 npm ci --omit=optional --ignore-scripts --no-audit --no-fund
 npm run release:check
+node scripts/check-api-host-routes.js
 vercel deploy --prod --yes
 
 # Critical: api.supercompress.dev (and siblings) must stay aliased or the API

--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -91,6 +91,9 @@ echo "api=$API"
 echo "docs=$DOCS"
 echo
 
+# Static guard before any HTTP — fail PRs that reintroduce the catch-all outage.
+node scripts/check-api-host-routes.js
+
 # Domains / edge
 check "www home" 200 "$WWW/"
 check_api_root_redirect 8 || true
@@ -159,6 +162,19 @@ for host_label in www api; do
       expect_body "${host_label} ${path} body" 'API key' "$body"
     fi
   done
+done
+
+# Other API aliases on api host must not 308 either (no follow).
+for path in /retrieve /api/retrieve /api/health /api/keys /api/account; do
+  code="$(curl -sS -o "$TMP/alias" -w '%{http_code}' --max-time 25 "$API$path" || echo 000)"
+  loc="$(curl -sS -o /dev/null -w '%{redirect_url}' --max-time 25 "$API$path" || true)"
+  if [[ "$code" == "301" || "$code" == "302" || "$code" == "307" || "$code" == "308" ]]; then
+    echo "FAIL api GET ${path} redirected ($code → $loc) — API aliases must stay on api host"
+    fail=$((fail + 1))
+  else
+    echo "PASS api GET ${path} no-redirect ($code)"
+    pass=$((pass + 1))
+  fi
 done
 
 # GET compress must be method-not-allowed (not 5xx)

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -8,6 +8,7 @@ node --check api/account.js
 node --check api/v1/compress.js
 node --check web/assets/js/supercompress.js
 node scripts/check-versions.js
+node scripts/check-api-host-routes.js
 
 node - <<'NODE'
 const fs = require('fs');


### PR DESCRIPTION
## Summary
Locks the Aug 2026 `/compress` 308 outage out of CI and deploy:

- `scripts/check-api-host-routes.js` fails if `api.supercompress.dev` redirects use catch-alls/regex or match `/compress` + other API aliases (including vercel rewrites → `/api/*`).
- Unit test replays the exact outage pattern and asserts current `vercel.json` passes.
- Wired into **CI**, **release:check**, **deploy:prod**, and **prod-smoke** (runs before HTTP).
- Live smoke: `POST /compress` and other API aliases must **not** 3xx (no `curl -L`).

## Test plan
- [x] `node scripts/check-api-host-routes.test.js`
- [x] `node scripts/check-api-host-routes.js` on current vercel.json
- [ ] CI green
- [ ] Confirm injecting the old catch-all into vercel.json fails the checker

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a static configuration guard and production smoke checks intended to prevent API-host redirects from intercepting compression and other API routes.
- Runs the route guard in CI, release checks, production deployment, and smoke tests.
- Discovers protected paths from known aliases, API files, and rewrites.
- Adds regression tests for the historical negative-lookahead redirect.
- Expands live smoke coverage to reject redirects from additional API aliases.

<h3>Confidence Score: 4/5</h3>

The route-pattern false negative should be fixed before merging because it leaves the new deployment guard unable to enforce its stated catch-all ban.

A regex-constrained catch-all with an arbitrary parameter name is treated as a literal pattern, so the checker can approve a redirect that intercepts protected API requests.

**Files Needing Attention:** scripts/check-api-host-routes.js and scripts/check-api-host-routes.test.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-api-host-routes.js | Implements the central route guard, but its partial route-pattern parser misses equivalent named regex catch-alls and can allow a prohibited redirect through. |
| scripts/check-api-host-routes.test.js | Replays the historical outage and direct-path collision but omits coverage for alternate named regex catch-all syntax. |
| scripts/prod-smoke.sh | Runs the static guard before HTTP checks and verifies that several API aliases do not redirect. |
| .github/workflows/ci.yml | Adds both the regression test and live-configuration guard to CI. |
| scripts/deploy-prod.sh | Blocks production deployment when the static API-host route guard fails. |
| scripts/release-check.sh | Incorporates the new route guard into release validation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Load vercel.json] --> B[Discover protected API paths]
  B --> C[Inspect API-host redirects]
  C --> D{Catch-all or regex?}
  D -->|Yes| E[Fail check]
  D -->|No| F{Matches protected path?}
  F -->|Yes| E
  F -->|No| G[Pass check]
  G --> H[Continue CI, release, deploy, or smoke]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: run api-host route guard before v..."](https://github.com/supercompress/supercompress/commit/831c0d811c05c22e9a36673ac3541bd38c078cd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52420972)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->