### PR TITLE
execFileSync for launchctl/systemctl service setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Public page: https://www.supercompress.dev/changelog
 - Durable hourly rate-limit hits use the **payload fingerprint**, not the client-chosen request id (stops limit evasion)
 
 ### Coding agent plugin
+- Register/unregister the proxy service via `execFileSync` argv (no shell-interpolated `launchctl` / `systemctl` paths)
 - **`supercompress` TUI** (`0.5.19`): paper-branded interactive UI (usage / account / connect / setup / plugin / agents / proxy). Default in a TTY; needs Bun. Classic commands unchanged.
 - **OpenClaw auto-compress parity with Hermes**: `supercompress setup` / `plugin` wires MCP (absolute node+mcp), `AGENTS.md`, managed skill, internal hooks (`agent:bootstrap` + `session:compact:before`), and an extension plugin that compresses large tool dumps into the inbox
 - **Session-scoped OpenClaw inbox** (`inbox/<sessionId>/latest.md`) so sessions/projects cannot cross-contaminate digests; honor `SUPERCOMPRESS_CONFIG_DIR`

--- a/packages/proxy/src/service.js
+++ b/packages/proxy/src/service.js
@@ -9,10 +9,14 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const os = require("os");
 
 const HOME = os.homedir();
+
+function runFile(cmd, args) {
+  execFileSync(cmd, args, { stdio: "ignore" });
+}
 
 /**
  * Generate the launchd plist content for macOS.
@@ -112,16 +116,16 @@ function registerService(configDir, configPath) {
       fs.writeFileSync(plistPath, plistContent);
       fs.chmodSync(plistPath, 0o644);
 
-      // Load the service
+      // Load the service (argv, not shell — plistPath may contain spaces)
       try {
-        execSync(`launchctl load ${plistPath}`, { stdio: "ignore" });
+        runFile("launchctl", ["load", plistPath]);
       } catch (loadErr) {
         // Try unloading first (in case it's already loaded)
         try {
-          execSync(`launchctl unload ${plistPath}`, { stdio: "ignore" });
+          runFile("launchctl", ["unload", plistPath]);
         } catch {}
         try {
-          execSync(`launchctl load ${plistPath}`, { stdio: "ignore" });
+          runFile("launchctl", ["load", plistPath]);
         } catch (e2) {
           console.error(`  ⚠ Could not load launchd service: ${e2.message}`);
           return false;
@@ -143,9 +147,9 @@ function registerService(configDir, configPath) {
 
       // Enable and start
       try {
-        execSync("systemctl --user daemon-reload", { stdio: "ignore" });
-        execSync("systemctl --user enable supercompress", { stdio: "ignore" });
-        execSync("systemctl --user start supercompress", { stdio: "ignore" });
+        runFile("systemctl", ["--user", "daemon-reload"]);
+        runFile("systemctl", ["--user", "enable", "supercompress"]);
+        runFile("systemctl", ["--user", "start", "supercompress"]);
       } catch (e) {
         console.error(`  ⚠ Could not enable systemd service: ${e.message}`);
         return false;
@@ -177,14 +181,14 @@ function unregisterService() {
     if (platform === "darwin") {
       const plistPath = path.join(HOME, "Library", "LaunchAgents", "com.supercompress.proxy.plist");
       if (fs.existsSync(plistPath)) {
-        try { execSync(`launchctl unload ${plistPath}`, { stdio: "ignore" }); } catch {}
+        try { runFile("launchctl", ["unload", plistPath]); } catch {}
         fs.unlinkSync(plistPath);
       }
       return true;
     } else if (platform === "linux") {
       try {
-        execSync("systemctl --user stop supercompress", { stdio: "ignore" });
-        execSync("systemctl --user disable supercompress", { stdio: "ignore" });
+        runFile("systemctl", ["--user", "stop", "supercompress"]);
+        runFile("systemctl", ["--user", "disable", "supercompress"]);
       } catch {}
       const unitPath = path.join(HOME, ".config", "systemd", "user", "supercompress.service");
       if (fs.existsSync(unitPath)) fs.unlinkSync(unitPath);

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -244,6 +244,7 @@
           </ul>
           <h3>Coding agent plugin</h3>
           <ul>
+            <li>macOS/Linux service register+unregister uses <code>execFileSync</code> argv (no shell-interpolated <code>launchctl</code> paths).</li>
             <li><strong>Interactive TUI</strong> (<code>supercompress</code> / <code>supercompress tui</code>, npm <code>0.5.19</code>) — paper-branded live usage, connect, setup, plugin, agents, and proxy. Needs Bun; classic commands still work.</li>
             <li><strong>OpenClaw auto-compress</strong> parity with Hermes: setup/plugin installs MCP + <code>AGENTS.md</code> + managed skill + internal hooks + extension plugin.</li>
             <li><strong>Session-scoped inbox</strong> (<code>inbox/&lt;sessionId&gt;/latest.md</code>) + <code>SUPERCOMPRESS_CONFIG_DIR</code>; exact plugin path uninstall; real <code>compactSessionMemory</code>; chunk ≤120k; stable hook idempotency keys.</li>


### PR DESCRIPTION
## Summary
- Completes [@wuisabel-gif](https://github.com/wuisabel-gif)’s #65: `launchctl`/`systemctl` via `execFileSync` argv, not shell strings.
- Also covers **unregister** (still interpolated in #65) and Linux systemd.

## Test plan
- [x] `node --check packages/proxy/src/service.js`
- [ ] macOS `supercompress setup` still registers LaunchAgent when HOME has no spaces
- [ ] Paths with spaces would pass as a single argv (no shell split)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces shell-interpolated service-management commands with `execFileSync` and explicit argument arrays, preventing paths from being split or interpreted by a shell.
- Updates macOS LaunchAgent registration and removal.
- Updates Linux systemd service registration and removal.
- Documents the change in the Markdown and web changelogs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the explicit argument arrays preserving command behavior while correctly handling paths containing spaces.

The launchctl and systemctl invocations retain their existing executable names and argument ordering, while removing shell parsing from interpolated paths; no actionable regression was identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/service.js | Safely centralizes synchronous executable invocation and converts each launchctl/systemctl command to equivalent explicit argv. |
| CHANGELOG.md | Documents the safer service registration and unregistration behavior. |
| web/changelog.html | Mirrors the service-command change in the public web changelog. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Note execFileSync service registration o..."](https://github.com/supercompress/supercompress/commit/ca29273378e991f1a31f2c3e3df4a99cc215c79c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52438691)</sub>

<!-- /greptile_comment -->