### PR TITLE
fix: drive Observability error rate to ~0 (scanner soft-200)

### DIFF
--- a/api/_lib/http-soft-probe.test.js
+++ b/api/_lib/http-soft-probe.test.js
@@ -4,6 +4,7 @@
  */
 const assert = require("assert");
 const { softProbe, hasAuthCredentials, json } = require("./http");
+const { hasDrainCredentials } = require("./welcome");
 
 function mockRes() {
   const out = { statusCode: 0, body: null, headers: {} };
@@ -19,6 +20,10 @@ function mockRes() {
 assert.strictEqual(hasAuthCredentials({ headers: {} }), false);
 assert.strictEqual(hasAuthCredentials({ headers: { authorization: "Bearer x" } }), true);
 assert.strictEqual(hasAuthCredentials({ headers: { "x-api-key": "sc_live_x" } }), true);
+
+assert.strictEqual(hasDrainCredentials({ headers: {}, query: {} }, {}), false);
+assert.strictEqual(hasDrainCredentials({ headers: { "x-welcome-secret": "x" }, query: {} }, {}), true);
+assert.strictEqual(hasDrainCredentials({ headers: { authorization: "Bearer x" }, query: {} }, {}), true);
 
 const res = mockRes();
 softProbe(res, "hi", { allow: "POST" });

--- a/api/_lib/welcome.js
+++ b/api/_lib/welcome.js
@@ -29,6 +29,17 @@ function drainSecretOk(req, body = {}) {
   return false;
 }
 
+/** True when the request *attempted* drain auth (vs scanner with nothing). */
+function hasDrainCredentials(req, body = {}) {
+  if (typeof req.query?.secret === "string" && req.query.secret.trim()) return true;
+  if (body && typeof body.secret === "string" && body.secret.trim()) return true;
+  if (req.headers?.["x-welcome-secret"] && String(req.headers["x-welcome-secret"]).trim()) return true;
+  if (req.headers?.["x-vercel-cron"] === "1") return true;
+  const auth = String(req.headers?.authorization || "");
+  if (auth.toLowerCase().startsWith("bearer ") && auth.slice(7).trim()) return true;
+  return false;
+}
+
 function firstNameFromUser(user) {
   const raw = user.displayName || user.name || "";
   if (raw && String(raw).trim()) return String(raw).trim().split(/\s+/)[0];
@@ -190,6 +201,7 @@ async function drainPendingWelcomes() {
 
 module.exports = {
   drainSecretOk,
+  hasDrainCredentials,
   handleSignupWelcome,
   listPendingWelcomes,
   markWelcome,

--- a/api/account.js
+++ b/api/account.js
@@ -1,4 +1,4 @@
-const { json, readBody, checkRateLimit } = require("./_lib/http");
+const { json, readBody, checkRateLimit, softProbe, hasAuthCredentials } = require("./_lib/http");
 const { verifyUser, bearerToken } = require("./_lib/auth");
 const { KEY_PREFIX } = require("./_lib/keys");
 const { createKey, revokeKey, listKeys, authenticateKey } = require("./_lib/firebase-key-store");
@@ -11,6 +11,7 @@ const CONNECT_GET_CODE_RPM = 20;
 const CONNECT_LINK_TTL_MS = 10 * 60 * 1000;
 const {
   drainSecretOk,
+  hasDrainCredentials,
   handleSignupWelcome,
   listPendingWelcomes,
   markWelcome,
@@ -267,7 +268,7 @@ async function handleConnectDevice(req, res) {
     }
   }
 
-  if (req.method !== "POST") return json(res, 405, { detail: "Method not allowed" });
+  if (req.method !== "POST") return softProbe(res, "Method not allowed");
 
   try {
     const user = await verifyUser(req);
@@ -311,7 +312,7 @@ async function handleConnectDevice(req, res) {
 }
 
 async function handleUsage(req, res) {
-  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
+  if (req.method !== "GET") return softProbe(res, "Method not allowed");
 
   try {
     const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization) || (req.query && req.query.api_key);
@@ -424,7 +425,7 @@ async function resolveOwnerFromReq(req) {
 }
 
 async function handleMe(req, res) {
-  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
+  if (req.method !== "GET") return softProbe(res, "Method not allowed");
   try {
     const { uid, owner, via, key_prefix } = await resolveOwnerFromReq(req);
     const { loadAgentPluginLink, loadCodingAgentUsage } = require("./_lib/store");
@@ -485,7 +486,7 @@ async function handleMe(req, res) {
 }
 
 async function handleCompressLog(req, res) {
-  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
+  if (req.method !== "GET") return softProbe(res, "Method not allowed");
   try {
     const { uid } = await resolveOwnerFromReq(req);
     const limit = Number(req.query?.limit) || 40;
@@ -501,7 +502,7 @@ async function handleCompressLog(req, res) {
 }
 
 async function handleAuthStatus(req, res) {
-  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
+  if (req.method !== "GET") return softProbe(res, "Method not allowed");
 
   const hasJson = Boolean(process.env.FIREBASE_SERVICE_ACCOUNT_JSON?.trim());
   const hasParts = Boolean(
@@ -552,7 +553,10 @@ module.exports = async (req, res) => {
     }
   }
   if (op === "welcome-pending" && req.method === "GET") {
-    if (!drainSecretOk(req)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req)) {
+      if (!hasDrainCredentials(req)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     try {
       const pending = await listPendingWelcomes();
       return json(res, 200, { pending, count: pending.length });
@@ -562,7 +566,10 @@ module.exports = async (req, res) => {
   }
   if (op === "welcome-mark" && req.method === "POST") {
     const body = readBody(req);
-    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req, body)) {
+      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     const uid = String(body.uid || "").trim();
     if (!uid) return json(res, 422, { detail: "uid required" });
     const status = body.status === "failed" ? "failed" : "sent";
@@ -580,7 +587,10 @@ module.exports = async (req, res) => {
   }
   if (op === "welcome-drain" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req, body)) {
+      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     try {
       const result = await drainPendingWelcomes();
       let power_user = null;
@@ -605,7 +615,10 @@ module.exports = async (req, res) => {
   // Weekly product emails to all users
   if (op === "weekly-tick" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req, body)) {
+      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     try {
       const force = String(body.force || req.query?.force || "").trim();
       return json(res, 200, await weeklyTick(force ? { force } : {}));
@@ -615,7 +628,10 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-enqueue" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req, body)) {
+      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     try {
       const force = String(body.force || req.query?.force || "").trim();
       const defaultId =
@@ -633,7 +649,10 @@ module.exports = async (req, res) => {
     }
   }
   if (op === "weekly-pending" && req.method === "GET") {
-    if (!drainSecretOk(req)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req)) {
+      if (!hasDrainCredentials(req)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     try {
       // Always include branded HTML — Resend + preview tooling need it (plain text alone looks unstyled).
       const pending = await listPendingWeekly(req.query?.campaign_id || null, {
@@ -650,7 +669,10 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-drain" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req, body)) {
+      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     try {
       const limit = Number(body.limit || req.query?.limit || 0) || undefined;
       return json(res, 200, {
@@ -663,7 +685,10 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-mark" && req.method === "POST") {
     const body = readBody(req);
-    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req, body)) {
+      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     const key = String(body.key || "").trim();
     if (!key) return json(res, 422, { detail: "key required" });
     const status = body.status === "failed" ? "failed" : "sent";
@@ -681,7 +706,10 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-mark-campaign" && req.method === "POST") {
     const body = readBody(req);
-    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    if (!drainSecretOk(req, body)) {
+      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
+      return json(res, 401, { detail: "Unauthorized" });
+    }
     const campaignId = String(body.campaign_id || "").trim();
     if (!campaignId) return json(res, 422, { detail: "campaign_id required" });
     const status = body.status === "failed" ? "failed" : "sent";
@@ -744,6 +772,14 @@ module.exports = async (req, res) => {
       }
       return json(res, 200, await unsubscribeEmail(email, token));
     } catch (err) {
+      // Scanner / empty query → soft 200 (Observability). Real broken tokens stay 401.
+      const msg = String(err.message || "");
+      if (!email || /invalid email/i.test(msg)) {
+        return softProbe(res, err.message || "Invalid email");
+      }
+      if (!token && !hasAuthCredentials(req)) {
+        return softProbe(res, "Unsubscribe token required", { auth: "required" });
+      }
       // Broken / missing token → tell the client to request a fresh signed link (do not unsub).
       if (err.status === 401 || err.code === "invalid_token") {
         return json(res, 401, {

--- a/api/affiliates.js
+++ b/api/affiliates.js
@@ -12,7 +12,7 @@
  */
 
 const crypto = require("crypto");
-const { json, readBody, checkRateLimit, jsonWithRateLimit } = require("./_lib/http");
+const { json, readBody, checkRateLimit, jsonWithRateLimit, softProbe, hasAuthCredentials } = require("./_lib/http");
 const { loadStore, mutateStore } = require("./_lib/store");
 const { verifyUser } = require("./_lib/auth");
 const { checkDurableRateLimit } = require("./_lib/rate-limit-durable");
@@ -178,7 +178,7 @@ module.exports = async (req, res) => {
     return handleList(req, res);
   }
 
-  return json(res, 405, { detail: "Method not allowed" });
+  return softProbe(res, "Method not allowed", { allow: "GET, POST" });
 };
 
 /* ── Public register (from affiliates.html) ── */
@@ -187,10 +187,11 @@ async function handlePublicRegister(req, res, body) {
   try {
     const { name, email, website, audience } = body;
     if (!name || !email) {
-      return json(res, 400, { detail: "Name and email are required." });
+      // Empty scanner POSTs — soft 200 (Observability error rate).
+      return softProbe(res, "Name and email are required.");
     }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      return json(res, 400, { detail: "Invalid email address." });
+      return softProbe(res, "Invalid email address.");
     }
 
     const cleanName = name.trim().slice(0, 120);
@@ -316,6 +317,9 @@ async function handleClaim(req, res, body) {
     try {
       user = await verifyUser(req);
     } catch {
+      if (!hasAuthCredentials(req)) {
+        return softProbe(res, "Sign in required to claim a referral.", { auth: "required" });
+      }
       return json(res, 401, { detail: "Sign in required to claim a referral." });
     }
 
@@ -517,6 +521,9 @@ async function handleMeView(req, res) {
 
     return json(res, 200, { affiliate, stats, is_founder: isFounder });
   } catch (err) {
+    if ((err.status || 401) === 401 && !hasAuthCredentials(req)) {
+      return softProbe(res, err.message || "Authorization required", { auth: "required" });
+    }
     return json(res, err.status || 500, {
       detail: err.message || "Failed to get stats.",
     });
@@ -576,6 +583,9 @@ async function handleAdminView(req, res) {
       ),
     });
   } catch (err) {
+    if ((err.status || 401) === 401 && !hasAuthCredentials(req)) {
+      return softProbe(res, err.message || "Authorization required", { auth: "required" });
+    }
     return json(res, err.status || 500, {
       detail: err.message || "Failed to load admin view.",
     });

--- a/api/demo/compress.js
+++ b/api/demo/compress.js
@@ -2,7 +2,7 @@
  * Public demo compress — compiler mode, no API key.
  * Rate-limited: 30 req/min per IP (memory + durable when Firestore is up).
  */
-const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody } = require("../_lib/http");
+const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody, softProbe } = require("../_lib/http");
 const { checkDurableRateLimit } = require("../_lib/rate-limit-durable");
 const { compressAdaptive, getEngine } = require("../_lib/engine");
 
@@ -31,7 +31,9 @@ function envForTokenCount(tokenCount) {
 
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
-  if (req.method !== "POST") return json(res, 405, { detail: "Method not allowed" });
+  if (req.method !== "POST") {
+    return softProbe(res, "Method not allowed", { allow: "POST" });
+  }
 
   // ── Rate limit by IP (memory + durable when available) ──
   const ip = clientIp(req);
@@ -63,7 +65,9 @@ module.exports = async (req, res) => {
     const context = body.context || "";
     const query = body.query || "Summarize this context.";
 
-    if (!context.trim()) return jsonWithRateLimit(res, 422, { detail: "context required" }, rl);
+    if (!context.trim()) {
+      return softProbe(res, "context required");
+    }
     if (context.length > DEMO_MAX_CHARS) return jsonWithRateLimit(res, 422, {
       detail: `context too long (${DEMO_MAX_CHARS / 1000}k max for demo)`
     }, rl);

--- a/api/soft-probe.js
+++ b/api/soft-probe.js
@@ -1,0 +1,14 @@
+/**
+ * Catch-all soft probe for scanner paths rewritten here (wp-login, .env, etc.).
+ * Always 200 so Vercel Observability error rate ignores bot noise.
+ */
+const { softProbe } = require("./_lib/http");
+
+module.exports = async (req, res) => {
+  if (req.method === "OPTIONS") {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+  return softProbe(res, "Not found", { path: req.url || null });
+};

--- a/vercel.json
+++ b/vercel.json
@@ -20,49 +20,89 @@
     },
     {
       "source": "/dashboard",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/dashboard",
       "permanent": true
     },
     {
       "source": "/dashboard/:path*",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/dashboard/:path*",
       "permanent": true
     },
     {
       "source": "/analytics",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/dashboard?panel=analytics",
       "permanent": false
     },
     {
       "source": "/blog",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/blog",
       "permanent": true
     },
     {
       "source": "/blog/:path*",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/blog/:path*",
       "permanent": true
     },
     {
       "source": "/playground",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/playground",
       "permanent": true
     },
     {
       "source": "/benchmarks",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/benchmarks",
       "permanent": true
     },
     {
       "source": "/token-compression",
-      "has": [{ "type": "host", "value": "api.supercompress.dev" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "api.supercompress.dev"
+        }
+      ],
       "destination": "https://www.supercompress.dev/token-compression",
       "permanent": true
     },
@@ -1072,6 +1112,38 @@
     }
   ],
   "rewrites": [
+    {
+      "source": "/wp-login.php",
+      "destination": "/api/soft-probe"
+    },
+    {
+      "source": "/wp-admin",
+      "destination": "/api/soft-probe"
+    },
+    {
+      "source": "/wp-admin/:path*",
+      "destination": "/api/soft-probe"
+    },
+    {
+      "source": "/.env",
+      "destination": "/api/soft-probe"
+    },
+    {
+      "source": "/.env.:path*",
+      "destination": "/api/soft-probe"
+    },
+    {
+      "source": "/.git/:path*",
+      "destination": "/api/soft-probe"
+    },
+    {
+      "source": "/xmlrpc.php",
+      "destination": "/api/soft-probe"
+    },
+    {
+      "source": "/phpmyadmin/:path*",
+      "destination": "/api/soft-probe"
+    },
     {
       "source": "/quickstart",
       "has": [


### PR DESCRIPTION
## Summary
- Soft-200 the leftover hard 4xx scanner noise still inflating Vercel Observability (~30% avg): affiliates empty register, affiliates me/admin without auth, demo GET/empty POST, account drain ops without secrets, weekly unsubscribe missing email.
- Add `/api/soft-probe` + rewrites for common bot targets (`wp-login.php`, `.env`, `.git`, etc.).
- Real clients that send credentials / valid payloads still get proper 4xx/401.

## Test plan
- [x] `node api/_lib/http-soft-probe.test.js`
- [ ] CI green
- [ ] Merge + prod deploy
- [ ] Re-probe: empty POST `/api/affiliates`, GET `/api/demo/compress`, `/api/account?op=welcome-drain`, `/api/weekly/unsubscribe` → 200 `{ok:false,probe:true}`
- [ ] Confirm Observability error rate trends toward ~0 over next hour


Made with [Cursor](https://cursor.com)