### PR TITLE
fix(proxy): resolve spawnSync ENOENT when opening browser on Windows

### DIFF
--- a/packages/proxy/bin/supercompress.js
+++ b/packages/proxy/bin/supercompress.js
@@ -89,8 +89,14 @@ async function connectAccount() {
   // 128-bit pairing code (was 32-bit) — hardens device-link against enumeration
   const code = crypto.randomBytes(16).toString("hex");
   const connectUrl = `https://www.supercompress.dev/dashboard?connect=${code}&source=cli`;
-  const openCommand = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-  try { require("child_process").execFileSync(openCommand, [connectUrl], { stdio: "ignore" }); } catch {}
+  try {
+    if (process.platform === "win32") {
+      require("child_process").execFileSync("cmd.exe", ["/c", "start", "", connectUrl], { stdio: "ignore" });
+    } else {
+      const openCommand = process.platform === "darwin" ? "open" : "xdg-open";
+      require("child_process").execFileSync(openCommand, [connectUrl], { stdio: "ignore" });
+    }
+  } catch {}
   console.log(`  → Finish sign-in in the browser to link this install.`);
   console.log(`  → If the dashboard is already open, refresh that tab.`);
   console.log(`  → Connection code: ${code}`);

--- a/packages/proxy/bin/supercompress.js
+++ b/packages/proxy/bin/supercompress.js
@@ -91,7 +91,8 @@ async function connectAccount() {
   const connectUrl = `https://www.supercompress.dev/dashboard?connect=${code}&source=cli`;
   try {
     if (process.platform === "win32") {
-      require("child_process").execFileSync("cmd.exe", ["/c", "start", "", connectUrl], { stdio: "ignore" });
+      // Use execSync with a quoted URL so cmd.exe does not split the URL at &
+      require("child_process").execSync(`start "" "${connectUrl}"`, { stdio: "ignore" });
     } else {
       const openCommand = process.platform === "darwin" ? "open" : "xdg-open";
       require("child_process").execFileSync(openCommand, [connectUrl], { stdio: "ignore" });

--- a/packages/proxy/src/mcp.js
+++ b/packages/proxy/src/mcp.js
@@ -120,9 +120,13 @@ async function handleToolCall(name, args = {}) {
     // 128-bit pairing code (was 32-bit) — must match server normalizeCode length rules
     const code = require("crypto").randomBytes(16).toString("hex");
     const url = `${CONNECT_URL}${code}`;
-    const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
     try {
-      execFile(opener, [url]);
+      if (process.platform === "win32") {
+        execFile("cmd.exe", ["/c", "start", "", url]);
+      } else {
+        const opener = process.platform === "darwin" ? "open" : "xdg-open";
+        execFile(opener, [url]);
+      }
     } catch (err) {
       log("open browser failed:", err.message || err);
     }

--- a/packages/proxy/src/mcp.js
+++ b/packages/proxy/src/mcp.js
@@ -122,7 +122,8 @@ async function handleToolCall(name, args = {}) {
     const url = `${CONNECT_URL}${code}`;
     try {
       if (process.platform === "win32") {
-        execFile("cmd.exe", ["/c", "start", "", url]);
+        // Use execSync with a quoted URL so cmd.exe does not split the URL at &
+        require("child_process").execSync(`start "" "${url}"`, { stdio: "ignore" });
       } else {
         const opener = process.platform === "darwin" ? "open" : "xdg-open";
         execFile(opener, [url]);

--- a/packages/proxy/src/setup.js
+++ b/packages/proxy/src/setup.js
@@ -37,10 +37,13 @@ async function connectViaBrowser() {
   // 128-bit pairing code (was 32-bit) — hardens device-link against enumeration
   const code = crypto.randomBytes(16).toString("hex");
   const connectUrl = `https://www.supercompress.dev/dashboard?connect=${code}&source=setup`;
-  const openCommand = process.platform === "darwin" ? "open" :
-    process.platform === "win32" ? "start" : "xdg-open";
   try {
-    execSync(`${openCommand} "${connectUrl}"`, { stdio: "ignore" });
+    if (process.platform === "win32") {
+      execSync(`start "" "${connectUrl}"`, { stdio: "ignore" });
+    } else {
+      const openCommand = process.platform === "darwin" ? "open" : "xdg-open";
+      execSync(`${openCommand} "${connectUrl}"`, { stdio: "ignore" });
+    }
   } catch {}
 
   console.log("  → Finish sign-in in the browser to connect your account.");


### PR DESCRIPTION
## Summary

Fixes an issue on Windows where `supercompress connect`, `supercompress setup`, and the MCP `connect_account` tool fail to open the web browser to complete user authentication.

###  Problem

On Windows, `start` is a built-in shell command in `cmd.exe` rather than a standalone executable file. Calling `execFileSync("start", ...)` or `execFile("start", ...)` throws an unhandled exception:
`Error: spawnSync start ENOENT`

As a result:
- Running `supercompress connect` prints the connection URL, but silently fails to launch the browser tab.
- Calling `connect_account` via MCP fails with `open browser failed: spawn start ENOENT`.

###  Solution

- Replaced direct `start` binary invocation with `cmd.exe /c start ""` on Windows across `bin/supercompress.js`, `src/mcp.js`, and `src/setup.js`.
- Retained `open` for macOS and `xdg-open` for Linux/POSIX platforms.

---

###  Visual Proof (Before & After)

**Before (Browser fails to open / ENOENT error):**

https://github.com/user-attachments/assets/41e7385e-8dd6-4de8-ae7d-a34bbbf22d8f



**After (Browser opens automatically on Windows):**


https://github.com/user-attachments/assets/915c2f3c-edd0-41e6-a2ad-6a6f0834d441


---

###  Testing & Verification

- Verified `node packages/proxy/bin/supercompress.js connect` on Windows — browser launches the sign-in URL without errors.
- Verified unit & protocol tests pass via `node packages/proxy/test/protocol-safety.js`.

<img width="912" height="382" alt="image" src="https://github.com/user-attachments/assets/1486584b-b902-4d45-8ece-5ca250a5ede1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account connection and setup flows when opening browser links on Windows.
  * Continued support for browser launching on macOS and Linux.
  * Browser-launch failures remain handled without interrupting the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects Windows browser launching for account-connection flows by invoking the `start` shell builtin with a quoted pairing URL.
- Updates the CLI `connect` command to preserve the complete URL on Windows.
- Applies the same browser-launch behavior to MCP account connection and interactive setup.
- Retains the existing macOS and Linux launch commands.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/bin/supercompress.js | Uses the Windows shell builtin with a quoted CLI pairing URL while retaining argument-safe launchers elsewhere. |
| packages/proxy/src/mcp.js | Correctly preserves both MCP pairing parameters when opening the dashboard on Windows. |
| packages/proxy/src/setup.js | Updates setup browser launching to use the valid Windows `start` invocation with a quoted URL. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(proxy): resolve spawnSync ENOENT and..."](https://github.com/supercompress/supercompress/commit/1d1d9dd3a95885026e31ea597e8e11cf025ee9c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52472163)</sub>

<!-- /greptile_comment -->