### PR TITLE
fix: restore compress when Firestore is disabled

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -572,9 +572,14 @@ async function applyUsageAndBurn({
     if (err.paywall || err.code === "free_quota_exhausted" || err.code === "credits_exhausted" || err.code === "idempotency_conflict") {
       throw err;
     }
-    if (isFirestoreBackendDown(err)) {
-      console.warn("billing-ledger: Firestore down — claims/gist billing fallback");
-      return applyUsageAndBurnClaimsFallback({
+    // Any Firestore outage (disabled API, timeout, permission) must not 100%-down compress.
+    console.warn(
+      "billing-ledger: Firestore txn failed — claims/gist billing fallback:",
+      err?.code,
+      err?.message || err
+    );
+    try {
+      return await applyUsageAndBurnClaimsFallback({
         uid,
         tokensIn,
         tokensOut,
@@ -584,8 +589,18 @@ async function applyUsageAndBurn({
         fingerprint: fp,
         response,
       });
+    } catch (fallbackErr) {
+      if (
+        fallbackErr.paywall ||
+        fallbackErr.code === "free_quota_exhausted" ||
+        fallbackErr.code === "credits_exhausted" ||
+        fallbackErr.code === "idempotency_conflict"
+      ) {
+        throw fallbackErr;
+      }
+      console.error("billing-ledger claims fallback failed:", fallbackErr?.message || fallbackErr);
+      throw billingError("billing_unavailable", "Billing ledger unavailable");
     }
-    throw err;
   }
 
   if (!result.already) {

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -293,18 +293,16 @@ async function loadLedger(uid, claims = {}) {
     return normalizeLedger(snap.exists ? snap.data() : null, claims);
   } catch (err) {
     if (err.code === "billing_unavailable") throw err;
-    if (isFirestoreBackendDown(err)) {
-      console.warn("billing-ledger: Firestore down — using Auth claims ledger");
-      return normalizeLedger(null, claims);
-    }
-    console.warn("billing-ledger load failed:", err.message || err);
-    throw billingError("billing_unavailable", "Billing ledger unavailable");
+    console.warn("billing-ledger load failed — using Auth claims:", err.message || err);
+    return normalizeLedger(null, claims);
   }
 }
 
 /**
- * When Cloud Firestore is disabled/unavailable, bill via Auth claims + gist
- * idempotency so compress does not 100%-outage. Prefer Firestore when healthy.
+ * When Cloud Firestore is disabled/unavailable, bill via Auth claims only.
+ * Do not depend on gist here — gist rate limits caused the outage recovery path
+ * to fail. Replay text is not stored (claims size); retries recompress but do
+ * not double-bill (request id watermark on claims).
  */
 async function applyUsageAndBurnClaimsFallback({
   uid,
@@ -318,75 +316,77 @@ async function applyUsageAndBurnClaimsFallback({
 }) {
   const rid = sanitizeRequestId(requestId);
   const fp = String(fingerprint || "").trim() || null;
-  const replay = sanitizeReplayResponse(response);
-  const { mutateStore } = require("./store");
-  const key = `${uid}:${rid}`;
+  if (!rid) throw billingError("billing_unavailable", "Billing request id required");
 
-  const result = await mutateStore((store) => {
-    if (!store.billing_usage_fallback) store.billing_usage_fallback = {};
-    const prev = store.billing_usage_fallback[key];
-    if (prev) {
-      assertUsageIdempotencyMatch(prev, {
+  const fresh = await admin().auth().getUser(uid);
+  const liveClaims = { ...(fresh.customClaims || {}), ...claims };
+  const recent = Array.isArray(liveClaims.sc_recent_billing)
+    ? liveClaims.sc_recent_billing
+    : [];
+  const prior = recent.find((r) => r && r.i === rid);
+  if (prior) {
+    assertUsageIdempotencyMatch(
+      {
+        fingerprint: prior.f || null,
+        tokens_in: prior.tin,
+        tokens_out: prior.tout,
+        tokens_saved: prior.ts,
+      },
+      {
         fingerprint: fp,
         tokensIn,
         tokensOut,
         tokensSaved,
-      });
-      return {
-        burned_micros: Number(prev.burned_micros || 0),
-        ledger: normalizeLedger(null, claims),
-        already: true,
-        request_id: rid,
-        fingerprint: prev.fingerprint || fp || null,
-        response: prev.response || replay || null,
-        backend: "claims-fallback",
-      };
-    }
-
-    const ledger = normalizeLedger(null, claims);
-    const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims });
-    store.billing_usage_fallback[key] = {
-      uid,
-      request_id: rid,
-      fingerprint: fp,
-      tokens_in: Number(tokensIn) || 0,
-      tokens_out: Number(tokensOut) || 0,
-      tokens_saved: Number(tokensSaved) || 0,
-      burned_micros: planned.burned_micros,
-      created_at: new Date().toISOString(),
-      ...(replay ? { response: replay } : {}),
-    };
-
-    // Bound growth — keep newest ~400 fallback rows.
-    const keys = Object.keys(store.billing_usage_fallback);
-    if (keys.length > 400) {
-      keys
-        .sort(
-          (a, b) =>
-            String(store.billing_usage_fallback[a]?.created_at || "").localeCompare(
-              String(store.billing_usage_fallback[b]?.created_at || "")
-            )
-        )
-        .slice(0, keys.length - 400)
-        .forEach((k) => {
-          delete store.billing_usage_fallback[k];
-        });
-    }
-
+      }
+    );
     return {
-      ...planned,
-      already: false,
+      burned_micros: Number(prior.b || 0),
+      ledger: normalizeLedger(null, liveClaims),
+      already: true,
       request_id: rid,
-      fingerprint: fp,
-      response: replay,
+      fingerprint: prior.f || fp || null,
+      response: null,
       backend: "claims-fallback",
     };
+  }
+
+  const ledger = normalizeLedger(null, liveClaims);
+  const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims: liveClaims });
+  const nextRecent = [
+    {
+      i: rid.slice(0, 64),
+      f: fp ? String(fp).slice(0, 32) : null,
+      tin: Number(tokensIn) || 0,
+      tout: Number(tokensOut) || 0,
+      ts: Number(tokensSaved) || 0,
+      b: planned.burned_micros,
+      t: Date.now(),
+    },
+    ...recent,
+  ].slice(0, 5);
+
+  await admin().auth().setCustomUserClaims(uid, {
+    ...liveClaims,
+    sc_usage: {
+      month: planned.ledger.month,
+      requests: planned.ledger.requests,
+      tokens_in: planned.ledger.tokens_in,
+      tokens_out: planned.ledger.tokens_out,
+      tokens_saved: planned.ledger.tokens_saved,
+      tokens_reported: planned.ledger.tokens_reported || 0,
+    },
+    sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
+    sc_recent_billing: nextRecent,
   });
 
-  if (!result.already) {
-    await mirrorClaims(uid, result.ledger);
-  }
-  return result;
+  return {
+    ...planned,
+    already: false,
+    request_id: rid,
+    fingerprint: fp,
+    response: sanitizeReplayResponse(response),
+    backend: "claims-fallback",
+  };
 }
 
 /**

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -274,6 +274,16 @@ function planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims = {} }
   };
 }
 
+function isFirestoreBackendDown(err) {
+  if (!err) return false;
+  const code = err.code;
+  if (code === 7 || code === "7" || code === "SERVICE_DISABLED") return true;
+  const msg = String(err.message || err || "");
+  return /SERVICE_DISABLED|Cloud Firestore API has not been used|firestore\.googleapis\.com|PERMISSION_DENIED: Cloud Firestore/i.test(
+    msg
+  );
+}
+
 async function loadLedger(uid, claims = {}) {
   if (!uid || !initFirebaseAdmin()) {
     throw billingError("billing_unavailable", "Billing ledger unavailable");
@@ -283,9 +293,100 @@ async function loadLedger(uid, claims = {}) {
     return normalizeLedger(snap.exists ? snap.data() : null, claims);
   } catch (err) {
     if (err.code === "billing_unavailable") throw err;
+    if (isFirestoreBackendDown(err)) {
+      console.warn("billing-ledger: Firestore down — using Auth claims ledger");
+      return normalizeLedger(null, claims);
+    }
     console.warn("billing-ledger load failed:", err.message || err);
     throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
+}
+
+/**
+ * When Cloud Firestore is disabled/unavailable, bill via Auth claims + gist
+ * idempotency so compress does not 100%-outage. Prefer Firestore when healthy.
+ */
+async function applyUsageAndBurnClaimsFallback({
+  uid,
+  tokensIn,
+  tokensOut,
+  tokensSaved,
+  claims = {},
+  requestId,
+  fingerprint,
+  response = null,
+}) {
+  const rid = sanitizeRequestId(requestId);
+  const fp = String(fingerprint || "").trim() || null;
+  const replay = sanitizeReplayResponse(response);
+  const { mutateStore } = require("./store");
+  const key = `${uid}:${rid}`;
+
+  const result = await mutateStore((store) => {
+    if (!store.billing_usage_fallback) store.billing_usage_fallback = {};
+    const prev = store.billing_usage_fallback[key];
+    if (prev) {
+      assertUsageIdempotencyMatch(prev, {
+        fingerprint: fp,
+        tokensIn,
+        tokensOut,
+        tokensSaved,
+      });
+      return {
+        burned_micros: Number(prev.burned_micros || 0),
+        ledger: normalizeLedger(null, claims),
+        already: true,
+        request_id: rid,
+        fingerprint: prev.fingerprint || fp || null,
+        response: prev.response || replay || null,
+        backend: "claims-fallback",
+      };
+    }
+
+    const ledger = normalizeLedger(null, claims);
+    const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims });
+    store.billing_usage_fallback[key] = {
+      uid,
+      request_id: rid,
+      fingerprint: fp,
+      tokens_in: Number(tokensIn) || 0,
+      tokens_out: Number(tokensOut) || 0,
+      tokens_saved: Number(tokensSaved) || 0,
+      burned_micros: planned.burned_micros,
+      created_at: new Date().toISOString(),
+      ...(replay ? { response: replay } : {}),
+    };
+
+    // Bound growth — keep newest ~400 fallback rows.
+    const keys = Object.keys(store.billing_usage_fallback);
+    if (keys.length > 400) {
+      keys
+        .sort(
+          (a, b) =>
+            String(store.billing_usage_fallback[a]?.created_at || "").localeCompare(
+              String(store.billing_usage_fallback[b]?.created_at || "")
+            )
+        )
+        .slice(0, keys.length - 400)
+        .forEach((k) => {
+          delete store.billing_usage_fallback[k];
+        });
+    }
+
+    return {
+      ...planned,
+      already: false,
+      request_id: rid,
+      fingerprint: fp,
+      response: replay,
+      backend: "claims-fallback",
+    };
+  });
+
+  if (!result.already) {
+    await mirrorClaims(uid, result.ledger);
+  }
+  return result;
 }
 
 /**
@@ -371,12 +472,22 @@ async function lookupUsageReplay(uid, requestId) {
   if (!uid || !rid || !initFirebaseAdmin()) return null;
   try {
     const snap = await db().collection("billing_usage").doc(`${uid}:${rid}`).get();
-    if (!snap.exists) return null;
-    return snap.data() || null;
+    if (snap.exists) return snap.data() || null;
   } catch (err) {
-    console.warn("lookupUsageReplay failed:", err?.message || err);
-    return null;
+    if (!isFirestoreBackendDown(err)) {
+      console.warn("lookupUsageReplay failed:", err?.message || err);
+    }
   }
+  // Firestore-down fallback: gist-backed idempotency rows.
+  try {
+    const { loadStore } = require("./store");
+    const store = await loadStore();
+    const prev = store.billing_usage_fallback?.[`${uid}:${rid}`];
+    if (prev) return prev;
+  } catch (err) {
+    console.warn("lookupUsageReplay fallback failed:", err?.message || err);
+  }
+  return null;
 }
 
 async function applyUsageAndBurn({
@@ -402,59 +513,80 @@ async function applyUsageAndBurn({
 
   const ref = db().collection("billing").doc(uid);
   const usageRef = db().collection("billing_usage").doc(`${uid}:${rid}`);
-  const result = await db().runTransaction(async (tx) => {
-    // All reads before writes (Firestore txn rule).
-    const usageSnap = await tx.get(usageRef);
-    const snap = await tx.get(ref);
-    const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
+  let result;
+  try {
+    result = await db().runTransaction(async (tx) => {
+      // All reads before writes (Firestore txn rule).
+      const usageSnap = await tx.get(usageRef);
+      const snap = await tx.get(ref);
+      const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
 
-    if (usageSnap.exists) {
-      const prev = usageSnap.data() || {};
-      assertUsageIdempotencyMatch(prev, {
+      if (usageSnap.exists) {
+        const prev = usageSnap.data() || {};
+        assertUsageIdempotencyMatch(prev, {
+          fingerprint: fp,
+          tokensIn,
+          tokensOut,
+          tokensSaved,
+        });
+        // Backfill response on legacy rows that billed before replay storage existed.
+        if (replay && !prev.response) {
+          tx.set(usageRef, { response: replay }, { merge: true });
+        }
+        return {
+          burned_micros: Number(prev.burned_micros || 0),
+          ledger,
+          already: true,
+          request_id: rid,
+          fingerprint: prev.fingerprint || fp || null,
+          response: prev.response || replay || null,
+        };
+      }
+
+      const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims });
+      tx.set(ref, planned.ledger, { merge: true });
+      tx.set(
+        usageRef,
+        {
+          uid,
+          request_id: rid,
+          fingerprint: fp,
+          tokens_in: Number(tokensIn) || 0,
+          tokens_out: Number(tokensOut) || 0,
+          tokens_saved: Number(tokensSaved) || 0,
+          burned_micros: planned.burned_micros,
+          created_at: new Date().toISOString(),
+          ...(replay ? { response: replay } : {}),
+        },
+        { merge: false }
+      );
+      return {
+        ...planned,
+        already: false,
+        request_id: rid,
         fingerprint: fp,
+        response: replay,
+      };
+    });
+  } catch (err) {
+    if (err.paywall || err.code === "free_quota_exhausted" || err.code === "credits_exhausted" || err.code === "idempotency_conflict") {
+      throw err;
+    }
+    if (isFirestoreBackendDown(err)) {
+      console.warn("billing-ledger: Firestore down — claims/gist billing fallback");
+      return applyUsageAndBurnClaimsFallback({
+        uid,
         tokensIn,
         tokensOut,
         tokensSaved,
-      });
-      // Backfill response on legacy rows that billed before replay storage existed.
-      if (replay && !prev.response) {
-        tx.set(usageRef, { response: replay }, { merge: true });
-      }
-      return {
-        burned_micros: Number(prev.burned_micros || 0),
-        ledger,
-        already: true,
-        request_id: rid,
-        fingerprint: prev.fingerprint || fp || null,
-        response: prev.response || replay || null,
-      };
-    }
-
-    const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims });
-    tx.set(ref, planned.ledger, { merge: true });
-    tx.set(
-      usageRef,
-      {
-        uid,
-        request_id: rid,
+        claims,
+        requestId: rid,
         fingerprint: fp,
-        tokens_in: Number(tokensIn) || 0,
-        tokens_out: Number(tokensOut) || 0,
-        tokens_saved: Number(tokensSaved) || 0,
-        burned_micros: planned.burned_micros,
-        created_at: new Date().toISOString(),
-        ...(replay ? { response: replay } : {}),
-      },
-      { merge: false }
-    );
-    return {
-      ...planned,
-      already: false,
-      request_id: rid,
-      fingerprint: fp,
-      response: replay,
-    };
-  });
+        response,
+      });
+    }
+    throw err;
+  }
 
   if (!result.already) {
     await mirrorClaims(uid, result.ledger);

--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -58,6 +58,7 @@ function emptyStore() {
     agent_links: {},
     welcome_emails: {},
     power_user_emails: {},
+    billing_usage_fallback: {},
     weekly_emails: {},
     weekly_unsubscribes: {},
     compress_logs: {},
@@ -84,6 +85,10 @@ function normalizeStore(raw) {
     agent_links: raw.agent_links && typeof raw.agent_links === "object" ? raw.agent_links : {},
     welcome_emails: raw.welcome_emails && typeof raw.welcome_emails === "object" ? raw.welcome_emails : {},
     power_user_emails: raw.power_user_emails && typeof raw.power_user_emails === "object" ? raw.power_user_emails : {},
+    billing_usage_fallback:
+      raw.billing_usage_fallback && typeof raw.billing_usage_fallback === "object"
+        ? raw.billing_usage_fallback
+        : {},
     weekly_emails: raw.weekly_emails && typeof raw.weekly_emails === "object" ? raw.weekly_emails : {},
     weekly_unsubscribes: raw.weekly_unsubscribes && typeof raw.weekly_unsubscribes === "object" ? raw.weekly_unsubscribes : {},
     compress_logs: raw.compress_logs && typeof raw.compress_logs === "object" ? raw.compress_logs : {},

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -213,20 +213,27 @@ module.exports = async (req, res) => {
         "rate_limit"
       );
     } catch (err) {
-      return json(res, 503, {
-        detail: "Rate limit service unavailable. Retry shortly.",
-        code: "rate_limit_unavailable",
-        request_id: requestId,
-      }, { "Idempotency-Key": requestId });
+      console.warn("durable rate limit timed out; using in-memory hourly IP:", err.message || err);
+      rl = { backend: "firestore-unavailable", error: err.message || "timeout", allowed: true };
     }
+    // Firestore durable RL is preferred, but must never hard-down compress when
+    // Cloud Firestore is disabled/timeout — fall back to in-memory hourly IP.
     if (rl.backend && rl.backend !== "firestore") {
-      return json(res, 503, {
-        detail: "Rate limit service unavailable. Retry shortly.",
-        code: "rate_limit_unavailable",
-        request_id: requestId,
-      }, { "Idempotency-Key": requestId });
-    }
-    if (!rl.allowed) {
+      console.warn(
+        "durable rate limit unavailable; using in-memory hourly IP fallback:",
+        rl.backend,
+        rl.error || ""
+      );
+      const rlHour = checkRateLimit(`v1ip:h:${ip}`, V1_IP_HOURLY, 60 * 60_000);
+      if (!rlHour.allowed) {
+        return jsonWithRateLimit(res, 429, {
+          detail: `IP rate limit exceeded (${V1_IP_HOURLY}/hour). Spread traffic or contact support.`,
+          retry_after_seconds: Math.max(1, Math.ceil((rlHour.resetMs - Date.now()) / 1000)),
+          request_id: requestId,
+        }, rlHour);
+      }
+      rl = { ...rlHour, backend: "memory-fallback", limit: V1_IP_HOURLY };
+    } else if (!rl.allowed) {
       return jsonWithRateLimit(res, 429, {
         detail: `IP rate limit exceeded (${V1_IP_HOURLY}/hour). Spread traffic or contact support.`,
         retry_after_seconds: Math.max(1, Math.ceil((rl.resetMs - Date.now()) / 1000)),


### PR DESCRIPTION
## Summary
- Cloud Firestore API is disabled on `supercompress` → durable RL returned `firestore-unavailable` → fail-closed 503 on every paid compress (100% error rate).
- Fail-open durable RL to in-memory hourly IP when Firestore is down.
- Bill via Auth claims + gist idempotency fallback when Firestore returns SERVICE_DISABLED.

## Test plan
- [x] Authenticated `POST /v1/compress` returns 200 after deploy (was 503 `rate_limit_unavailable`)
- [ ] Enable Cloud Firestore API in GCP console when possible so durable RL/ledger return


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Billing usage and quota checks now continue during temporary database outages.
  - Previously recorded usage requests can be safely replayed without duplicate charges.
  - Compression requests remain available during rate-limit storage outages, subject to an in-memory hourly limit.
  - Rate-limited requests now return a clear limit response instead of an unavailable-service error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->