### PR TITLE
fix: billing credit integrity + public abuse hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
           node --check packages/proxy/src/server.js
       - name: Billing ledger unit tests
         run: node api/_lib/billing-ledger.test.js
+      - name: Credit amount helpers
+        run: node api/_lib/credit-amount.test.js
       - name: Coding agent monthly usage unit tests
         run: node api/_lib/coding-agent-usage.test.js
       - name: Soft-probe unit tests

--- a/api/_lib/credit-amount.js
+++ b/api/_lib/credit-amount.js
@@ -1,0 +1,48 @@
+/**
+ * Paid credit math — never trust Checkout metadata for dollars credited.
+ * Metadata is attacker/operator-editable relative to what Stripe actually charged;
+ * amount_total / PaymentIntent.amount is the source of truth.
+ */
+const { roundUsd, MIN_CREDIT_LIMIT_USD, MAX_CREDIT_LIMIT_USD } = require("./stripe");
+
+/**
+ * USD actually charged on a Checkout session or synthetic PI session.
+ * @returns {number|null} null when amount unknown
+ */
+function paidCreditUsdFromSession(session) {
+  if (!session || typeof session !== "object") return null;
+  if (session.amount_total != null && Number.isFinite(Number(session.amount_total))) {
+    return roundUsd(Number(session.amount_total) / 100);
+  }
+  if (session.amount != null && Number.isFinite(Number(session.amount))) {
+    return roundUsd(Number(session.amount) / 100);
+  }
+  return null;
+}
+
+/**
+ * Whether a paid amount is eligible to grant prepaid wallet credit.
+ * $0 (100% promo) and unknown amounts must not mint free credits.
+ */
+function isCreditablePaidUsd(usd) {
+  if (usd == null || !Number.isFinite(Number(usd))) return false;
+  const n = Number(usd);
+  return n > 0 && n <= MAX_CREDIT_LIMIT_USD * 2;
+}
+
+/**
+ * Auto-recharge / checkout pack size only — clamps to product min/max.
+ * Do NOT use for applying credits after payment.
+ */
+function clampPackUsd(raw, fallback = MIN_CREDIT_LIMIT_USD) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  const rounded = Math.round(n * 100) / 100;
+  return Math.min(MAX_CREDIT_LIMIT_USD, Math.max(MIN_CREDIT_LIMIT_USD, rounded));
+}
+
+module.exports = {
+  paidCreditUsdFromSession,
+  isCreditablePaidUsd,
+  clampPackUsd,
+};

--- a/api/_lib/credit-amount.test.js
+++ b/api/_lib/credit-amount.test.js
@@ -1,0 +1,34 @@
+/**
+ * Unit tests for paid-credit amount helpers.
+ * Run: node api/_lib/credit-amount.test.js
+ */
+const assert = require("assert");
+const {
+  paidCreditUsdFromSession,
+  isCreditablePaidUsd,
+  clampPackUsd,
+} = require("./credit-amount");
+
+assert.strictEqual(paidCreditUsdFromSession({ amount_total: 1000 }), 10);
+assert.strictEqual(paidCreditUsdFromSession({ amount_total: 0 }), 0);
+assert.strictEqual(paidCreditUsdFromSession({ amount: 1500 }), 15);
+assert.strictEqual(paidCreditUsdFromSession({}), null);
+assert.strictEqual(
+  paidCreditUsdFromSession({
+    amount_total: 1000,
+    metadata: { credit_usd: "1000" },
+  }),
+  10,
+  "must ignore metadata.credit_usd even if inflated"
+);
+
+assert.strictEqual(isCreditablePaidUsd(10), true);
+assert.strictEqual(isCreditablePaidUsd(0), false, "promo $0 must not credit");
+assert.strictEqual(isCreditablePaidUsd(-1), false);
+assert.strictEqual(isCreditablePaidUsd(null), false);
+
+assert.strictEqual(clampPackUsd(0), 10, "pack size still min $10");
+assert.strictEqual(clampPackUsd(5), 10);
+assert.strictEqual(clampPackUsd(25), 25);
+
+console.log("credit-amount.test.js: ok");

--- a/api/_lib/credit-topup.js
+++ b/api/_lib/credit-topup.js
@@ -10,6 +10,10 @@ const {
   tokensToUsd,
   TOKENS_PER_BILLING_UNIT,
 } = require("./stripe");
+const {
+  paidCreditUsdFromSession,
+  isCreditablePaidUsd,
+} = require("./credit-amount");
 const { mutateStore } = require("./store");
 const { initFirebaseAdmin } = require("./auth");
 const admin = require("firebase-admin");
@@ -17,6 +21,50 @@ const admin = require("firebase-admin");
 /** Thank-you grant on first successful credit top-up (1M tokens @ current PAYG rate). */
 const FIRST_PAY_BONUS_TOKENS = TOKENS_PER_BILLING_UNIT;
 const FIRST_PAY_BONUS_USD = tokensToUsd(FIRST_PAY_BONUS_TOKENS);
+
+function stripeAlreadyCredited(session) {
+  const meta = session?.metadata || {};
+  return meta.sc_credited === "true" || meta.sc_credited === true;
+}
+
+/**
+ * Durable idempotency beyond the sliding sc_credited_sessions window:
+ * stamp the Checkout session / PaymentIntent so reconcile cannot re-mint credits
+ * after old session ids age out of Auth claims.
+ */
+async function markStripeCredited(session) {
+  if (!session?.id || stripeAlreadyCredited(session)) return;
+  try {
+    const stripe = getStripe();
+    const stamp = {
+      sc_credited: "true",
+      sc_credited_at: new Date().toISOString().slice(0, 19) + "Z",
+    };
+    const id = String(session.id);
+    if (id.startsWith("cs_")) {
+      await stripe.checkout.sessions.update(id, {
+        metadata: { ...(session.metadata || {}), ...stamp },
+      });
+      return;
+    }
+    // Synthetic PI sessions use id `pi_<PaymentIntentId>` or bare PI id.
+    const piId = id.startsWith("pi_pi_")
+      ? id.slice(3)
+      : id.startsWith("pi_")
+        ? id
+        : session.payment_intent
+          ? String(session.payment_intent)
+          : null;
+    if (piId) {
+      const pi = await stripe.paymentIntents.retrieve(piId);
+      await stripe.paymentIntents.update(piId, {
+        metadata: { ...(pi.metadata || {}), ...stamp },
+      });
+    }
+  } catch (err) {
+    console.warn("Could not stamp Stripe sc_credited:", err.message || err);
+  }
+}
 
 async function updateBillingClaims(userId, data) {
   if (!userId || !initFirebaseAdmin()) return;
@@ -86,8 +134,35 @@ async function applyCreditTopUp(session) {
   if (!userId || !kind.startsWith("credit_")) {
     return { applied: false, reason: "not_credit_session" };
   }
+  // Require an explicit paid signal when present. Synthetic PI sessions set payment_status.
   if (session.payment_status && session.payment_status !== "paid") {
     return { applied: false, reason: "not_paid" };
+  }
+  // Never credit "complete but unpaid" async Checkout (e.g. bank debits still pending).
+  if (session.status === "complete" && session.payment_status && session.payment_status !== "paid") {
+    return { applied: false, reason: "not_paid" };
+  }
+
+  if (stripeAlreadyCredited(session)) {
+    if (!initFirebaseAdmin()) {
+      return { applied: true, already: true, balance: 0, creditUsd: 0 };
+    }
+    const u = await admin.auth().getUser(userId);
+    const prev = u.customClaims || {};
+    return {
+      applied: true,
+      already: true,
+      balance: roundUsd(Number(prev.sc_credit_balance_usd || 0)),
+      creditUsd: 0,
+      firstPayBonusUsd: 0,
+      firstPayBonusTokens: 0,
+    };
+  }
+
+  // Dollars credited = what Stripe charged, never metadata.credit_usd (promo / mismatch / spoof).
+  const creditUsd = paidCreditUsdFromSession(session);
+  if (!isCreditablePaidUsd(creditUsd)) {
+    return { applied: false, reason: "invalid_paid_amount", creditUsd };
   }
 
   if (!initFirebaseAdmin()) return { applied: false, reason: "firebase_unavailable" };
@@ -98,6 +173,7 @@ async function applyCreditTopUp(session) {
     : [];
   if (credited.includes(session.id)) {
     console.log("Credit top-up already applied:", session.id);
+    await markStripeCredited(session);
     const alreadyBonus = prev.sc_first_pay_bonus_at
       ? Number(prev.sc_first_pay_bonus_usd || FIRST_PAY_BONUS_USD)
       : 0;
@@ -111,10 +187,6 @@ async function applyCreditTopUp(session) {
     };
   }
 
-  const creditUsd = normalizeCreditLimitUsd(
-    session.metadata?.credit_usd || (session.amount_total != null ? session.amount_total / 100 : null),
-    DEFAULT_CREDIT_LIMIT_USD
-  );
   const autoRecharge =
     session.metadata?.auto_recharge === "true"
       ? true
@@ -127,6 +199,17 @@ async function applyCreditTopUp(session) {
     const stripe = getStripe();
     if (session.payment_intent) {
       const pi = await stripe.paymentIntents.retrieve(String(session.payment_intent));
+      if (pi.metadata?.sc_credited === "true") {
+        await markStripeCredited(session);
+        return {
+          applied: true,
+          already: true,
+          balance: roundUsd(Number(prev.sc_credit_balance_usd || 0)),
+          creditUsd: 0,
+          firstPayBonusUsd: 0,
+          firstPayBonusTokens: 0,
+        };
+      }
       paymentMethod = pi.payment_method || paymentMethod;
       if (paymentMethod && session.customer) {
         await stripe.customers.update(session.customer, {
@@ -139,9 +222,10 @@ async function applyCreditTopUp(session) {
   }
 
   const grantFirstPayBonusUsd = FIRST_PAY_BONUS_USD;
+  // Recharge threshold stays a pack size (min $10), independent of this payment's amount.
   const limitUsd = normalizeCreditLimitUsd(
-    session.metadata?.credit_usd || prev.sc_credit_limit_usd,
-    creditUsd
+    prev.sc_credit_limit_usd || session.metadata?.credit_usd,
+    Math.max(DEFAULT_CREDIT_LIMIT_USD, creditUsd)
   );
 
   // Ledger first (idempotent by session.id). First-pay bonus is create-once in txn.
@@ -161,6 +245,7 @@ async function applyCreditTopUp(session) {
 
   if (ledgerResult.already) {
     console.log("Credit top-up already applied (ledger):", session.id);
+    await markStripeCredited(session);
     return {
       applied: true,
       already: true,
@@ -207,6 +292,7 @@ async function applyCreditTopUp(session) {
   }
 
   await persistSubscription(userId, persistPayload);
+  await markStripeCredited(session);
 
   console.log(
     `Credited $${creditUsd}${bonusUsd ? ` + $${bonusUsd} first-pay bonus` : ""} to ${userId}; balance=$${newBalance}`
@@ -305,8 +391,13 @@ async function reconcileOutstandingCreditCheckouts({
   for (const session of sessions.data) {
     const kind = session.metadata?.kind || "";
     if (!kind.startsWith("credit_")) continue;
-    if (session.payment_status !== "paid" && session.status !== "complete") continue;
+    // Strict: only settle money that Stripe confirms paid (not async-pending "complete").
+    if (session.payment_status !== "paid") continue;
     if (session.metadata?.user_id && session.metadata.user_id !== userId) continue;
+    if (session.metadata?.sc_credited === "true") {
+      already.add(session.id);
+      continue;
+    }
     if (already.has(session.id)) continue;
     try {
       const result = await applyCreditTopUp(session);
@@ -320,6 +411,7 @@ async function reconcileOutstandingCreditCheckouts({
         applied: Boolean(result.applied),
         already: Boolean(result.already),
         creditUsd: result.creditUsd || 0,
+        reason: result.reason,
       });
     } catch (err) {
       console.error("outstanding credit reconcile failed:", session.id, err?.message || err);

--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -52,6 +52,7 @@ function emptyStore() {
     subscriptions: {},
     affiliates: {},
     affiliate_tracking: {},
+    affiliate_daily: {},
     affiliate_conversions: {},
     connections: {},
     coding_agent_usage: {},
@@ -79,6 +80,7 @@ function normalizeStore(raw) {
     subscriptions: raw.subscriptions && typeof raw.subscriptions === "object" ? raw.subscriptions : {},
     affiliates: raw.affiliates && typeof raw.affiliates === "object" ? raw.affiliates : {},
     affiliate_tracking: raw.affiliate_tracking && typeof raw.affiliate_tracking === "object" ? raw.affiliate_tracking : {},
+    affiliate_daily: raw.affiliate_daily && typeof raw.affiliate_daily === "object" ? raw.affiliate_daily : {},
     affiliate_conversions: raw.affiliate_conversions && typeof raw.affiliate_conversions === "object" ? raw.affiliate_conversions : {},
     connections: raw.connections && typeof raw.connections === "object" ? raw.connections : {},
     coding_agent_usage: raw.coding_agent_usage && typeof raw.coding_agent_usage === "object" ? raw.coding_agent_usage : {},
@@ -351,7 +353,7 @@ async function mutateStore(mutator) {
 
   for (let attempt = 0; attempt < 5; attempt++) {
     try {
-      return await db().runTransaction(async (tx) => {
+      const committed = await db().runTransaction(async (tx) => {
         const snap = await tx.get(docRef);
         const store = snap.exists ? normalizeStore(snap.data()) : emptyStore();
 
@@ -364,16 +366,18 @@ async function mutateStore(mutator) {
 
         tx.set(docRef, store);
 
-        // Update in-memory cache
-        writeCache = cloneStore(store);
-
-        return result;
+        // Return snapshot only after txn body finishes; writeCache updates
+        // AFTER runTransaction resolves so failed txns cannot poison warm lambdas.
+        return { result, snapshot: cloneStore(store) };
       });
+      writeCache = committed.snapshot;
+      return committed.result;
     } catch (err) {
+      // Always drop cache on failure — never keep a speculative store.
+      invalidateCache();
       // Firestore throws code 10 (ABORTED) when a transaction conflicts.
       // Retry with exponential backoff.
       if (attempt < 4 && err.code === 10) {
-        invalidateCache();
         await new Promise((r) => setTimeout(r, 80 + attempt * 60));
         continue;
       }
@@ -848,6 +852,39 @@ function repairMisattributedCodingAgents(agents) {
   if (!looksLikeCursorTool) return { agents: next, changed: false };
 
   const cursor = next.cursor && typeof next.cursor === "object" ? next.cursor : null;
+  const mergedMonths = {};
+  for (const srcMonths of [cursor?.months, bad.months]) {
+    if (!srcMonths || typeof srcMonths !== "object") continue;
+    for (const [month, snap] of Object.entries(srcMonths)) {
+      if (!snap || typeof snap !== "object") continue;
+      const prev = mergedMonths[month] || {};
+      mergedMonths[month] = {
+        requests: (prev.requests || 0) + (snap.requests || 0),
+        tokens_in: (prev.tokens_in || 0) + (snap.tokens_in || 0),
+        tokens_out: (prev.tokens_out || 0) + (snap.tokens_out || 0),
+        tokens_saved: (prev.tokens_saved || 0) + (snap.tokens_saved || 0),
+        first_seen:
+          [prev.first_seen, snap.first_seen].filter(Boolean).sort()[0] || snap.first_seen || null,
+        last_seen:
+          [prev.last_seen, snap.last_seen].filter(Boolean).sort().slice(-1)[0] ||
+          snap.last_seen ||
+          null,
+        last_pct: snap.last_pct != null ? snap.last_pct : prev.last_pct ?? null,
+        last_query: snap.last_query || prev.last_query || null,
+        last_source: snap.last_source || prev.last_source || null,
+        latency_sum_ms: (prev.latency_sum_ms || 0) + (snap.latency_sum_ms || 0),
+        latency_samples: (prev.latency_samples || 0) + (snap.latency_samples || 0),
+        last_latency_ms:
+          snap.last_latency_ms != null ? snap.last_latency_ms : prev.last_latency_ms ?? null,
+      };
+      if (mergedMonths[month].latency_samples > 0) {
+        mergedMonths[month].avg_latency_ms = Math.round(
+          mergedMonths[month].latency_sum_ms / mergedMonths[month].latency_samples
+        );
+      }
+    }
+  }
+
   const merged = {
     requests: (cursor?.requests || 0) + (bad.requests || 0),
     tokens_in: (cursor?.tokens_in || 0) + (bad.tokens_in || 0),
@@ -862,6 +899,7 @@ function repairMisattributedCodingAgents(agents) {
     latency_samples: (cursor?.latency_samples || 0) + (bad.latency_samples || 0),
     last_latency_ms: bad.last_latency_ms != null ? bad.last_latency_ms : cursor?.last_latency_ms ?? null,
   };
+  if (Object.keys(mergedMonths).length) merged.months = mergedMonths;
   if (merged.latency_samples > 0) {
     merged.avg_latency_ms = Math.round(merged.latency_sum_ms / merged.latency_samples);
   } else if (cursor?.avg_latency_ms != null || bad.avg_latency_ms != null) {

--- a/api/_lib/stripe.js
+++ b/api/_lib/stripe.js
@@ -295,7 +295,7 @@ async function createCreditTopUpCheckout({
         credit_usd: String(amount),
       },
     },
-    allow_promotion_codes: true,
+    allow_promotion_codes: false,
     billing_address_collection: "auto",
   });
 
@@ -372,9 +372,14 @@ async function attemptAutoRecharge(owner) {
       return { ok: false, error: `payment_${pi.status}`, paymentIntentId: pi.id };
     }
 
+    const paidUsd = roundUsd(Number(pi.amount || 0) / 100);
+    if (paidUsd <= 0) {
+      return { ok: false, error: "invalid_paid_amount", paymentIntentId: pi.id };
+    }
+
     const credited = await creditBalance({
       uid: owner.uid,
-      creditUsd: amount,
+      creditUsd: paidUsd,
       creditKey: `pi_${pi.id}`,
       claims,
       patch: {
@@ -384,9 +389,17 @@ async function attemptAutoRecharge(owner) {
       },
     });
 
+    try {
+      await stripe.paymentIntents.update(pi.id, {
+        metadata: { ...(pi.metadata || {}), sc_credited: "true" },
+      });
+    } catch (err) {
+      console.warn("Could not stamp auto-recharge PI:", err.message || err);
+    }
+
     return {
       ok: true,
-      balanceAdd: credited.already ? 0 : amount,
+      balanceAdd: credited.already ? 0 : paidUsd,
       paymentIntentId: pi.id,
       balance: credited.balance,
     };

--- a/api/account.js
+++ b/api/account.js
@@ -1,4 +1,4 @@
-const { json, readBody, checkRateLimit, softProbe, hasAuthCredentials } = require("./_lib/http");
+const { json, readBody, checkRateLimit } = require("./_lib/http");
 const { verifyUser, bearerToken } = require("./_lib/auth");
 const { KEY_PREFIX } = require("./_lib/keys");
 const { createKey, revokeKey, listKeys, authenticateKey } = require("./_lib/firebase-key-store");
@@ -267,7 +267,7 @@ async function handleConnectDevice(req, res) {
     }
   }
 
-  if (req.method !== "POST") return softProbe(res, "Method not allowed", { allow: "POST" });
+  if (req.method !== "POST") return json(res, 405, { detail: "Method not allowed" });
 
   try {
     const user = await verifyUser(req);
@@ -311,7 +311,7 @@ async function handleConnectDevice(req, res) {
 }
 
 async function handleUsage(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed", { allow: "GET" });
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
 
   try {
     const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization) || (req.query && req.query.api_key);
@@ -399,9 +399,9 @@ async function handleUsage(req, res) {
       ...planUsage(owner, total_tokens_in),
     });
   } catch (err) {
-    // Unauthenticated scanner GETs — soft 200 so Observability error rate stays ~0.
-    if ((err.status || 401) === 401 && !hasAuthCredentials(req)) {
-      return softProbe(res, err.message || "Authorization required", { auth: "required" });
+    // Unauthenticated scanner GETs — soft 200 so Observability error rate stays honest.
+    if ((err.status || 401) === 401) {
+      return json(res, 200, { ok: false, auth: "required", detail: err.message || "Authorization required" });
     }
     return json(res, err.status || 500, { detail: err.message });
   }
@@ -424,7 +424,7 @@ async function resolveOwnerFromReq(req) {
 }
 
 async function handleMe(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed", { allow: "GET" });
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
   try {
     const { uid, owner, via, key_prefix } = await resolveOwnerFromReq(req);
     const { loadAgentPluginLink, loadCodingAgentUsage } = require("./_lib/store");
@@ -485,7 +485,7 @@ async function handleMe(req, res) {
 }
 
 async function handleCompressLog(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed", { allow: "GET" });
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
   try {
     const { uid } = await resolveOwnerFromReq(req);
     const limit = Number(req.query?.limit) || 40;
@@ -501,7 +501,7 @@ async function handleCompressLog(req, res) {
 }
 
 async function handleAuthStatus(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed", { allow: "GET" });
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
 
   const hasJson = Boolean(process.env.FIREBASE_SERVICE_ACCOUNT_JSON?.trim());
   const hasParts = Boolean(
@@ -727,19 +727,55 @@ module.exports = async (req, res) => {
     } catch {
       /* keep raw */
     }
-    const confirmOnly =
-      body.confirm === true ||
-      body.confirm === "1" ||
-      String(req.query?.confirm || "") === "1";
     try {
-      return json(res, 200, await unsubscribeEmail(email, token, { confirmOnly }));
+      // Authenticated account may unsubscribe their own verified email without the mail token.
+      let authedSelf = false;
+      try {
+        const user = await verifyUser(req);
+        if (user?.email && String(user.email).trim().toLowerCase() === email.toLowerCase()) {
+          authedSelf = true;
+        }
+      } catch (_) {
+        /* anonymous one-click from email */
+      }
+      if (authedSelf && !token) {
+        const { unsubToken } = require("./_lib/weekly");
+        token = unsubToken(email);
+      }
+      return json(res, 200, await unsubscribeEmail(email, token));
     } catch (err) {
+      // Broken / missing token → tell the client to request a fresh signed link (do not unsub).
+      if (err.status === 401 || err.code === "invalid_token") {
+        return json(res, 401, {
+          detail: err.message || "Invalid unsubscribe token",
+          code: "invalid_token",
+          hint: "Request a fresh signed link via weekly-unsub-link",
+        });
+      }
       return json(res, err.status || 500, { detail: err.message || "Unsubscribe failed" });
     }
   }
   if (op === "weekly-unsub-link" && req.method === "POST") {
     const body = readBody(req) || {};
     const email = String(body.email || "").trim();
+    const { checkRateLimit, clientIp, jsonWithRateLimit } = require("./_lib/http");
+    const { checkDurableRateLimit } = require("./_lib/rate-limit-durable");
+    const ip = clientIp(req);
+    const mem = checkRateLimit(`unsub-link:${ip}`, 5);
+    if (!mem.allowed) {
+      return jsonWithRateLimit(res, 429, { detail: "Too many requests. Try again later." }, mem);
+    }
+    const recipKey = `unsub-link-to:${String(email).trim().toLowerCase()}`;
+    const recipMem = checkRateLimit(recipKey, 2, 60 * 60_000);
+    if (!recipMem.allowed) {
+      return json(res, 429, { detail: "A link was already sent recently. Check your inbox." });
+    }
+    try {
+      const durable = await checkDurableRateLimit(`unsub-link:${ip}`, 10, 60 * 60_000);
+      if (durable.backend === "firestore" && !durable.allowed) {
+        return jsonWithRateLimit(res, 429, { detail: "Too many requests. Try again later." }, durable);
+      }
+    } catch (_) {}
     try {
       return json(res, 200, await sendUnsubscribeLink(email));
     } catch (err) {

--- a/api/affiliates.js
+++ b/api/affiliates.js
@@ -12,11 +12,15 @@
  */
 
 const crypto = require("crypto");
-const { json, readBody, softProbe } = require("./_lib/http");
+const { json, readBody, checkRateLimit, jsonWithRateLimit } = require("./_lib/http");
 const { loadStore, mutateStore } = require("./_lib/store");
 const { verifyUser } = require("./_lib/auth");
+const { checkDurableRateLimit } = require("./_lib/rate-limit-durable");
 
 const REF_BASE = "https://supercompress.dev";
+const TRACK_RPM = 30;
+const TRACK_FIELD_MAX = 300;
+const AFFILIATE_DAILY_RETENTION_DAYS = 120;
 const FOUNDER_EMAILS = new Set(
   String(process.env.FOUNDER_ADMIN_EMAILS || "arjunkshah21@gmail.com")
     .split(",")
@@ -70,19 +74,30 @@ function clientIp(req) {
   );
 }
 
-function computeAffiliateStats(affiliate, tracking, conversions) {
+function computeAffiliateStats(affiliate, tracking, conversions, daily = {}) {
   const slug = affiliate.referral_slug;
-  const visits = Object.values(tracking).filter((v) => v.ref === slug);
-  const uniqueIps = new Set(visits.map((v) => v.ip));
-  const claims = Object.values(conversions).filter((c) => c.ref === slug);
+  const legacyVisits = Object.values(tracking || {}).filter((v) => v.ref === slug);
+  const uniqueIps = new Set(legacyVisits.map((v) => v.ip).filter(Boolean));
+
+  let dailyVisits = 0;
+  let dailyUnique = 0;
+  for (const [key, rec] of Object.entries(daily || {})) {
+    if (!rec || typeof rec !== "object") continue;
+    if (rec.ref === slug || String(key).startsWith(`${slug}:`)) {
+      dailyVisits += Number(rec.visits || 0);
+      dailyUnique += Array.isArray(rec.ip_hashes) ? rec.ip_hashes.length : Number(rec.unique_ips || 0);
+    }
+  }
+
+  const claims = Object.values(conversions || {}).filter((c) => c.ref === slug);
   const pendingPayouts = claims.filter((c) => c.status === "pending");
   const confirmedPayouts = claims.filter((c) => c.status === "confirmed");
   const totalPendingCents = pendingPayouts.length * 800;
   const totalPaidCents = confirmedPayouts.length * 800;
 
   return {
-    total_visits: visits.length,
-    unique_visitors: uniqueIps.size,
+    total_visits: legacyVisits.length + dailyVisits,
+    unique_visitors: uniqueIps.size + dailyUnique,
     total_conversions: claims.length,
     pending_conversions: pendingPayouts.length,
     confirmed_conversions: confirmedPayouts.length,
@@ -95,6 +110,21 @@ function computeAffiliateStats(affiliate, tracking, conversions) {
       .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
       .slice(0, 10),
   };
+}
+
+function clipField(value, max = TRACK_FIELD_MAX) {
+  const s = String(value == null ? "" : value);
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+function pruneAffiliateDaily(daily, keepDays = AFFILIATE_DAILY_RETENTION_DAYS) {
+  if (!daily || typeof daily !== "object") return;
+  const cutoff = Date.now() - keepDays * 24 * 60 * 60 * 1000;
+  for (const [key, rec] of Object.entries(daily)) {
+    const day = String(rec?.day || key.split(":").slice(-1)[0] || "");
+    const ts = Date.parse(`${day}T00:00:00.000Z`);
+    if (Number.isFinite(ts) && ts < cutoff) delete daily[key];
+  }
 }
 
 /* ── Route handler ── */
@@ -148,7 +178,7 @@ module.exports = async (req, res) => {
     return handleList(req, res);
   }
 
-  return softProbe(res, "Method not allowed", { allow: "GET, POST" });
+  return json(res, 405, { detail: "Method not allowed" });
 };
 
 /* ── Public register (from affiliates.html) ── */
@@ -157,11 +187,10 @@ async function handlePublicRegister(req, res, body) {
   try {
     const { name, email, website, audience } = body;
     if (!name || !email) {
-      // Empty scanner POSTs — soft 200 (Observability error rate).
-      return softProbe(res, "Name and email are required.");
+      return json(res, 400, { detail: "Name and email are required." });
     }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      return softProbe(res, "Invalid email address.");
+      return json(res, 400, { detail: "Invalid email address." });
     }
 
     const cleanName = name.trim().slice(0, 120);
@@ -209,33 +238,66 @@ async function handlePublicRegister(req, res, body) {
   }
 }
 
-/* ── Track visit ── */
+/* ── Track visit ──
+ * Never write per-visit rows into config/store (DoS / size bomb).
+ * Only valid active affiliates get a bounded {slug, day} counter bump.
+ */
 
 async function handleTrack(req, res, body) {
   try {
-    const ref = (body.ref || "").trim().toLowerCase();
-    if (!ref || ref.length < 2 || ref.length > 60) {
+    const ip = clientIp(req);
+    const mem = checkRateLimit(`aff-track:${ip}`, TRACK_RPM);
+    if (!mem.allowed) {
+      return jsonWithRateLimit(res, 429, { tracked: false, detail: "rate_limited" }, mem);
+    }
+    try {
+      const durable = await checkDurableRateLimit(`aff-track:${ip}`, TRACK_RPM, 60_000);
+      if (durable.backend === "firestore" && !durable.allowed) {
+        return jsonWithRateLimit(res, 429, { tracked: false, detail: "rate_limited" }, durable);
+      }
+    } catch (_) {
+      /* memory limit already applied */
+    }
+
+    const ref = clipField((body.ref || "").trim().toLowerCase(), 60);
+    if (!ref || ref.length < 2) {
       return json(res, 200, { tracked: false });
     }
+
+    // Invalid / unknown slugs: acknowledge but do not touch the shared store.
     const affiliate = await validateSlug(ref);
-    const ip = clientIp(req);
-    const visitId = `${ref}_${Date.now()}_${ip}`.replace(
-      /[^a-zA-Z0-9_-]/g,
-      "_"
-    );
+    if (!affiliate) {
+      return json(res, 200, { tracked: false, reason: "unknown_ref" });
+    }
+
+    const day = new Date().toISOString().slice(0, 10);
+    const dayKey = `${ref}:${day}`;
+    const ipHash = crypto.createHash("sha256").update(String(ip)).digest("hex").slice(0, 12);
 
     await mutateStore((store) => {
-      if (!store.affiliate_tracking) store.affiliate_tracking = {};
-      store.affiliate_tracking[visitId] = {
+      if (!store.affiliate_daily) store.affiliate_daily = {};
+      pruneAffiliateDaily(store.affiliate_daily);
+      const prev = store.affiliate_daily[dayKey] || {
         ref,
-        ip,
-        page: body.page || "/",
-        referrer: body.referrer || null,
-        user_agent: req.headers["user-agent"] || null,
-        affiliate_exists: !!affiliate,
-        ts: body.ts || new Date().toISOString(),
-        logged_at: new Date().toISOString(),
+        day,
+        visits: 0,
+        ip_hashes: [],
+        updated_at: null,
       };
+      const hashes = Array.isArray(prev.ip_hashes) ? prev.ip_hashes.slice(0, 64) : [];
+      if (!hashes.includes(ipHash) && hashes.length < 64) hashes.push(ipHash);
+      store.affiliate_daily[dayKey] = {
+        ref,
+        day,
+        visits: Number(prev.visits || 0) + 1,
+        ip_hashes: hashes,
+        // Cap optional debug fields — never store raw multi-KB page/UA blobs.
+        last_page: clipField(body.page || "/", TRACK_FIELD_MAX),
+        last_referrer: clipField(body.referrer || "", TRACK_FIELD_MAX) || null,
+        updated_at: new Date().toISOString(),
+      };
+      // Do not write affiliate_tracking per-visit rows anymore.
+      return { tracked: true };
     });
 
     return json(res, 200, { tracked: true });
@@ -248,14 +310,28 @@ async function handleTrack(req, res, body) {
 
 async function handleClaim(req, res, body) {
   try {
+    // Must be the signed-in user claiming their own signup — otherwise anyone can
+    // spam pending commissions for arbitrary emails.
+    let user;
+    try {
+      user = await verifyUser(req);
+    } catch {
+      return json(res, 401, { detail: "Sign in required to claim a referral." });
+    }
+
     const ref = (body.ref || "").trim().toLowerCase();
-    const userEmail = (body.user_email || "").trim().toLowerCase();
+    const userEmail = String(user.email || body.user_email || "")
+      .trim()
+      .toLowerCase();
     const action = body.action_type || "signup";
 
     if (!ref || !userEmail) {
       return json(res, 400, {
-        detail: "Both 'ref' and 'user_email' are required.",
+        detail: "Both 'ref' and a verified account email are required.",
       });
+    }
+    if (body.user_email && String(body.user_email).trim().toLowerCase() !== userEmail) {
+      return json(res, 403, { detail: "user_email must match the signed-in account." });
     }
 
     const affiliate = await validateSlug(ref);
@@ -263,14 +339,19 @@ async function handleClaim(req, res, body) {
       return json(res, 404, { detail: "Affiliate not found or inactive." });
     }
 
+    // Self-referral / same email as affiliate
+    if (String(affiliate.email || "").trim().toLowerCase() === userEmail) {
+      return json(res, 400, { detail: "You cannot claim your own referral link." });
+    }
+
     const store = await loadStore();
     const conversions = store.affiliate_conversions || {};
     for (const conv of Object.values(conversions)) {
-      if (conv.user_email === userEmail && conv.ref === ref) {
+      if (conv.user_email === userEmail) {
         return json(res, 200, {
           claimed: true,
           duplicate: true,
-          detail: "Referral already claimed.",
+          detail: "Referral already claimed for this account.",
         });
       }
     }
@@ -288,6 +369,7 @@ async function handleClaim(req, res, body) {
         affiliate_email: affiliate.email,
         affiliate_name: affiliate.name,
         user_email: userEmail,
+        user_id: user.uid,
         action,
         status: "pending",
         commission_pct: 40,
@@ -416,6 +498,7 @@ async function handleMeView(req, res) {
     const store = await loadStore();
     const affiliates = store.affiliates || {};
     const tracking = store.affiliate_tracking || {};
+    const daily = store.affiliate_daily || {};
     const conversions = store.affiliate_conversions || {};
 
     const affiliate = Object.values(affiliates).find(
@@ -430,7 +513,7 @@ async function handleMeView(req, res) {
     }
 
     const isFounder = FOUNDER_EMAILS.has(email);
-    const stats = computeAffiliateStats(affiliate, tracking, conversions);
+    const stats = computeAffiliateStats(affiliate, tracking, conversions, daily);
 
     return json(res, 200, { affiliate, stats, is_founder: isFounder });
   } catch (err) {
@@ -455,11 +538,12 @@ async function handleAdminView(req, res) {
     const store = await loadStore();
     const affiliates = store.affiliates || {};
     const tracking = store.affiliate_tracking || {};
+    const daily = store.affiliate_daily || {};
     const conversions = store.affiliate_conversions || {};
 
     const list = Object.values(affiliates).map((a) => ({
       ...a,
-      stats: computeAffiliateStats(a, tracking, conversions),
+      stats: computeAffiliateStats(a, tracking, conversions, daily),
     }));
 
     const totalAffiliates = list.length;

--- a/api/billing-webhook.js
+++ b/api/billing-webhook.js
@@ -51,7 +51,8 @@ module.exports = async (req, res) => {
     const event = stripe.webhooks.constructEvent(rawBody, sig, webhookSecret);
 
     switch (event.type) {
-      case "checkout.session.completed": {
+      case "checkout.session.completed":
+      case "checkout.session.async_payment_succeeded": {
         const session = event.data.object;
         const kind = session.metadata?.kind || "";
         if (kind.startsWith("credit_")) {
@@ -135,11 +136,13 @@ module.exports = async (req, res) => {
         // Auto-recharge credits balance when charged off-session (idempotent via PI id in credited list)
         const pi = event.data.object;
         if (pi.metadata?.kind === "credit_auto_recharge" && pi.metadata?.user_id) {
+          if (pi.metadata?.sc_credited === "true") break;
           const fakeSession = {
             id: `pi_${pi.id}`,
             metadata: {
               user_id: pi.metadata.user_id,
               kind: "credit_auto_recharge",
+              // credit_usd metadata is informational only — applyCreditTopUp uses amount_total
               credit_usd: pi.metadata.credit_usd,
               auto_recharge: "true",
             },

--- a/api/demo/compress.js
+++ b/api/demo/compress.js
@@ -1,11 +1,13 @@
 /**
  * Public demo compress — compiler mode, no API key.
- * Rate-limited: 30 req/min per IP.
+ * Rate-limited: 30 req/min per IP (memory + durable when Firestore is up).
  */
-const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody, softProbe } = require("../_lib/http");
+const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody } = require("../_lib/http");
+const { checkDurableRateLimit } = require("../_lib/rate-limit-durable");
 const { compressAdaptive, getEngine } = require("../_lib/engine");
 
 const DEMO_RPM = 30;
+const DEMO_MAX_CHARS = 20_000;
 
 const ASSUMPTIONS = {
   tokens_per_gpu_second: 2500,
@@ -29,18 +31,31 @@ function envForTokenCount(tokenCount) {
 
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
-  if (req.method !== "POST") {
-    return softProbe(res, "Method not allowed", { allow: "POST" });
-  }
+  if (req.method !== "POST") return json(res, 405, { detail: "Method not allowed" });
 
-  // ── Rate limit by IP ──
+  // ── Rate limit by IP (memory + durable when available) ──
   const ip = clientIp(req);
-  const rl = checkRateLimit(`demo:${ip}`, DEMO_RPM);
-  if (!rl.allowed) {
+  const rlMem = checkRateLimit(`demo:${ip}`, DEMO_RPM);
+  if (!rlMem.allowed) {
     return jsonWithRateLimit(res, 429, {
       detail: `Rate limit exceeded (${DEMO_RPM} requests/minute). Try again shortly or use your own API key via POST /api/v1/compress.`,
-      retry_after_seconds: Math.max(1, Math.ceil((rl.resetMs - Date.now()) / 1000)),
-    }, rl);
+      retry_after_seconds: Math.max(1, Math.ceil((rlMem.resetMs - Date.now()) / 1000)),
+    }, rlMem);
+  }
+  let rl = rlMem;
+  try {
+    const durable = await checkDurableRateLimit(`demo:${ip}`, DEMO_RPM, 60_000);
+    if (durable.backend === "firestore") {
+      if (!durable.allowed) {
+        return jsonWithRateLimit(res, 429, {
+          detail: `Rate limit exceeded (${DEMO_RPM} requests/minute). Try again shortly or use your own API key via POST /api/v1/compress.`,
+          retry_after_seconds: Math.max(1, Math.ceil((durable.resetMs - Date.now()) / 1000)),
+        }, durable);
+      }
+      rl = { ...durable, remaining: Math.min(durable.remaining, rlMem.remaining) };
+    }
+  } catch (_) {
+    /* memory already applied */
   }
 
   try {
@@ -48,16 +63,9 @@ module.exports = async (req, res) => {
     const context = body.context || "";
     const query = body.query || "Summarize this context.";
 
-    // Empty-body scanner POSTs — soft 200 (Observability error rate).
-    if (!context.trim()) {
-      return jsonWithRateLimit(res, 200, {
-        ok: false,
-        probe: true,
-        detail: "context required",
-      }, rl);
-    }
-    if (context.length > 80_000) return jsonWithRateLimit(res, 422, {
-      detail: "context too long (80k max for demo)"
+    if (!context.trim()) return jsonWithRateLimit(res, 422, { detail: "context required" }, rl);
+    if (context.length > DEMO_MAX_CHARS) return jsonWithRateLimit(res, 422, {
+      detail: `context too long (${DEMO_MAX_CHARS / 1000}k max for demo)`
     }, rl);
 
     const result = await compressAdaptive(context, query);

--- a/api/weekly/unsubscribe.js
+++ b/api/weekly/unsubscribe.js
@@ -1,0 +1,11 @@
+/**
+ * Public one-click unsubscribe alias used in weekly email List-Unsubscribe /
+ * HTML links: POST|GET /api/weekly/unsubscribe?email=&token=
+ *
+ * Delegates to api/account.js?op=weekly-unsubscribe (token required).
+ */
+module.exports = async (req, res) => {
+  if (!req.query || typeof req.query !== "object") req.query = {};
+  req.query.op = "weekly-unsubscribe";
+  return require("../account")(req, res);
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1289,6 +1289,10 @@
       "destination": "/api/account?op=welcome-drain"
     },
     {
+      "source": "/api/weekly/unsubscribe",
+      "destination": "/api/account?op=weekly-unsubscribe"
+    },
+    {
       "source": "/dashboard",
       "destination": "/dashboard.html"
     },

--- a/web/unsubscribe.html
+++ b/web/unsubscribe.html
@@ -83,6 +83,27 @@
         });
         const data = await res.json().catch(() => ({}));
         if (!res.ok) {
+          if (res.status === 401 || data.code === "invalid_token") {
+            status.innerHTML = "That unsubscribe link is invalid or expired. " +
+              "<button type=\"button\" id=\"resend\" style=\"margin-left:8px;color:var(--brand);background:none;border:none;cursor:pointer;text-decoration:underline\">Email me a fresh link</button>";
+            document.getElementById("resend")?.addEventListener("click", async () => {
+              status.textContent = "Sending…";
+              try {
+                const r2 = await fetch("/api/account?op=weekly-unsub-link", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json", Accept: "application/json" },
+                  body: JSON.stringify({ email }),
+                });
+                const d2 = await r2.json().catch(() => ({}));
+                status.textContent = r2.ok
+                  ? "Check your inbox for a fresh unsubscribe link."
+                  : (d2.detail || "Could not send a link. Reply to any email instead.");
+              } catch {
+                status.textContent = "Network error sending link.";
+              }
+            });
+            return;
+          }
           status.textContent = data.detail || "Could not unsubscribe. Reply to any email and ask Arjun to remove you.";
           return;
         }


### PR DESCRIPTION
## Audit findings → fixes

### Critical — prepaid credits
1. **Trusted metadata over charge amount** — `applyCreditTopUp` credited `metadata.credit_usd` (clamped with min \$10) instead of Stripe `amount_total`. A promo / mismatch could mint \$10+ for \$0–\$5 paid. **Fix:** credit exact `amount_total` / PI `amount` only; reject \$0.
2. **Sliding-window re-mint** — `sc_credited_sessions` keeps ~40 ids. After that, reconcile could re-apply old paid sessions when Firestore is down. **Fix:** stamp Checkout/PI metadata `sc_credited=true` after apply; skip if already stamped.
3. **Async unpaid “complete”** — outstanding reconcile treated `status=complete` as paid. **Fix:** require `payment_status === "paid"`; handle `checkout.session.async_payment_succeeded`.
4. **Promo codes** — disabled on credit Checkout (`allow_promotion_codes: false`) so wallet loads stay 1:1 with cash.

### High — public surfaces (from #77 + extras)
5. **Affiliate `track` DoS** — per-visit rows into monolithic store → daily counters + IP rate limits + field caps.
6. **Unauthenticated affiliate `claim`** — anyone could spam pending commissions for arbitrary emails. **Fix:** require signed-in user; email must match; block self-referral; one claim per account.
7. **Weekly unsubscribe** — missing `/api/weekly/unsubscribe` + tokenless risk. **Fix:** real route + account hardening from #77.
8. **Demo compress** — durable IP RL + 20k context cap.

### Already live from #81
- Claims fallback when Firestore is down
- Billing GET auto-heal for empty wallets
- Success-page reconcile retries
- Webhook 500 on processing failure (Stripe retries)

## Test plan
- [x] `node api/_lib/credit-amount.test.js`
- [x] `node api/_lib/billing-ledger.test.js`
- [ ] CI green
- [ ] Merge + prod deploy
- [ ] Spot-check: paid \$10 top-up credits \$10; reconcile does not double-credit
- [ ] Enable Cloud Firestore API on GCP `supercompress` when possible (durable ledger)


Made with [Cursor](https://cursor.com)