### PR TITLE
feat: Resend inbound webhook (/api/resend/webhook)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
         run: node api/_lib/coding-agent-usage.test.js
       - name: Power-user milestone unit tests
         run: node api/_lib/power-user.test.js
+      - name: Resend webhook signature unit tests
+        run: node api/_lib/resend-webhook.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
       - name: Proxy package tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Public page: https://www.supercompress.dev/changelog
 - Keep user emails / outreach dumps / welcome-drain ops **out of OSS** (gitignore + CI PII gate); drain scripts live under `~/agent-bridge/private/supercompress-email/`
 
 ### API / dashboard
+- **Resend inbound webhook:** `POST https://www.supercompress.dev/api/resend/webhook` (Svix-verified `email.received` → `inbound_mail` + notify)
 - Auto branded **power-user email** when someone *newly* crosses 1M tokens (once ever; no backfill of current 1M+ accounts)
 - **Dashboard Analytics panel** (dither charts): live usage from `/api/keys` after sign-in — tokens saved, requests, coding agents, and key breakdown. `/analytics` stays inside `/dashboard?panel=analytics`.
 - Fix Analytics chart paint: Bayer wells + stacked dither canvases, wait for layout before draw, no demo/fake flash on production.

--- a/api/_lib/resend-webhook.js
+++ b/api/_lib/resend-webhook.js
@@ -1,0 +1,258 @@
+/**
+ * Resend webhook helpers (Svix signature verify + inbound email.received).
+ * Docs: https://resend.com/docs/webhooks/verify-webhooks-requests
+ */
+const crypto = require("crypto");
+const { initFirebaseAdmin } = require("./auth");
+const { sendViaResend } = require("./mail");
+
+const MAX_SKEW_SEC = 300;
+const BODY_PREVIEW_CHARS = 4000;
+
+function header(headers, name) {
+  if (!headers || typeof headers !== "object") return "";
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (String(k).toLowerCase() === lower) return String(v || "");
+  }
+  return "";
+}
+
+function timingSafeEqualStr(a, b) {
+  const ba = Buffer.from(String(a || ""), "utf8");
+  const bb = Buffer.from(String(b || ""), "utf8");
+  if (ba.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ba, bb);
+}
+
+/**
+ * Verify Resend/Svix webhook. Returns parsed JSON event.
+ * @param {string|Buffer} rawBody
+ * @param {Record<string, string>} headers
+ * @param {string} secret whsec_…
+ */
+function verifyResendWebhook(rawBody, headers, secret) {
+  const payload = Buffer.isBuffer(rawBody) ? rawBody.toString("utf8") : String(rawBody || "");
+  const whsec = String(secret || "").trim();
+  if (!whsec) {
+    const err = new Error("RESEND_WEBHOOK_SECRET not configured");
+    err.status = 503;
+    throw err;
+  }
+
+  const id = header(headers, "svix-id");
+  const timestamp = header(headers, "svix-timestamp");
+  const signatureHeader = header(headers, "svix-signature");
+  if (!id || !timestamp || !signatureHeader) {
+    const err = new Error("Missing Svix signature headers");
+    err.status = 400;
+    throw err;
+  }
+
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) {
+    const err = new Error("Invalid Svix timestamp");
+    err.status = 400;
+    throw err;
+  }
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSec - ts) > MAX_SKEW_SEC) {
+    const err = new Error("Svix timestamp outside allowed skew");
+    err.status = 400;
+    throw err;
+  }
+
+  const secretPart = whsec.startsWith("whsec_") ? whsec.slice("whsec_".length) : whsec;
+  let key;
+  try {
+    key = Buffer.from(secretPart, "base64");
+  } catch {
+    const err = new Error("Invalid RESEND_WEBHOOK_SECRET");
+    err.status = 503;
+    throw err;
+  }
+  if (!key.length) {
+    const err = new Error("Invalid RESEND_WEBHOOK_SECRET");
+    err.status = 503;
+    throw err;
+  }
+
+  const signed = `${id}.${timestamp}.${payload}`;
+  const expected = crypto.createHmac("sha256", key).update(signed, "utf8").digest("base64");
+  const ok = String(signatureHeader)
+    .split(/\s+/)
+    .some((part) => {
+      const [ver, sig] = part.split(",");
+      return ver === "v1" && sig && timingSafeEqualStr(sig, expected);
+    });
+  if (!ok) {
+    const err = new Error("Invalid webhook signature");
+    err.status = 400;
+    throw err;
+  }
+
+  try {
+    return JSON.parse(payload);
+  } catch {
+    const err = new Error("Invalid JSON payload");
+    err.status = 400;
+    throw err;
+  }
+}
+
+function clip(s, n = BODY_PREVIEW_CHARS) {
+  const t = String(s || "").trim();
+  if (t.length <= n) return t;
+  return `${t.slice(0, n)}…`;
+}
+
+async function fetchReceivedEmail(emailId) {
+  const apiKey = (process.env.RESEND_API_KEY || "").trim();
+  if (!apiKey || !emailId) return null;
+  const res = await fetch(`https://api.resend.com/emails/receiving/${encodeURIComponent(emailId)}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    console.warn("resend receiving get failed:", res.status, detail.slice(0, 200));
+    return null;
+  }
+  return res.json();
+}
+
+function inboundNotifyTo() {
+  return (
+    (process.env.RESEND_INBOUND_NOTIFY_TO || "").trim() ||
+    (process.env.WELCOME_REPLY_TO || "").trim() ||
+    "arjunkshah21@gmail.com"
+  );
+}
+
+function shouldNotify(fromAddr, subject) {
+  const notify = inboundNotifyTo().toLowerCase();
+  const from = String(fromAddr || "").toLowerCase();
+  if (from && notify && from.includes(notify)) return false;
+  if (/^\[sc inbound\]/i.test(String(subject || ""))) return false;
+  return true;
+}
+
+async function persistInbound(record) {
+  try {
+    initFirebaseAdmin();
+    const db = require("firebase-admin").firestore();
+    const id = String(record.email_id || record.svix_id || `anon_${Date.now()}`);
+    const ref = db.collection("inbound_mail").doc(id);
+    await db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (snap.exists) {
+        record._duplicate = true;
+        return;
+      }
+      tx.set(ref, {
+        ...record,
+        created_at: new Date().toISOString(),
+        // Soft retention hint for ops / TTL policies (not auto-deleted here).
+        retain_until: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      });
+    });
+    return record;
+  } catch (err) {
+    console.warn("inbound_mail persist failed:", err.message);
+    return record;
+  }
+}
+
+async function notifyInbound(meta, body) {
+  if (!shouldNotify(meta.from, meta.subject)) {
+    return { ok: true, skipped: true };
+  }
+  const to = inboundNotifyTo();
+  const textBody = clip(body?.text || body?.html?.replace(/<[^>]+>/g, " ") || "(no body fetched)");
+  const subject = `[SC inbound] ${clip(meta.subject || "(no subject)", 80)}`;
+  const text = [
+    `Inbound email via Resend`,
+    `From: ${meta.from || "?"}`,
+    `To: ${(meta.to || []).join(", ") || "?"}`,
+    `Subject: ${meta.subject || "?"}`,
+    `Email id: ${meta.email_id || "?"}`,
+    ``,
+    textBody,
+  ].join("\n");
+  return sendViaResend({
+    to,
+    subject,
+    text,
+    html: `<pre style="font:14px/1.45 ui-monospace,Menlo,monospace;white-space:pre-wrap">${escapeHtml(text)}</pre>`,
+  });
+}
+
+function escapeHtml(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Handle a verified Resend event. Returns a small JSON-serializable result.
+ */
+async function handleResendEvent(event, { svixId } = {}) {
+  const type = event?.type || "";
+  if (type !== "email.received") {
+    return { ok: true, ignored: true, type };
+  }
+
+  const data = event.data || {};
+  const emailId = data.email_id || "";
+  const meta = {
+    email_id: emailId,
+    svix_id: svixId || "",
+    from: data.from || "",
+    to: Array.isArray(data.to) ? data.to : [],
+    cc: Array.isArray(data.cc) ? data.cc : [],
+    subject: data.subject || "",
+    message_id: data.message_id || "",
+    attachments: Array.isArray(data.attachments) ? data.attachments.map((a) => ({
+      id: a.id,
+      filename: a.filename,
+      content_type: a.content_type,
+    })) : [],
+    created_at_provider: data.created_at || event.created_at || "",
+  };
+
+  const body = await fetchReceivedEmail(emailId);
+  const record = {
+    ...meta,
+    text_preview: clip(body?.text || ""),
+    html_preview: clip(body?.html || ""),
+    fetched: Boolean(body),
+  };
+
+  await persistInbound(record);
+  if (record._duplicate) {
+    return { ok: true, duplicate: true, email_id: emailId };
+  }
+
+  const notify = await notifyInbound(meta, body);
+  return {
+    ok: true,
+    email_id: emailId,
+    fetched: record.fetched,
+    notified: Boolean(notify?.ok) && !notify?.skipped,
+    notify_skipped: Boolean(notify?.skipped),
+    notify_error: notify?.ok ? null : notify?.error || null,
+  };
+}
+
+module.exports = {
+  verifyResendWebhook,
+  handleResendEvent,
+  fetchReceivedEmail,
+  inboundNotifyTo,
+  shouldNotify,
+  // test helpers
+  _timingSafeEqualStr: timingSafeEqualStr,
+  BODY_PREVIEW_CHARS,
+  MAX_SKEW_SEC,
+};

--- a/api/_lib/resend-webhook.test.js
+++ b/api/_lib/resend-webhook.test.js
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for Resend/Svix webhook verification.
+ * Run: node api/_lib/resend-webhook.test.js
+ */
+const assert = require("assert");
+const crypto = require("crypto");
+const {
+  verifyResendWebhook,
+  shouldNotify,
+  MAX_SKEW_SEC,
+} = require("./resend-webhook");
+
+function sign(raw, secret, id, timestamp) {
+  const secretPart = secret.startsWith("whsec_") ? secret.slice(6) : secret;
+  const key = Buffer.from(secretPart, "base64");
+  const expected = crypto
+    .createHmac("sha256", key)
+    .update(`${id}.${timestamp}.${raw}`, "utf8")
+    .digest("base64");
+  return `v1,${expected}`;
+}
+
+const secret = `whsec_${Buffer.from("supercompress-test-secret-key!!").toString("base64")}`;
+const id = "msg_test_123";
+const timestamp = String(Math.floor(Date.now() / 1000));
+const payload = JSON.stringify({
+  type: "email.received",
+  created_at: new Date().toISOString(),
+  data: {
+    email_id: "em_test",
+    from: "user@example.com",
+    to: ["hello@supercompress.dev"],
+    subject: "Hi",
+    attachments: [],
+  },
+});
+
+const headers = {
+  "svix-id": id,
+  "svix-timestamp": timestamp,
+  "svix-signature": sign(payload, secret, id, timestamp),
+};
+
+const event = verifyResendWebhook(payload, headers, secret);
+assert.strictEqual(event.type, "email.received");
+assert.strictEqual(event.data.email_id, "em_test");
+
+// Tampered body
+assert.throws(
+  () => verifyResendWebhook(payload + " ", headers, secret),
+  /Invalid webhook signature/
+);
+
+// Bad secret
+assert.throws(
+  () => verifyResendWebhook(payload, headers, "whsec_" + Buffer.from("nope").toString("base64")),
+  /Invalid webhook signature/
+);
+
+// Stale timestamp
+const staleTs = String(Math.floor(Date.now() / 1000) - MAX_SKEW_SEC - 60);
+assert.throws(
+  () =>
+    verifyResendWebhook(payload, {
+      ...headers,
+      "svix-timestamp": staleTs,
+      "svix-signature": sign(payload, secret, id, staleTs),
+    }, secret),
+  /timestamp outside allowed skew/
+);
+
+assert.strictEqual(shouldNotify("user@example.com", "Hello"), true);
+assert.strictEqual(shouldNotify("arjunkshah21@gmail.com", "Hello"), false);
+assert.strictEqual(shouldNotify("user@example.com", "[SC inbound] loop"), false);
+
+console.log("resend-webhook.test.js: ok");

--- a/api/resend-webhook.js
+++ b/api/resend-webhook.js
@@ -1,0 +1,66 @@
+/**
+ * POST /api/resend/webhook  (rewrite → /api/resend-webhook)
+ *
+ * Resend inbound + delivery webhooks (Svix-signed).
+ * Register in Resend dashboard:
+ *   URL:    https://www.supercompress.dev/api/resend/webhook
+ *   Events: email.received  (add others if you want delivery telemetry)
+ *   Secret: RESEND_WEBHOOK_SECRET=whsec_… on Vercel
+ *
+ * email.received → fetch body via Receiving API → inbound_mail/{id} → notify RESEND_INBOUND_NOTIFY_TO
+ */
+const {
+  verifyResendWebhook,
+  handleResendEvent,
+} = require("./_lib/resend-webhook");
+
+module.exports.config = { api: { bodyParser: false } };
+
+function corsHeaders(res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader(
+    "Access-Control-Allow-Headers",
+    "Content-Type, svix-id, svix-timestamp, svix-signature"
+  );
+}
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+module.exports = async (req, res) => {
+  if (req.method === "OPTIONS") {
+    corsHeaders(res);
+    return res.status(204).end();
+  }
+  if (req.method !== "POST") {
+    corsHeaders(res);
+    return res.status(405).json({ detail: "Method not allowed" });
+  }
+
+  const webhookSecret = (process.env.RESEND_WEBHOOK_SECRET || "").trim();
+  if (!webhookSecret) {
+    corsHeaders(res);
+    return res.status(503).json({ detail: "RESEND_WEBHOOK_SECRET not configured" });
+  }
+
+  try {
+    const rawBody = await readRawBody(req);
+    const event = verifyResendWebhook(rawBody, req.headers, webhookSecret);
+    const svixId = req.headers["svix-id"] || req.headers["Svix-Id"] || "";
+    const result = await handleResendEvent(event, { svixId: String(svixId) });
+    corsHeaders(res);
+    return res.status(200).json(result);
+  } catch (err) {
+    const status = err.status || 400;
+    console.error("resend webhook error:", err.message);
+    corsHeaders(res);
+    return res.status(status).json({ detail: err.message || "Webhook error" });
+  }
+};

--- a/scripts/check-api-host-routes.js
+++ b/scripts/check-api-host-routes.js
@@ -28,6 +28,7 @@ const EXTRA_PROTECTED = [
   "/api/usage",
   "/api/billing",
   "/api/billing/webhook",
+  "/api/resend/webhook",
   "/api/me",
   "/me",
   "/api/stats",

--- a/vercel.json
+++ b/vercel.json
@@ -1257,6 +1257,10 @@
       "destination": "/api/billing-webhook"
     },
     {
+      "source": "/api/resend/webhook",
+      "destination": "/api/resend-webhook"
+    },
+    {
       "source": "/api/auth-status",
       "destination": "/api/account?op=auth-status"
     },


### PR DESCRIPTION
## Summary
- New endpoint: `https://www.supercompress.dev/api/resend/webhook`
- Verifies Resend/Svix signatures (`RESEND_WEBHOOK_SECRET`)
- On `email.received`: fetch body via Receiving API, persist to `inbound_mail/{id}` (idempotent), notify `RESEND_INBOUND_NOTIFY_TO` / `WELCOME_REPLY_TO`
- Loop-safe (`[SC inbound]` subjects + self-notify skip)
- Unit tests + api-host route protection

## Setup (after merge/deploy)
1. Vercel env: `RESEND_WEBHOOK_SECRET=whsec_…` (from Resend webhook create)
2. Optional: `RESEND_INBOUND_NOTIFY_TO=you@…`
3. Resend → Webhooks → Add:
   - URL: `https://www.supercompress.dev/api/resend/webhook`
   - Event: `email.received`

## Test plan
- [x] `node api/_lib/resend-webhook.test.js`
- [x] `node scripts/check-api-host-routes.js`
- [ ] After deploy: send mail to receiving address → notify arrives; duplicate webhook does not re-notify


Made with [Cursor](https://cursor.com)