### PR TITLE
fix: credit top-ups when Firestore is down

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -610,9 +610,98 @@ async function applyUsageAndBurn({
 }
 
 /**
+ * When Cloud Firestore is disabled/unavailable, credit via Auth claims only.
+ * Idempotent on sc_credited_sessions / credited_keys. First-pay bonus uses
+ * sc_first_pay_bonus_at (weaker than Firestore billing_bonus, but keeps Checkout
+ * from silently charging without balance when Firestore is down).
+ */
+async function creditBalanceClaimsFallback({
+  uid,
+  creditUsd,
+  creditKey,
+  claims = {},
+  patch = {},
+  firstPayBonusUsd = 0,
+}) {
+  const key = String(creditKey);
+  const fresh = await admin().auth().getUser(uid);
+  const liveClaims = { ...(fresh.customClaims || {}), ...claims };
+  const credited = Array.isArray(liveClaims.sc_credited_sessions)
+    ? liveClaims.sc_credited_sessions
+    : [];
+  const ledger = normalizeLedger(null, liveClaims);
+  const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
+
+  if (credited.includes(key) || keys.includes(key)) {
+    return {
+      applied: true,
+      already: true,
+      ledger,
+      balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+      credit_usd: 0,
+      bonus_usd: 0,
+      backend: "claims-fallback",
+    };
+  }
+
+  const paymentUsd = Number(creditUsd) || 0;
+  const wantBonus = Math.max(0, Number(firstPayBonusUsd) || 0);
+  const bonusUsd = wantBonus > 0 && !liveClaims.sc_first_pay_bonus_at ? wantBonus : 0;
+  const add = usdToMicros(paymentUsd + bonusUsd);
+  ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
+  if (patch.credit_limit_usd != null) {
+    ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
+  }
+  if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
+  if (patch.customer_id) ledger.customer_id = patch.customer_id;
+  ledger.credited_keys = [...keys.filter((k) => k !== key).slice(-39), key];
+  ledger.updated_at = new Date().toISOString();
+
+  const nextCredited = [...credited.filter((k) => k !== key).slice(-39), key];
+  const bonusPatch =
+    bonusUsd > 0
+      ? {
+          sc_first_pay_bonus_at: new Date().toISOString(),
+          sc_first_pay_bonus_usd: bonusUsd,
+        }
+      : {};
+
+  await admin().auth().setCustomUserClaims(uid, {
+    ...liveClaims,
+    sc_plan: liveClaims.sc_plan || "payg",
+    sc_metered: false,
+    sc_usage: {
+      month: ledger.month,
+      requests: ledger.requests,
+      tokens_in: ledger.tokens_in,
+      tokens_out: ledger.tokens_out,
+      tokens_saved: ledger.tokens_saved,
+      tokens_reported: ledger.tokens_reported || 0,
+    },
+    sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+    sc_credit_limit_usd: ledger.credit_limit_usd,
+    sc_auto_recharge: Boolean(ledger.auto_recharge),
+    sc_credited_sessions: nextCredited,
+    ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
+    ...bonusPatch,
+  });
+
+  return {
+    applied: true,
+    already: false,
+    ledger,
+    balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+    credit_usd: paymentUsd,
+    bonus_usd: bonusUsd,
+    backend: "claims-fallback",
+  };
+}
+
+/**
  * Credit prepaid balance. Idempotent via permanent billing_credits/{creditKey}.
  * Optional first-pay bonus is create-once via billing_bonus/{uid}:first_pay
  * (not Auth claims — avoids concurrent Checkout double-bonus races).
+ * Falls back to Auth claims when Cloud Firestore is disabled/unavailable.
  *
  * @param {number} [firstPayBonusUsd=0] candidate bonus; txn grants at most once ever
  */
@@ -632,73 +721,90 @@ async function creditBalance({
   const bonusRef = db().collection("billing_bonus").doc(`${uid}:first_pay`);
   const wantBonus = Math.max(0, Number(firstPayBonusUsd) || 0);
 
-  const result = await db().runTransaction(async (tx) => {
-    const creditSnap = await tx.get(creditRef);
-    const bonusSnap = wantBonus > 0 ? await tx.get(bonusRef) : null;
-    const snap = await tx.get(ref);
-    const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
+  let result;
+  try {
+    result = await db().runTransaction(async (tx) => {
+      const creditSnap = await tx.get(creditRef);
+      const bonusSnap = wantBonus > 0 ? await tx.get(bonusRef) : null;
+      const snap = await tx.get(ref);
+      const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
 
-    if (creditSnap.exists) {
-      const prevCredit = creditSnap.data() || {};
-      return {
-        applied: true,
-        already: true,
-        ledger,
-        balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-        credit_usd: Number(prevCredit.credit_usd || 0),
-        bonus_usd: Number(prevCredit.bonus_usd || 0),
-      };
-    }
+      if (creditSnap.exists) {
+        const prevCredit = creditSnap.data() || {};
+        return {
+          applied: true,
+          already: true,
+          ledger,
+          balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+          credit_usd: Number(prevCredit.credit_usd || 0),
+          bonus_usd: Number(prevCredit.bonus_usd || 0),
+        };
+      }
 
-    let bonusUsd = 0;
-    if (wantBonus > 0 && bonusSnap && !bonusSnap.exists) {
-      bonusUsd = wantBonus;
+      let bonusUsd = 0;
+      if (wantBonus > 0 && bonusSnap && !bonusSnap.exists) {
+        bonusUsd = wantBonus;
+        tx.set(
+          bonusRef,
+          {
+            uid,
+            kind: "first_pay",
+            credit_usd: bonusUsd,
+            credit_key: String(creditKey),
+            created_at: new Date().toISOString(),
+          },
+          { merge: false }
+        );
+      }
+
+      const paymentUsd = Number(creditUsd) || 0;
+      const totalUsd = paymentUsd + bonusUsd;
+      const add = usdToMicros(totalUsd);
+      ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
+      if (patch.credit_limit_usd != null) {
+        ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
+      }
+      if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
+      if (patch.customer_id) ledger.customer_id = patch.customer_id;
+      const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
+      ledger.credited_keys = [...keys.filter((k) => k !== creditKey).slice(-39), creditKey];
+      ledger.updated_at = new Date().toISOString();
+
       tx.set(
-        bonusRef,
+        creditRef,
         {
           uid,
-          kind: "first_pay",
-          credit_usd: bonusUsd,
-          credit_key: String(creditKey),
+          credit_usd: paymentUsd,
+          bonus_usd: bonusUsd,
           created_at: new Date().toISOString(),
         },
         { merge: false }
       );
-    }
-
-    const paymentUsd = Number(creditUsd) || 0;
-    const totalUsd = paymentUsd + bonusUsd;
-    const add = usdToMicros(totalUsd);
-    ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
-    if (patch.credit_limit_usd != null) {
-      ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
-    }
-    if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
-    if (patch.customer_id) ledger.customer_id = patch.customer_id;
-    const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
-    ledger.credited_keys = [...keys.filter((k) => k !== creditKey).slice(-39), creditKey];
-    ledger.updated_at = new Date().toISOString();
-
-    tx.set(
-      creditRef,
-      {
-        uid,
+      tx.set(ref, ledger, { merge: true });
+      return {
+        applied: true,
+        already: false,
+        ledger,
+        balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
         credit_usd: paymentUsd,
         bonus_usd: bonusUsd,
-        created_at: new Date().toISOString(),
-      },
-      { merge: false }
+      };
+    });
+  } catch (err) {
+    console.warn(
+      "billing-ledger: credit txn failed — claims credit fallback:",
+      err?.code,
+      err?.message || err
     );
-    tx.set(ref, ledger, { merge: true });
-    return {
-      applied: true,
-      already: false,
-      ledger,
-      balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-      credit_usd: paymentUsd,
-      bonus_usd: bonusUsd,
-    };
-  });
+    return creditBalanceClaimsFallback({
+      uid,
+      creditUsd,
+      creditKey,
+      claims,
+      patch,
+      firstPayBonusUsd,
+    });
+  }
 
   // Patch payg flags only when this credit actually applied (not on replay).
   if (result.applied && !result.already) {

--- a/api/_lib/credit-topup.js
+++ b/api/_lib/credit-topup.js
@@ -258,11 +258,91 @@ async function reconcileCreditCheckout({ userId, sessionId }) {
   };
 }
 
+/**
+ * Self-heal: find recent paid credit Checkout sessions for this user that never
+ * landed in sc_credited_sessions, and apply them. Covers webhook drops + Firestore
+ * outages without requiring the customer to paste a session_id.
+ *
+ * Bounded lookback (default 14 sessions / ~30d of Stripe list pages) so billing GET
+ * stays cheap.
+ */
+async function reconcileOutstandingCreditCheckouts({
+  userId,
+  customerId = null,
+  claims = null,
+  limit = 14,
+} = {}) {
+  if (!userId || !initFirebaseAdmin()) {
+    return { ok: false, applied: 0, credited_usd: 0, detail: "unavailable" };
+  }
+  const stripe = getStripe();
+  let custId = customerId;
+  if (!custId) {
+    const matches = await stripe.customers.search({
+      query: `metadata['user_id']:'${String(userId).replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`,
+      limit: 1,
+    });
+    custId = matches.data[0]?.id || null;
+  }
+  if (!custId) {
+    return { ok: true, applied: 0, credited_usd: 0, sessions: [] };
+  }
+
+  const fresh = await admin.auth().getUser(userId);
+  const liveClaims = claims || fresh.customClaims || {};
+  const already = new Set(
+    Array.isArray(liveClaims.sc_credited_sessions) ? liveClaims.sc_credited_sessions : []
+  );
+
+  const sessions = await stripe.checkout.sessions.list({
+    customer: custId,
+    limit: Math.max(1, Math.min(25, Number(limit) || 14)),
+  });
+
+  let applied = 0;
+  let creditedUsd = 0;
+  const results = [];
+  for (const session of sessions.data) {
+    const kind = session.metadata?.kind || "";
+    if (!kind.startsWith("credit_")) continue;
+    if (session.payment_status !== "paid" && session.status !== "complete") continue;
+    if (session.metadata?.user_id && session.metadata.user_id !== userId) continue;
+    if (already.has(session.id)) continue;
+    try {
+      const result = await applyCreditTopUp(session);
+      if (result.applied && !result.already) {
+        applied += 1;
+        creditedUsd = roundUsd(creditedUsd + Number(result.creditUsd || 0) + Number(result.firstPayBonusUsd || 0));
+      }
+      already.add(session.id);
+      results.push({
+        id: session.id,
+        applied: Boolean(result.applied),
+        already: Boolean(result.already),
+        creditUsd: result.creditUsd || 0,
+      });
+    } catch (err) {
+      console.error("outstanding credit reconcile failed:", session.id, err?.message || err);
+      results.push({ id: session.id, error: err?.message || String(err) });
+    }
+  }
+
+  const after = await admin.auth().getUser(userId);
+  return {
+    ok: true,
+    applied,
+    credited_usd: creditedUsd,
+    credit_balance_usd: roundUsd(Number(after.customClaims?.sc_credit_balance_usd || 0)),
+    sessions: results,
+  };
+}
+
 module.exports = {
   applyCreditTopUp,
   persistSubscription,
   updateBillingClaims,
   reconcileCreditCheckout,
+  reconcileOutstandingCreditCheckouts,
   FIRST_PAY_BONUS_TOKENS,
   FIRST_PAY_BONUS_USD,
 };

--- a/api/billing-webhook.js
+++ b/api/billing-webhook.js
@@ -159,6 +159,11 @@ module.exports = async (req, res) => {
   } catch (err) {
     console.error("Webhook error:", err);
     corsHeaders(res);
-    return res.status(400).json({ detail: `Webhook Error: ${err.message}` });
+    // Signature / parse failures → 400 (no retry useful). Processing failures → 500 so Stripe retries.
+    const msg = String(err?.message || err || "");
+    const isSig =
+      /signature|No signatures found|Invalid signature|payload/i.test(msg) ||
+      err?.type === "StripeSignatureVerificationError";
+    return res.status(isSig ? 400 : 500).json({ detail: `Webhook Error: ${msg}` });
   }
 };

--- a/api/billing.js
+++ b/api/billing.js
@@ -33,7 +33,10 @@ const {
   createCreditTopUpCheckout,
   roundUsd,
 } = require("./_lib/stripe");
-const { reconcileCreditCheckout } = require("./_lib/credit-topup");
+const {
+  reconcileCreditCheckout,
+  reconcileOutstandingCreditCheckouts,
+} = require("./_lib/credit-topup");
 const { loadStore, mutateStore } = require("./_lib/store");
 
 const BASE_URL = "https://www.supercompress.dev";
@@ -121,8 +124,33 @@ async function patchCreditClaims(userId, patch) {
 async function handleGet(req, res, user) {
   const store = await loadStoreOrEmpty();
   initFirebaseAdmin();
-  const owner = await admin.auth().getUser(user.uid).catch(() => ({ uid: user.uid, customClaims: {} }));
-  const claims = owner.customClaims || {};
+  let owner = await admin.auth().getUser(user.uid).catch(() => ({ uid: user.uid, customClaims: {} }));
+  let claims = owner.customClaims || {};
+
+  // Self-heal paid Checkout that never credited (webhook / Firestore outage).
+  // Only when wallet looks empty — happy-path GET stays cheap; success-page
+  // reconcile + webhook cover top-ups while balance > 0.
+  const looksEmpty =
+    claims.sc_credit_balance_usd == null || Number(claims.sc_credit_balance_usd) <= 0;
+  if (looksEmpty) {
+    try {
+      const healed = await reconcileOutstandingCreditCheckouts({
+        userId: user.uid,
+        customerId: claims.sc_customer_id || null,
+        claims,
+        limit: 14,
+      });
+      if (healed.applied > 0) {
+        owner = await admin.auth().getUser(user.uid);
+        claims = owner.customClaims || {};
+        console.log(
+          `billing GET healed ${healed.applied} credit session(s) for ${user.uid}; balance=$${healed.credit_balance_usd}`
+        );
+      }
+    } catch (err) {
+      console.warn("outstanding credit reconcile skipped:", err.message || err);
+    }
+  }
 
   let sub = store.subscriptions?.[user.uid];
   if (!sub) {

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -1352,18 +1352,33 @@ function initBilling() {
       });
     };
     if (sessionId.startsWith("cs_")) {
-      apiFetch("/api/billing", {
-        method: "POST",
-        body: JSON.stringify({ action: "reconcile_checkout", session_id: sessionId }),
-      })
-        .then((data) => {
-          celebrate(data || {});
-          return loadSubscription();
-        })
-        .catch((err) => {
-          console.warn("Checkout reconcile:", err?.message || err);
-          showPaySuccessCelebration({});
+      const reconcileOnce = () =>
+        apiFetch("/api/billing", {
+          method: "POST",
+          body: JSON.stringify({ action: "reconcile_checkout", session_id: sessionId }),
         });
+      // Retry a few times — covers brief Auth/claims races after Checkout return.
+      (async () => {
+        let last = null;
+        for (let i = 0; i < 4; i++) {
+          try {
+            last = await reconcileOnce();
+            if (last && (last.credited_usd > 0 || last.already || last.credit_balance_usd > 0)) {
+              break;
+            }
+          } catch (err) {
+            last = { error: err };
+            console.warn("Checkout reconcile attempt", i + 1, err?.message || err);
+          }
+          await new Promise((r) => setTimeout(r, 400 * (i + 1)));
+        }
+        if (last && !last.error) {
+          celebrate(last);
+        } else {
+          showPaySuccessCelebration({});
+        }
+        await loadSubscription();
+      })();
     } else {
       showPaySuccessCelebration({});
       setTimeout(() => loadSubscription(), 800);


### PR DESCRIPTION
## Summary
- Paid Stripe Checkout for prepaid credits was succeeding while `creditBalance` failed hard when Cloud Firestore is disabled — wallets stayed at $0 until manual reconcile (seen today for `josonpreet@gmail.com`, two $10 payments).
- Adds an Auth-claims fallback for credit top-ups (same pattern as usage-burn fallback from #76), idempotent on `sc_credited_sessions` / credited keys.
- Customer already reconciled manually to ~$30; this prevents the next silent miss.

## Test plan
- [x] `node api/_lib/billing-ledger.test.js`
- [ ] Merge + deploy prod
- [ ] Optional: enable Cloud Firestore API on GCP project `supercompress` so ledger is durable again
- [ ] Spot-check a $10 top-up still credits without manual reconcile


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prepaid credits can now be applied when the primary billing service is temporarily unavailable.
  * Credit operations avoid duplicate application during fallback processing.
  * Eligible first-time payment bonuses continue to be applied during fallback processing.
  * Billing updates now return additional processing status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->