### PR TITLE
fix: live dashboard Analytics charts actually paint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Public page: https://www.supercompress.dev/changelog
 - Keep user emails / outreach dumps / welcome-drain ops **out of OSS** (gitignore + CI PII gate); drain scripts live under `~/agent-bridge/private/supercompress-email/`
 
 ### API / dashboard
+- **Dashboard Analytics panel** (dither charts): live usage from `/api/keys` after sign-in — tokens saved, requests, coding agents, and key breakdown. `/analytics` stays inside `/dashboard?panel=analytics`.
+- Fix Analytics chart paint: Bayer wells + stacked dither canvases, wait for layout before draw, no demo/fake flash on production.
 - Align `/api/account?op=usage` + dashboard `account_usage` with the billing ledger (CLI no longer under-counts vs dashboard)
 - Idempotent compress: replay stored response for same Idempotency-Key + fingerprint (no free recompute)
 - Durable IP rate limit counts each client key (not payload fingerprint alone)

--- a/web/assets/css/dashboard-analytics.css
+++ b/web/assets/css/dashboard-analytics.css
@@ -10,6 +10,7 @@
   --an-paper: #f4f5f8;
   --an-card: #ffffff;
   --an-serif: "Platypi", "EB Garamond", Georgia, serif;
+  --an-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
   --an-radius: 14px;
 }
 #panel-analytics .an-hero { margin: 8px 0 28px; max-width: 40rem; }
@@ -22,7 +23,6 @@
   font-size: clamp(1.85rem, 3.2vw, 2.55rem); letter-spacing: -0.02em; color: var(--an-ink); line-height: 1.15;
 }
 #panel-analytics .an-hero p { margin: 0; font-size: 15px; line-height: 1.55; color: var(--an-muted); }
-#panel-analytics .an-hero .bayer { color: var(--an-brand-ink); font-weight: 600; }
 #panel-analytics .an-status {
   display: flex; align-items: center; gap: 10px; margin: 0 0 20px;
   font-size: 13px; color: var(--an-muted);
@@ -32,6 +32,7 @@
   border: 1px solid var(--an-line); background: #fff; font-size: 12px; font-weight: 600;
 }
 #panel-analytics .an-pill--live { border-color: #b7ebc6; background: #f0fff4; color: #137333; }
+#panel-analytics .an-pill--fake { border-color: #f0d48a; background: #fff8e8; color: #8a5a00; }
 #panel-analytics .an-pill--load { border-color: var(--an-line); color: var(--an-muted); }
 #panel-analytics .an-pill--err { border-color: #f5c2c0; background: #fff5f5; color: #b42318; }
 #panel-analytics .kpi-grid {
@@ -43,48 +44,136 @@
   position: relative; overflow: hidden; border: 1px solid var(--an-line); border-radius: var(--an-radius);
   background: var(--an-card); box-shadow: 0 1px 2px rgba(23,23,23,0.04); min-height: 118px;
 }
-#panel-analytics .kpi--cut { border-color: rgba(5,102,255,0.28); background: linear-gradient(180deg, #fff, var(--an-brand-soft)); }
-#panel-analytics .kpi-wash { position: absolute; inset: 0; opacity: 0.55; pointer-events: none; }
+#panel-analytics .kpi--cut {
+  border-color: rgba(5,102,255,0.28);
+  background: linear-gradient(165deg, rgba(5,102,255,0.08), transparent 58%), var(--an-card);
+}
+#panel-analytics .kpi-wash {
+  position: absolute; inset: 0; z-index: 0; pointer-events: none; opacity: 1;
+  mask-image: linear-gradient(115deg, transparent 18%, #000 72%);
+  -webkit-mask-image: linear-gradient(115deg, transparent 18%, #000 72%);
+}
+#panel-analytics .kpi-wash canvas,
+#panel-analytics .dk-wash-canvas {
+  position: absolute !important; inset: 0 !important; width: 100% !important; height: 100% !important; display: block;
+}
 #panel-analytics .kpi-body { position: relative; z-index: 1; padding: 16px 16px 14px; }
 #panel-analytics .kpi-l { display: block; font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--an-faint); }
-#panel-analytics .kpi-n { display: block; margin-top: 6px; font-family: var(--an-serif); font-size: 2rem; font-weight: 400; letter-spacing: -0.03em; color: var(--an-ink); line-height: 1; }
+#panel-analytics .kpi-n { display: block; margin-top: 8px; font-family: var(--an-serif); font-size: 2rem; font-weight: 400; letter-spacing: -0.03em; color: var(--an-ink); line-height: 1; }
 #panel-analytics .kpi-s { display: block; margin-top: 8px; font-size: 12px; color: var(--an-muted); }
 #panel-analytics .charts {
-  display: grid; grid-template-columns: 1.4fr 1fr; gap: 14px;
+  display: grid; grid-template-columns: 1.15fr 0.85fr; gap: 14px;
 }
 @media (max-width: 900px) { #panel-analytics .charts { grid-template-columns: 1fr; } }
 #panel-analytics .panel {
-  border: 1px solid var(--an-line); border-radius: var(--an-radius); background: var(--an-card);
-  box-shadow: 0 1px 2px rgba(23,23,23,0.04); padding: 16px;
+  border: 1px solid var(--an-line); border-radius: 16px; background: var(--an-card);
+  box-shadow: 0 1px 2px rgba(23,23,23,0.04); padding: 18px 18px 16px;
+  display: flex; flex-direction: column; min-width: 0;
 }
 #panel-analytics .panel--wide { grid-column: 1 / -1; }
 #panel-analytics .panel-head {
-  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 12px;
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 14px;
 }
-#panel-analytics .panel-head h2 { margin: 0; font-size: 15px; font-weight: 600; color: var(--an-ink); }
-#panel-analytics .panel-head p { margin: 4px 0 0; font-size: 12px; color: var(--an-muted); }
+#panel-analytics .panel-head h2 {
+  margin: 0; font-family: var(--an-serif); font-size: 18px; font-weight: 400; letter-spacing: -0.02em; color: var(--an-ink);
+}
+#panel-analytics .panel-head p { margin: 4px 0 0; font-size: 12.5px; color: var(--an-muted); }
 #panel-analytics .chip {
-  display: inline-flex; align-items: center; padding: 4px 8px; border-radius: 999px;
-  border: 1px solid var(--an-line); font-size: 11px; font-weight: 600; color: var(--an-muted); white-space: nowrap;
+  display: inline-flex; align-items: center; padding: 4px 9px; border-radius: 999px;
+  background: var(--an-brand-soft); color: var(--an-brand-ink); font-size: 11px; font-weight: 600; white-space: nowrap;
 }
-#panel-analytics .chip--cut { border-color: rgba(5,102,255,0.3); color: var(--an-brand-ink); background: var(--an-brand-soft); }
-#panel-analytics .chart-well { width: 100%; min-height: 220px; }
-#panel-analytics .chart-well--lg { min-height: 280px; }
-#panel-analytics .rank-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 12px; }
+#panel-analytics .chip--cut { background: var(--an-brand-soft); color: var(--an-brand-ink); }
+
+#panel-analytics .chart-well {
+  position: relative;
+  width: 100%;
+  height: 260px;
+  border-radius: 12px;
+  overflow: hidden;
+  isolation: isolate;
+  contain: paint;
+  background:
+    radial-gradient(90% 80% at 0% 0%, rgba(5, 102, 255, 0.07), transparent 55%),
+    radial-gradient(70% 60% at 100% 100%, rgba(5, 102, 255, 0.05), transparent 50%),
+    #f7f8fb;
+  border: 0.5px solid rgba(5, 102, 255, 0.06);
+}
+#panel-analytics .chart-well--lg { height: 300px; }
+#panel-analytics .chart-well.dk-hovering { box-shadow: inset 0 0 0 1px rgba(5, 102, 255, 0.18); }
+#panel-analytics .dk-chart {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+#panel-analytics .chart-well.dk-chart { height: 260px; }
+#panel-analytics .chart-well--lg.dk-chart { height: 300px; }
+#panel-analytics .dk-chart canvas {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
+#panel-analytics .dk-tip {
+  position: absolute;
+  z-index: 5;
+  min-width: 118px;
+  max-width: 220px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #f8fafc;
+  font-size: 12px;
+  line-height: 1.35;
+  pointer-events: none;
+  opacity: 0;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+}
+#panel-analytics .dk-tip strong {
+  display: block; font-size: 10px; font-weight: 600; letter-spacing: 0.08em;
+  text-transform: uppercase; color: rgba(148, 163, 184, 0.95); margin-bottom: 4px;
+}
+#panel-analytics .dk-tip span { display: block; color: rgba(226, 232, 240, 0.92); margin-bottom: 2px; }
+#panel-analytics .dk-tip em {
+  display: block; font-style: normal; font-family: var(--an-serif);
+  font-size: 18px; font-weight: 400; letter-spacing: -0.02em; color: #fff;
+}
+
+#panel-analytics .rank-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
 #panel-analytics .rank-row {
-  display: grid; grid-template-columns: 28px minmax(0, 1fr) auto; gap: 10px; align-items: start;
+  display: grid; grid-template-columns: 28px minmax(0, 1fr) auto; gap: 12px; align-items: center;
+  padding: 10px 12px; border-radius: 12px; background: #f7f8fb; border: 0.5px solid rgba(5, 102, 255, 0.06);
 }
 #panel-analytics .key-list .rank-row { grid-template-columns: minmax(0, 1fr) auto; }
 #panel-analytics .rank-idx {
   width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center;
-  background: var(--an-brand-soft); color: var(--an-brand-ink); font-size: 12px; font-weight: 700;
+  background: var(--an-brand-soft); color: var(--an-brand); font-family: var(--an-serif); font-size: 14px; font-weight: 400;
 }
-#panel-analytics .rank-name { margin: 0; font-size: 14px; font-weight: 600; color: var(--an-ink); }
-#panel-analytics .rank-meta { margin: 2px 0 6px; font-size: 12px; color: var(--an-muted); }
-#panel-analytics .rank-track { height: 6px; border-radius: 999px; background: #eef0f4; overflow: hidden; }
-#panel-analytics .rank-fill { display: block; height: 100%; width: 0; border-radius: inherit; background: linear-gradient(90deg, #0566ff, #4d8fff); transition: width 0.7s ease; }
-#panel-analytics .rank-val { text-align: right; font-size: 14px; font-weight: 600; color: var(--an-ink); }
-#panel-analytics .rank-val small { display: block; font-size: 11px; font-weight: 500; color: var(--an-faint); }
+#panel-analytics .rank-main { min-width: 0; }
+#panel-analytics .rank-name { margin: 0; font-size: 14px; font-weight: 500; color: var(--an-ink); }
+#panel-analytics .rank-meta { margin: 2px 0 8px; font-size: 12px; color: var(--an-muted); }
+#panel-analytics .rank-track {
+  position: relative; height: 8px; border-radius: 999px; background: rgba(5, 102, 255, 0.08); overflow: hidden;
+}
+#panel-analytics .rank-fill {
+  position: absolute; inset: 0 auto 0 0; width: 0; border-radius: inherit;
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(5, 102, 255, 0.95),
+    rgba(5, 102, 255, 0.95) 1px,
+    rgba(94, 156, 255, 0.55) 1px,
+    rgba(94, 156, 255, 0.55) 3px
+  );
+  transition: width 0.9s cubic-bezier(0.22, 1, 0.36, 1);
+}
+#panel-analytics .rank-val {
+  text-align: right; font-family: var(--an-serif); font-size: 20px; font-weight: 300;
+  letter-spacing: -0.02em; color: var(--an-ink); font-variant-numeric: tabular-nums; white-space: nowrap;
+}
+#panel-analytics .rank-val small {
+  display: block; margin-top: 2px; font-size: 11px; font-weight: 500; color: var(--an-muted); text-align: right;
+}
 #panel-analytics .key-dot {
   display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--an-brand); margin-right: 8px; vertical-align: middle;
 }
@@ -93,3 +182,4 @@
   border: 1px dashed var(--an-line); border-radius: var(--an-radius); padding: 28px 18px;
   text-align: center; color: var(--an-muted); font-size: 14px; background: #fafbfd; margin-bottom: 16px;
 }
+#panel-analytics .an-loading.hidden { display: none; }

--- a/web/assets/js/analytics-data.js
+++ b/web/assets/js/analytics-data.js
@@ -121,6 +121,92 @@
     };
   }
 
+  /** Realistic /api/keys shape for local Analytics debug (never used in prod). */
+  function fakeKeysPayload() {
+    const days = dayKeys(30);
+    const mk = (i, scale) => {
+      const d = new Date(days[i] + "T12:00:00");
+      const weekend = d.getDay() === 0 || d.getDay() === 6 ? 0.32 : 1;
+      const wave = 0.62 + 0.38 * Math.sin(i / 2.35);
+      const ramp = 0.5 + (i / 29) * 0.75;
+      const saved = Math.max(0, Math.round((38000 + i * 2600) * wave * ramp * weekend * scale));
+      const tin = Math.round(saved / 0.53);
+      const requests = Math.max(
+        0,
+        Math.round((16 + i * 1.15 + Math.sin(i / 1.65) * 9) * weekend * scale)
+      );
+      return { tokens_saved: saved, tokens_in: tin, requests };
+    };
+
+    const buckets = [
+      ["fake_prod", 0.58],
+      ["fake_stg", 0.17],
+      ["fake_cursor", 0.25],
+    ];
+    const usage = {};
+    const totals = { requests: 0, tokens_in: 0, tokens_saved: 0, tokens_out: 0 };
+    for (const [id, scale] of buckets) {
+      const byDay = {};
+      let saved = 0;
+      let tin = 0;
+      let req = 0;
+      days.forEach((iso, i) => {
+        const rec = mk(i, scale);
+        byDay[iso] = rec;
+        saved += rec.tokens_saved;
+        tin += rec.tokens_in;
+        req += rec.requests;
+      });
+      usage[id] = {
+        total_requests: req,
+        total_tokens_in: tin,
+        total_tokens_out: Math.max(0, tin - saved),
+        total_tokens_saved: saved,
+        by_day: byDay,
+      };
+      totals.requests += req;
+      totals.tokens_in += tin;
+      totals.tokens_saved += saved;
+      totals.tokens_out += Math.max(0, tin - saved);
+    }
+
+    const month = new Date().toISOString().slice(0, 7);
+    const cursorShare = 0.58;
+    const codexShare = 0.24;
+    const claudeShare = 0.18;
+    return {
+      _fake: true,
+      keys: [
+        { id: "fake_prod", name: "Production", prefix: "sc_live_prod", created_at: "2026-06-02T00:00:00.000Z" },
+        { id: "fake_stg", name: "Staging", prefix: "sc_live_stg", created_at: "2026-07-11T00:00:00.000Z" },
+        { id: "fake_cursor", name: "Cursor plugin", prefix: "sc_live_cur", created_at: "2026-07-28T00:00:00.000Z" },
+      ],
+      usage,
+      account_usage: { month, ...totals },
+      coding_agent_usage: {
+        Cursor: {
+          requests: Math.round(totals.requests * cursorShare),
+          tokens_in: Math.round(totals.tokens_in * cursorShare),
+          tokens_saved: Math.round(totals.tokens_saved * cursorShare),
+          tokens_out: Math.round(totals.tokens_out * cursorShare),
+        },
+        Codex: {
+          requests: Math.round(totals.requests * codexShare),
+          tokens_in: Math.round(totals.tokens_in * codexShare),
+          tokens_saved: Math.round(totals.tokens_saved * codexShare),
+          tokens_out: Math.round(totals.tokens_out * codexShare),
+        },
+        "Claude Code": {
+          requests: Math.round(totals.requests * claudeShare),
+          tokens_in: Math.round(totals.tokens_in * claudeShare),
+          tokens_saved: Math.round(totals.tokens_saved * claudeShare),
+          tokens_out: Math.round(totals.tokens_out * claudeShare),
+        },
+      },
+      agent_plugin: { linked: true },
+    };
+  }
+
   function demoBundle() {
     const keys = dayKeys(30);
     const byDay = {};
@@ -284,6 +370,7 @@
     labelDay,
     isChartDay,
     aggregateUsage,
+    fakeKeysPayload,
     demoBundle,
     bundleToSeries,
     escapeHtml,

--- a/web/assets/js/analytics-data.test.js
+++ b/web/assets/js/analytics-data.test.js
@@ -8,12 +8,23 @@ const {
   aggregateUsage,
   bundleToSeries,
   demoBundle,
+  fakeKeysPayload,
   escapeHtml,
 } = require("./analytics-data.js");
 
 assert.strictEqual(isChartDay("2026-08-11"), true);
 assert.strictEqual(isChartDay("reconcile-2026-08"), false);
 assert.strictEqual(isChartDay(""), false);
+
+const fake = fakeKeysPayload();
+assert.strictEqual(fake._fake, true);
+assert.ok(fake.keys.length >= 3);
+const fakeSeries = bundleToSeries(aggregateUsage(fake));
+assert.ok(fakeSeries.totalSaved > 100000, "fake usage has meaty savings");
+assert.ok(fakeSeries.cut > 40 && fakeSeries.cut < 70, `fake cut=${fakeSeries.cut}`);
+assert.ok(fakeSeries.areaData.some((d) => d.y > 0));
+assert.ok(fakeSeries.agents.some((a) => a.label === "Cursor"));
+assert.ok(fakeSeries.keys.some((k) => k.label === "Production"));
 
 const demo = bundleToSeries(demoBundle());
 assert.ok(demo.totalSaved > 0, "demo has savings");

--- a/web/assets/js/dashboard-analytics.js
+++ b/web/assets/js/dashboard-analytics.js
@@ -38,22 +38,12 @@
     if (message) el.textContent = message;
   }
 
-  function animateNumber(el, to, { suffix = "", compact = false, duration = 900 } = {}) {
+  function animateNumber(el, to, { suffix = "", compact = false } = {}) {
     const kit = DK();
     if (!el) return;
-    if (!kit) {
-      el.textContent = (compact ? String(Math.round(to)) : String(Math.round(to))) + suffix;
-      return;
-    }
-    const t0 = performance.now();
-    const ease = (t) => 1 - Math.pow(1 - t, 3);
-    const frame = (now) => {
-      const p = Math.min(1, (now - t0) / duration);
-      const v = to * ease(p);
-      el.textContent = (compact ? kit.formatCompact(v) : String(Math.round(v))) + suffix;
-      if (p < 1) requestAnimationFrame(frame);
-    };
-    requestAnimationFrame(frame);
+    const n = Number(to);
+    const v = Number.isFinite(n) ? Math.max(0, n) : 0;
+    el.textContent = (compact && kit ? kit.formatCompact(v) : String(Math.round(v))) + suffix;
   }
 
   function paint(series) {
@@ -99,46 +89,29 @@
       yMax: areaMax,
       empty: !series.areaData.some((d) => d.y > 0),
       emptyLabel: "No daily savings yet",
+      data: series.areaData,
+      interactive: true,
     };
-    kit.animateChart((p) => {
-      kit.renderAreaChart(areaEl, {
-        ...areaOpts,
-        data: series.areaData.map((d) => ({ x: d.x, y: d.y * p })),
-        interactive: false,
-      });
-      if (p > 0.98) {
-        kit.renderAreaChart(areaEl, { ...areaOpts, data: series.areaData, interactive: true });
-        kit.startChartDitherLoop(areaEl, {
-          kind: "area",
-          ...areaOpts,
-          data: series.areaData,
-          interactive: true,
-        });
-      }
-    }, 1100);
+    kit.renderAreaChart(areaEl, areaOpts);
+    kit.startChartDitherLoop(areaEl, { kind: "area", ...areaOpts });
 
-    kit.animateChart((p) => {
-      const done = p > 0.98;
-      const barOpts = {
-        data: series.reqs.map((r) => ({ label: r.label, value: r.value, full: r.full })),
-        orientation: "vertical",
-        color: "brand",
-        variant: "gradient",
-        bloom: "aura",
-        maxBars: 30,
-        progress: done ? 1 : p,
-        yMax: reqMax,
-        unit: "requests",
-        tooltipTitle: "Requests",
-        interactive: done,
-        empty: !series.reqs.some((r) => r.value > 0),
-        emptyLabel: "No requests yet",
-      };
-      kit.renderBarChart(barsEl, barOpts);
-      if (done) {
-        kit.startChartDitherLoop(barsEl, { kind: "bar", ...barOpts, progress: 1, interactive: true });
-      }
-    }, 1100);
+    const barOpts = {
+      data: series.reqs.map((r) => ({ label: r.label, value: r.value, full: r.full })),
+      orientation: "vertical",
+      color: "brand",
+      variant: "gradient",
+      bloom: "aura",
+      maxBars: 30,
+      progress: 1,
+      yMax: reqMax,
+      unit: "requests",
+      tooltipTitle: "Requests",
+      interactive: true,
+      empty: !series.reqs.some((r) => r.value > 0),
+      emptyLabel: "No requests yet",
+    };
+    kit.renderBarChart(barsEl, barOpts);
+    kit.startChartDitherLoop(barsEl, { kind: "bar", ...barOpts });
 
     const esc = data.escapeHtml;
     const agentTotal = series.agents.reduce((s, a) => s + a.value, 0) || 1;
@@ -208,18 +181,30 @@
     }
     if (loading) return;
     if (loadedOnce && !force) {
-      // Re-paint washes on revisit (canvas size can stale after hide)
-      for (const [id, opts] of washes) {
-        const el = $(id);
-        if (el) kit.renderDitherWash(el, opts);
+      const areaH = $("an-area")?.querySelector("canvas")?.getBoundingClientRect().height || 0;
+      if (areaH >= 80) {
+        for (const [id, opts] of washes) {
+          const el = $(id);
+          if (el) kit.renderDitherWash(el, opts);
+        }
+        return;
       }
-      return;
+      // First paint happened while the panel was 0×0 — do a full redraw.
     }
 
     loading = true;
     setLoading(true, "Loading your live usage…");
     setPill("load", "Live · loading…");
     try {
+      await new Promise((resolve) => {
+        let n = 16;
+        const tick = () => {
+          const w = $("an-area")?.getBoundingClientRect().width || 0;
+          if (w > 40 || n-- <= 0) return resolve();
+          requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      });
       const token = await getIdToken();
       if (!token) throw new Error("Not signed in");
       const payload = await fetchKeys(token);

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -1705,14 +1705,16 @@ function openDashboardPanel(panel, { updateUrl = true } = {}) {
   }
   if (panel === "analytics") {
     const user = currentUser;
-    window.SCDashboardAnalytics?.show({
-      getIdToken: async () => {
-        if (idToken && String(idToken).startsWith("dev:")) return idToken;
-        if (user?.getIdToken) return getUserToken(user);
-        if (idToken) return idToken;
-        throw new Error("Not signed in");
-      },
-    });
+    const boot = () =>
+      window.SCDashboardAnalytics?.show({
+        getIdToken: async () => {
+          if (idToken && String(idToken).startsWith("dev:")) return idToken;
+          if (user?.getIdToken) return getUserToken(user);
+          if (idToken) return idToken;
+          throw new Error("Not signed in");
+        },
+      });
+    requestAnimationFrame(() => requestAnimationFrame(boot));
   }
 
   if (updateUrl && window.history?.replaceState) {

--- a/web/assets/js/dither-kit-lite.js
+++ b/web/assets/js/dither-kit-lite.js
@@ -116,12 +116,13 @@
 
   function sizeCanvases(host, crisp, bloom) {
     const rect = host.getBoundingClientRect();
-    // Hidden tabs report 0×0 — fall back to CSS height / sensible defaults.
-    const cssHAttr = parseFloat(getComputedStyle(host).height) || 0;
+    // Hidden tabs report 0×0 — fall back to CSS height / min-height / sensible defaults.
+    const cs = host ? getComputedStyle(host) : null;
+    const cssHAttr = parseFloat(cs?.height) || parseFloat(cs?.minHeight) || 0;
     const cssW = Math.max(40, Math.round(rect.width || host.clientWidth || host.parentElement?.clientWidth || 640));
     const cssH = Math.max(
-      40,
-      Math.round(rect.height || host.clientHeight || cssHAttr || 220)
+      120,
+      Math.round(rect.height || host.clientHeight || cssHAttr || 260)
     );
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
     for (const c of [crisp, bloom]) {
@@ -601,7 +602,9 @@
     const t0 = performance.now();
     const ease = (t) => 1 - Math.pow(1 - t, 3);
     const frame = (now) => {
-      const p = Math.min(1, (now - t0) / Math.max(1, duration));
+      let p = (now - t0) / Math.max(1, duration);
+      if (!Number.isFinite(p) || p < 0) p = 1;
+      p = Math.min(1, p);
       fn(ease(p));
       if (p < 1) requestAnimationFrame(frame);
     };

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -227,8 +227,10 @@
           <span class="cl-badge cl-badge--unreleased">main</span>
         </div>
         <div class="cl-body">
-          <h3>API / billing</h3>
+          <h3>API / dashboard</h3>
           <ul>
+            <li><strong>Analytics panel</strong> inside the API dashboard — live token savings, requests, coding-agent share, and key breakdown from your signed-in <code>/api/keys</code> meter (dither charts). <code>/analytics</code> stays on <code>/dashboard?panel=analytics</code>.</li>
+            <li>Fix Analytics chart paint (Bayer wells, layout-ready draw). No demo/fake flash in production.</li>
             <li><strong>Fingerprint-bound Idempotency-Key</strong> — reuse with a different compress payload returns <code>409 idempotency_conflict</code> (blocks free recompress / billing bypass).</li>
             <li>Durable hourly rate-limit hits keyed by <strong>payload fingerprint</strong>, not the client-chosen request id.</li>
             <li><strong>Request-level billing idempotency</strong> (<code>Idempotency-Key</code> / <code>billing_usage/{uid}:{requestId}</code>) so billing timeouts cannot double-charge on retry.</li>

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -28,7 +28,7 @@
   <meta name="theme-color" content="rgb(251,251,248)" />
   <link rel="stylesheet" href="assets/css/supercompress.css?v=112" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/dashboard-analytics.css?v=1" />
+  <link rel="stylesheet" href="/assets/css/dashboard-analytics.css?v=3" />
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet" />
 <style>
     /* Dashboard: no dark bg layers, full light page */
@@ -826,7 +826,7 @@ npm exec supercompress setup</pre>
           <div class="dash-panel-head">
             <div>
               <h1>Analytics</h1>
-              <p>Token savings, <strong>in Bayer</strong> — live meter from your keys and coding agents, last 30 days.</p>
+              <p>Token savings from your keys and coding agents, last 30 days.</p>
             </div>
             <div class="dash-panel-actions">
               <span class="an-status" style="margin:0">
@@ -1118,10 +1118,10 @@ npm exec supercompress setup</pre>
   </footer>
   <script src="assets/js/firebase-config.js?v=3"></script>
   <script src="assets/js/supercompress.js?v=1"></script>
-  <script src="/assets/js/dither-kit-lite.js?v=10"></script>
-  <script src="/assets/js/analytics-data.js?v=2"></script>
-  <script src="/assets/js/dashboard-analytics.js?v=2"></script>
-  <script type="module" src="assets/js/dashboard-api.js?v=34"></script>
+  <script src="/assets/js/dither-kit-lite.js?v=12"></script>
+  <script src="/assets/js/analytics-data.js?v=3"></script>
+  <script src="/assets/js/dashboard-analytics.js?v=5"></script>
+  <script type="module" src="assets/js/dashboard-api.js?v=36"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- Fix dashboard Analytics so Bayer dither charts render after layout (wells, stacked canvases, no 0×0 first paint).
- Live meter only: signed-in `/api/keys` usage (tokens saved, requests, agents, key breakdown). No demo/fake flash on production.
- `/analytics` still stays inside `/dashboard?panel=analytics`. Changelog updated.

## Test plan
- [ ] Sign in on `/dashboard?panel=analytics` and confirm KPIs + area/bar charts match Keys/Agents usage
- [ ] Refresh analytics; empty accounts show empty-state copy, not fake numbers
- [ ] `/analytics` redirects to `/dashboard?panel=analytics`
- [ ] `/compress` still 401 with no Location (no api-host catch-all)
- [ ] Changelog page lists the Analytics ship under Unreleased

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes the signed-in dashboard Analytics panel to paint its live `/api/keys` usage charts after layout is available and removes the initial chart animation that could render against hidden dimensions.
- Adds fixed chart wells, stacked canvas styling, live dither repaint loops, and layout-ready deferred initialization.
- Adds a realistic local-only fake payload with aggregation tests.
- Updates dashboard asset versions and documents the Analytics release in both changelogs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The layout wait, stable chart dimensions, and self-replacing repaint loops address hidden-panel rendering without introducing a reachable chart lifecycle or data-loading failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/assets/js/dashboard-analytics.js | Defers data loading until the chart has a measurable layout, paints charts directly, and starts self-replacing dither repaint loops. |
| web/assets/js/dither-kit-lite.js | Improves hidden-layout canvas sizing fallbacks and hardens animation progress against invalid timing values. |
| web/assets/js/dashboard-api.js | Defers Analytics initialization by two animation frames after exposing the selected dashboard panel. |
| web/assets/css/dashboard-analytics.css | Adds fixed chart wells and absolute stacked-canvas layout so charts receive stable dimensions. |
| web/assets/js/analytics-data.js | Adds an explicitly marked local debug payload while leaving production loading on live API data. |
| web/assets/js/analytics-data.test.js | Verifies that the debug payload aggregates into nonempty savings, request, agent, and key series. |
| web/dashboard.html | Updates Analytics copy and cache-busting versions for the changed CSS and JavaScript assets. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant D as Dashboard navigation
    participant A as Analytics controller
    participant K as /api/keys
    participant C as Dither charts
    U->>D: Open Analytics panel
    D->>D: Reveal panel
    D->>A: Start after two animation frames
    A->>A: Wait for measurable chart width
    A->>K: Fetch signed-in usage
    K-->>A: Keys, daily usage, and agents
    A->>C: Paint area and request charts
    A->>C: Start responsive dither loops
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: paint live dashboard Analytics char..."](https://github.com/supercompress/supercompress/commit/557bcf3e806f28a540811d5a8258f5df2d2eab87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52429340)</sub>

<!-- /greptile_comment -->