### PR TITLE
fix(dashboard): analytics load/animation + logos + dither billing bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Public page: https://www.supercompress.dev/changelog
 - Keep user emails / outreach dumps / welcome-drain ops **out of OSS** (gitignore + CI PII gate); drain scripts live under `~/agent-bridge/private/supercompress-email/`
 
 ### API / dashboard
+- Analytics: charts animate in; reuse signed-in keys cache for faster panel open; month-meter gaps spread across the month (not a single today spike)
+- Coding agents use real logos when detected; billing free-allowance bar is Bayer-dithered
 - Auto branded **power-user email** when someone *newly* crosses 1M tokens (once ever; no backfill of current 1M+ accounts)
 - **Dashboard Analytics panel** (dither charts): live usage from `/api/keys` after sign-in — tokens saved, requests, coding agents, and key breakdown. `/analytics` stays inside `/dashboard?panel=analytics`.
 - Fix Analytics chart paint: Bayer wells + stacked dither canvases, wait for layout before draw, no demo/fake flash on production.

--- a/web/assets/css/dashboard-analytics.css
+++ b/web/assets/css/dashboard-analytics.css
@@ -151,7 +151,22 @@
   background: var(--an-brand-soft); color: var(--an-brand); font-family: var(--an-serif); font-size: 14px; font-weight: 400;
 }
 #panel-analytics .rank-main { min-width: 0; }
-#panel-analytics .rank-name { margin: 0; font-size: 14px; font-weight: 500; color: var(--an-ink); }
+#panel-analytics .rank-name {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--an-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+#panel-analytics .sc-agent-logo {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+  flex-shrink: 0;
+  border-radius: 3px;
+}
 #panel-analytics .rank-meta { margin: 2px 0 8px; font-size: 12px; color: var(--an-muted); }
 #panel-analytics .rank-track {
   position: relative; height: 8px; border-radius: 999px; background: rgba(5, 102, 255, 0.08); overflow: hidden;

--- a/web/assets/js/analytics-data.js
+++ b/web/assets/js/analytics-data.js
@@ -279,24 +279,58 @@
     );
 
     // Month meter ahead of ISO by_day (common when ledger/agent totals exist but
-    // daily rows lagged). Fold the gap onto today so the area chart matches KPIs.
-    const gapSaved = saved - daySaved;
-    const gapIn = tin - dayIn;
-    const gapReq = req - dayReq;
+    // daily rows lagged). Spread the gap across days in the current calendar
+    // month (within the 30-day window) so charts aren't a single today-spike.
+    const gapSaved = Math.max(0, saved - daySaved);
+    const gapIn = Math.max(0, tin - dayIn);
+    const gapReq = Math.max(0, req - dayReq);
     if (gapSaved > 500 || gapIn > 500 || gapReq > 0) {
-      const today = keys[keys.length - 1];
-      const cur = bundle.byDay[today] || emptyDay();
-      bundle.byDay[today] = {
-        tokens_saved: cur.tokens_saved + Math.max(0, gapSaved),
-        tokens_in: cur.tokens_in + Math.max(0, gapIn),
-        requests: cur.requests + Math.max(0, gapReq),
-      };
+      distributeMeterGap(bundle.byDay, keys, gapSaved, gapIn, gapReq);
       daySaved = saved;
       dayIn = tin;
       dayReq = req;
     }
 
-    return { saved, tin, req, daySaved, dayIn, dayReq };
+    return { saved, tin, req, daySaved, dayIn, dayReq, gapFolded: gapSaved > 500 || gapIn > 500 || gapReq > 0 };
+  }
+
+  /**
+   * Spread unattributed month-meter gap across days in the current month.
+   * Prefers days that already have activity; otherwise every day in-month.
+   */
+  function distributeMeterGap(byDay, keys, gapSaved, gapIn, gapReq) {
+    const monthPrefix = new Date().toISOString().slice(0, 7);
+    const monthDays = keys.filter((iso) => String(iso).startsWith(monthPrefix));
+    const pool = monthDays.length ? monthDays : keys.slice();
+    const active = pool.filter((iso) => {
+      const d = byDay[iso] || emptyDay();
+      return d.tokens_saved > 0 || d.tokens_in > 0 || d.requests > 0;
+    });
+    // If we only have 0–1 real days, fill the whole month strip so the chart
+    // reads as a month — not one lonely spike + empty axis.
+    const days = active.length >= 2 ? active : pool;
+    const n = Math.max(1, days.length);
+    let remS = gapSaved;
+    let remI = gapIn;
+    let remR = gapReq;
+    const baseS = Math.floor(gapSaved / n);
+    const baseI = Math.floor(gapIn / n);
+    const baseR = Math.floor(gapReq / n);
+    days.forEach((iso, i) => {
+      const last = i === days.length - 1;
+      const addS = last ? remS : baseS;
+      const addI = last ? remI : baseI;
+      const addR = last ? remR : baseR;
+      remS -= addS;
+      remI -= addI;
+      remR -= addR;
+      const cur = byDay[iso] || emptyDay();
+      byDay[iso] = {
+        tokens_saved: cur.tokens_saved + addS,
+        tokens_in: cur.tokens_in + addI,
+        requests: cur.requests + addR,
+      };
+    });
   }
 
   function bundleToSeries(bundle) {
@@ -365,6 +399,39 @@
       .replace(/'/g, "&#39;");
   }
 
+  /** Map coding-agent label → logo under /assets/logos/ (null = no logo). */
+  function agentLogoSrc(name) {
+    const key = String(name || "")
+      .toLowerCase()
+      .replace(/_/g, "-")
+      .replace(/\s+/g, "-");
+    const map = {
+      cursor: "/assets/logos/cursor.svg",
+      "claude-code": "/assets/logos/claude.png",
+      claude: "/assets/logos/claude.png",
+      anthropic: "/assets/logos/anthropic.svg",
+      codex: "/assets/logos/codex.png",
+      "openai-client": "/assets/logos/openai.png",
+      openai: "/assets/logos/openai.png",
+      copilot: "/assets/logos/copilot.png",
+      "github-copilot": "/assets/logos/copilot.png",
+      windsurf: "/assets/logos/windsurf.png",
+      opencode: "/assets/logos/opencode.png",
+      gemini: "/assets/logos/gemini.png",
+      "google-gemini": "/assets/logos/gemini.png",
+      vscode: "/assets/logos/vscode.png",
+      "vs-code": "/assets/logos/vscode.png",
+    };
+    return map[key] || null;
+  }
+
+  function agentLogoHtml(name, { size = 18 } = {}) {
+    const src = agentLogoSrc(name);
+    if (!src) return "";
+    const alt = escapeHtml(String(name || "agent"));
+    return `<img class="sc-agent-logo" src="${src}" alt="${alt}" width="${size}" height="${size}" loading="lazy" decoding="async" />`;
+  }
+
   const api = {
     dayKeys,
     labelDay,
@@ -376,6 +443,9 @@
     escapeHtml,
     sumAgents,
     sumKeys,
+    distributeMeterGap,
+    agentLogoSrc,
+    agentLogoHtml,
   };
 
   root.SCAnalyticsData = api;

--- a/web/assets/js/analytics-data.test.js
+++ b/web/assets/js/analytics-data.test.js
@@ -127,5 +127,19 @@ assert.strictEqual(
   250000,
   "chart area matches month meter after gap fold"
 );
+assert.ok(
+  s3.activeDays >= 2,
+  "gap spread across multiple days, not a single today spike"
+);
+const todayIso = new Date().toISOString().slice(0, 10);
+const todayY = s3.areaData.find((d) => d.iso === todayIso)?.y || 0;
+assert.ok(
+  todayY < 250000,
+  "today should not hold the entire month gap alone"
+);
+
+assert.ok(typeof require("./analytics-data.js").agentLogoSrc === "function");
+assert.strictEqual(require("./analytics-data.js").agentLogoSrc("Cursor"), "/assets/logos/cursor.svg");
+assert.ok(require("./analytics-data.js").agentLogoHtml("Claude Code").includes("claude.png"));
 
 console.log("analytics-data.test.js: ok");

--- a/web/assets/js/dashboard-analytics.js
+++ b/web/assets/js/dashboard-analytics.js
@@ -18,6 +18,7 @@
 
   let loadedOnce = false;
   let loading = false;
+  let lastSeries = null;
 
   function setPill(mode, text) {
     const pill = $("an-data-pill");
@@ -38,18 +39,31 @@
     if (message) el.textContent = message;
   }
 
-  function animateNumber(el, to, { suffix = "", compact = false } = {}) {
+  function animateNumber(el, to, { suffix = "", compact = false, duration = 900 } = {}) {
     const kit = DK();
     if (!el) return;
     const n = Number(to);
-    const v = Number.isFinite(n) ? Math.max(0, n) : 0;
-    el.textContent = (compact && kit ? kit.formatCompact(v) : String(Math.round(v))) + suffix;
+    const target = Number.isFinite(n) ? Math.max(0, n) : 0;
+    if (!kit) {
+      el.textContent = (compact ? String(Math.round(target)) : String(Math.round(target))) + suffix;
+      return;
+    }
+    const t0 = performance.now();
+    const ease = (t) => 1 - Math.pow(1 - t, 3);
+    const frame = (now) => {
+      const p = Math.min(1, (now - t0) / duration);
+      const v = target * ease(p);
+      el.textContent = (compact ? kit.formatCompact(v) : String(Math.round(v))) + suffix;
+      if (p < 1) requestAnimationFrame(frame);
+    };
+    requestAnimationFrame(frame);
   }
 
   function paint(series) {
     const kit = DK();
     const data = DATA();
     if (!kit || !data) return;
+    lastSeries = series;
 
     setPill(series.live ? "live" : "err", series.live ? "Live · your account" : "Could not load live usage");
 
@@ -89,41 +103,64 @@
       yMax: areaMax,
       empty: !series.areaData.some((d) => d.y > 0),
       emptyLabel: "No daily savings yet",
-      data: series.areaData,
-      interactive: true,
     };
-    kit.renderAreaChart(areaEl, areaOpts);
-    kit.startChartDitherLoop(areaEl, { kind: "area", ...areaOpts });
+    kit.animateChart((p) => {
+      kit.renderAreaChart(areaEl, {
+        ...areaOpts,
+        data: series.areaData.map((d) => ({ x: d.x, y: d.y * p, iso: d.iso })),
+        interactive: false,
+      });
+      if (p > 0.98) {
+        kit.renderAreaChart(areaEl, {
+          ...areaOpts,
+          data: series.areaData,
+          interactive: true,
+        });
+        kit.startChartDitherLoop(areaEl, {
+          kind: "area",
+          ...areaOpts,
+          data: series.areaData,
+          interactive: true,
+        });
+      }
+    }, 1100);
 
-    const barOpts = {
-      data: series.reqs.map((r) => ({ label: r.label, value: r.value, full: r.full })),
-      orientation: "vertical",
-      color: "brand",
-      variant: "gradient",
-      bloom: "aura",
-      maxBars: 30,
-      progress: 1,
-      yMax: reqMax,
-      unit: "requests",
-      tooltipTitle: "Requests",
-      interactive: true,
-      empty: !series.reqs.some((r) => r.value > 0),
-      emptyLabel: "No requests yet",
-    };
-    kit.renderBarChart(barsEl, barOpts);
-    kit.startChartDitherLoop(barsEl, { kind: "bar", ...barOpts });
+    kit.animateChart((p) => {
+      const done = p > 0.98;
+      const barOpts = {
+        data: series.reqs.map((r) => ({ label: r.label, value: r.value, full: r.full })),
+        orientation: "vertical",
+        color: "brand",
+        variant: "gradient",
+        bloom: "aura",
+        maxBars: 30,
+        progress: done ? 1 : p,
+        yMax: reqMax,
+        unit: "requests",
+        tooltipTitle: "Requests",
+        interactive: done,
+        empty: !series.reqs.some((r) => r.value > 0),
+        emptyLabel: "No requests yet",
+      };
+      kit.renderBarChart(barsEl, barOpts);
+      if (done) {
+        kit.startChartDitherLoop(barsEl, { kind: "bar", ...barOpts, progress: 1, interactive: true });
+      }
+    }, 1100);
 
     const esc = data.escapeHtml;
+    const logoHtml = data.agentLogoHtml || (() => "");
     const agentTotal = series.agents.reduce((s, a) => s + a.value, 0) || 1;
     if ($("an-agents")) {
       $("an-agents").innerHTML = series.agents.length
         ? series.agents
             .map((a, i) => {
               const pct = Math.round((a.value / agentTotal) * 100);
+              const logo = logoHtml(a.label, { size: 18 });
               return `<li class="rank-row">
                 <span class="rank-idx">${i + 1}</span>
                 <div class="rank-main">
-                  <p class="rank-name">${esc(a.label)}</p>
+                  <p class="rank-name">${logo}<span>${esc(a.label)}</span></p>
                   <p class="rank-meta">${kit.formatCompact(a.value)} tokens saved</p>
                   <div class="rank-track"><span class="rank-fill" data-w="${pct}"></span></div>
                 </div>
@@ -162,13 +199,26 @@
     loadedOnce = true;
   }
 
-  async function fetchKeys(idToken) {
-    const res = await fetch(`/api/keys?fresh=1&_=${Date.now()}`, {
+  async function fetchKeys(idToken, { fresh = false } = {}) {
+    const q = fresh ? `?fresh=1&_=${Date.now()}` : `?_=${Date.now()}`;
+    const res = await fetch(`/api/keys${q}`, {
       headers: { Authorization: `Bearer ${idToken}` },
       cache: "no-store",
     });
     if (!res.ok) throw new Error(`keys ${res.status}`);
     return res.json();
+  }
+
+  function waitForLayout(maxFrames = 12) {
+    return new Promise((resolve) => {
+      let n = maxFrames;
+      const tick = () => {
+        const w = $("an-area")?.getBoundingClientRect().width || 0;
+        if (w > 40 || n-- <= 0) return resolve();
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    });
   }
 
   async function show({ getIdToken, force = false } = {}) {
@@ -180,7 +230,8 @@
       return;
     }
     if (loading) return;
-    if (loadedOnce && !force) {
+
+    if (loadedOnce && !force && lastSeries) {
       const areaH = $("an-area")?.querySelector("canvas")?.getBoundingClientRect().height || 0;
       if (areaH >= 80) {
         for (const [id, opts] of washes) {
@@ -189,27 +240,37 @@
         }
         return;
       }
-      // First paint happened while the panel was 0×0 — do a full redraw.
     }
 
     loading = true;
     setLoading(true, "Loading your live usage…");
     setPill("load", "Live · loading…");
     try {
-      await new Promise((resolve) => {
-        let n = 16;
-        const tick = () => {
-          const w = $("an-area")?.getBoundingClientRect().width || 0;
-          if (w > 40 || n-- <= 0) return resolve();
-          requestAnimationFrame(tick);
-        };
-        requestAnimationFrame(tick);
-      });
-      const token = await getIdToken();
-      if (!token) throw new Error("Not signed in");
-      const payload = await fetchKeys(token);
+      await waitForLayout(12);
+
+      // Prefer keys payload already loaded by the dashboard (same session).
+      let payload = !force && window.__scLastKeysPayload ? window.__scLastKeysPayload : null;
+      if (!payload) {
+        const token = await getIdToken();
+        if (!token) throw new Error("Not signed in");
+        payload = await fetchKeys(token, { fresh: false });
+        window.__scLastKeysPayload = payload;
+      }
+
       paint(data.bundleToSeries(data.aggregateUsage(payload)));
       setLoading(false);
+
+      // Soft refresh in background so charts stay current without blocking UI.
+      if (!force) {
+        getIdToken()
+          .then((token) => (token ? fetchKeys(token, { fresh: true }) : null))
+          .then((fresh) => {
+            if (!fresh) return;
+            window.__scLastKeysPayload = fresh;
+            paint(data.bundleToSeries(data.aggregateUsage(fresh)));
+          })
+          .catch(() => {});
+      }
     } catch (err) {
       console.error(err);
       setPill("err", "Load failed");

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -472,7 +472,7 @@ function renderCodingAgents() {
       const savedPct = a.tokens_in > 0 ? Math.round((a.tokens_saved / a.tokens_in) * 100) : 0;
       const icon = agentIcon(name);
       return `<tr>
-        <td><strong>${icon} ${escapeHtml(name)}</strong></td>
+        <td><strong class="sc-agent-cell">${icon}<span>${escapeHtml(name)}</span></strong></td>
         <td>${a.requests || 0}</td>
         <td>${n(a.tokens_in || 0)}</td>
         <td>${n(a.tokens_out || 0)}</td>
@@ -485,26 +485,26 @@ function renderCodingAgents() {
 }
 
 function agentIcon(name) {
-  const key = String(name || "").toLowerCase().replace(/_/g, "-");
+  const logo =
+    (window.SCAnalyticsData && typeof window.SCAnalyticsData.agentLogoHtml === "function"
+      ? window.SCAnalyticsData.agentLogoHtml(name, { size: 16 })
+      : "") || "";
+  if (logo) return logo;
+  const key = String(name || "").toLowerCase().replace(/_/g, "-").replace(/\s+/g, "-");
   const icons = {
-    cursor: "🖱️",
-    windsurf: "🏄",
     continue: "▶️",
     cline: "🤖",
-    "claude-code": "🧠",
     aider: "🤝",
-    copilot: "👻",
-    codex: "📝",
     mcp: "🔌",
-    "openai-client": "🔵",
     "api-client": "🔌",
   };
-  return icons[key] || "⚡";
+  return icons[key] || "";
 }
 
 async function loadKeys() {
   try {
     const data = await apiFetch("/api/keys");
+    window.__scLastKeysPayload = data;
     keysData = data.keys || [];
     usageData = data.usage || {};
     accountUsage = data.account_usage || null;
@@ -870,6 +870,58 @@ function renderPaygNudge(sub) {
   }
 }
 
+function paintBillingUsageDither() {
+  const BAYER4 = [
+    [0, 8, 2, 10],
+    [12, 4, 14, 6],
+    [3, 11, 1, 9],
+    [15, 7, 13, 5],
+  ];
+  const fill = document.querySelector(".dash-billing-usage-fill");
+  if (!fill) return;
+  const canvas = fill.querySelector("canvas.dash-billing-usage-dither");
+  if (!canvas) return;
+  const pct = Math.max(0, Math.min(100, Number(fill.getAttribute("data-pct") || 0)));
+  const tone = fill.classList.contains("dash-billing-usage-fill--full")
+    ? [239, 68, 68]
+    : fill.classList.contains("dash-billing-usage-fill--high")
+      ? [245, 158, 11]
+      : [5, 102, 255];
+  const paint = () => {
+    const cssW = Math.max(1, Math.round(fill.clientWidth || 1));
+    const cssH = Math.max(1, Math.round(fill.clientHeight || 8));
+    const cell = 2;
+    const w = Math.max(1, Math.floor(cssW / cell));
+    const h = Math.max(1, Math.floor(cssH / cell));
+    if (canvas.width !== w || canvas.height !== h) {
+      canvas.width = w;
+      canvas.height = h;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const [r, g, b] = tone;
+    ctx.clearRect(0, 0, w, h);
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const edge = w > 1 ? x / (w - 1) : 1;
+        const density = 0.22 + edge * 0.7;
+        const t = (BAYER4[y & 3][x & 3] + 0.5) / 16;
+        if (t < density) {
+          ctx.fillStyle = `rgb(${r},${g},${b})`;
+          ctx.fillRect(x, y, 1, 1);
+        }
+      }
+    }
+  };
+  requestAnimationFrame(paint);
+  if (!paintBillingUsageDither._bound) {
+    paintBillingUsageDither._bound = true;
+    window.addEventListener("resize", () => paintBillingUsageDither(), { passive: true });
+  }
+  // silence unused pct — width already encodes usage; density uses full fill
+  void pct;
+}
+
 function renderActivationChecklist() {
   /* Activation checklist removed from dashboard UI. */
 }
@@ -945,7 +997,9 @@ function renderSubscription(sub) {
         <span>${pct}%</span>
       </div>
       <div class="dash-billing-usage-track">
-        <div class="dash-billing-usage-fill ${fillClass}" style="width:${pct}%"></div>
+        <div class="dash-billing-usage-fill ${fillClass}" style="width:${pct}%" data-pct="${pct}" aria-hidden="true">
+          <canvas class="dash-billing-usage-dither"></canvas>
+        </div>
       </div>
     </div>
     ${creditWallet || hasCreditBalance
@@ -961,6 +1015,7 @@ function renderSubscription(sub) {
   `;
 
   $("btn-paywall-unlock")?.addEventListener("click", () => handleEnablePayg());
+  paintBillingUsageDither();
   // Update plan cards
   document.querySelectorAll(".dash-plan-card").forEach((card) => {
     const plan = card.dataset.plan;

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -28,7 +28,7 @@
   <meta name="theme-color" content="rgb(251,251,248)" />
   <link rel="stylesheet" href="assets/css/supercompress.css?v=112" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/dashboard-analytics.css?v=3" />
+  <link rel="stylesheet" href="/assets/css/dashboard-analytics.css?v=4" />
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet" />
 <style>
     /* Dashboard: no dark bg layers, full light page */
@@ -133,16 +133,46 @@
     .dash-billing-usage-fill {
       height: 100%;
       border-radius: 4px;
-      background: var(--brand);
+      background: transparent;
       transition: width 0.4s ease;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .dash-billing-usage-dither {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      display: block;
+      image-rendering: pixelated;
+    }
+
+    .dash-billing-usage-fill--high .dash-billing-usage-dither,
+    .dash-billing-usage-fill--full .dash-billing-usage-dither {
+      filter: none;
     }
 
     .dash-billing-usage-fill--high {
-      background: #f59e0b;
+      background: transparent;
     }
 
     .dash-billing-usage-fill--full {
-      background: #ef4444;
+      background: transparent;
+    }
+
+    .sc-agent-cell {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .sc-agent-logo {
+      width: 16px;
+      height: 16px;
+      object-fit: contain;
+      flex-shrink: 0;
+      border-radius: 3px;
     }
 
     .dash-plans-grid {
@@ -1119,9 +1149,9 @@ npm exec supercompress setup</pre>
   <script src="assets/js/firebase-config.js?v=3"></script>
   <script src="assets/js/supercompress.js?v=1"></script>
   <script src="/assets/js/dither-kit-lite.js?v=12"></script>
-  <script src="/assets/js/analytics-data.js?v=3"></script>
-  <script src="/assets/js/dashboard-analytics.js?v=5"></script>
-  <script type="module" src="assets/js/dashboard-api.js?v=36"></script>
+  <script src="/assets/js/analytics-data.js?v=4"></script>
+  <script src="/assets/js/dashboard-analytics.js?v=6"></script>
+  <script type="module" src="assets/js/dashboard-api.js?v=37"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- Analytics panel reuses the dashboard keys cache (background soft-refresh) so it stops feeling stuck on load
- Charts + KPIs animate in (same grow-in as `/analytics`)
- Month-meter gaps spread across days in the current month instead of dumping onto today (fixes “only a few days” charts)
- Detected coding agents use real logos from `/assets/logos/`
- Billing free-allowance usage bar is Bayer-dithered

## Test plan
- [x] `node web/assets/js/analytics-data.test.js`
- [ ] Open dashboard → Analytics: charts animate; more than a single-day spike when month totals exist
- [ ] Coding agents table shows Cursor/Claude/Codex logos
- [ ] Billing panel usage bar is dithered (blue / amber / red by %)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes dashboard analytics load from a shared keys cache, refresh in the background, animate charts and KPIs, distribute unattributed monthly usage, display coding-agent logos, and render a dithered billing meter.
- Reuses `/api/keys` data and adds a soft fresh refresh.
- Animates analytics charts and numeric KPIs.
- Distributes month-meter gaps over current-month chart days.
- Adds agent logo mapping and billing-bar canvas dithering.

<h3>Confidence Score: 2/5</h3>

This PR should not merge until the cross-account analytics cache exposure and stale-animation overwrite are fixed.

Cached account data is rendered without verifying ownership after authentication transitions, and uncancelled animations can restore stale chart data after a fresh response has already been painted.

**Files Needing Attention:** web/assets/js/dashboard-analytics.js and web/assets/js/dashboard-api.js

<details open><summary><h3>Security Review</h3></summary>

The account-scoped keys payload is cached globally without owner metadata or auth-transition invalidation, allowing an in-page account switch to display the preceding account's analytics until refresh. **How this was verified:** The cache is painted before obtaining the current token, and every inspected sign-out/account-switch path leaves it intact.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/assets/js/dashboard-analytics.js | Adds cache-first loading, background refresh, and animations, but leaves the account-scoped cache unowned and permits stale animations to overwrite refreshed charts. |
| web/assets/js/dashboard-api.js | Populates the shared analytics cache and adds logo and billing-dither rendering; authentication transitions do not invalidate the new cache. |
| web/assets/js/analytics-data.js | Adds monthly-gap distribution and allowlisted logo helpers with escaped labels. |
| web/assets/js/analytics-data.test.js | Extends unit coverage for distributed gaps and logo selection. |
| web/dashboard.html | Adds dither-canvas and agent-logo styling and increments static asset versions. |
| web/assets/css/dashboard-analytics.css | Adds layout and sizing styles for logos in analytics rankings. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Analytics panel
  participant Cache as Global keys cache
  participant API as /api/keys
  UI->>Cache: Read cached account payload
  Cache-->>UI: Paint immediately and animate
  UI->>API: Background fresh request
  API-->>UI: Fresh account payload
  UI->>UI: Start second animation
  Note over UI: Old and new RAF chains overlap
  UI->>UI: Last old completion may restore stale loop
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): faster analytics, month-..."](https://github.com/supercompress/supercompress/commit/4668e7b238dcefbeea1754f3f33e79c9146c29e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52593383)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->