### PR TITLE
fix: soft-200 unknown /api/* scanner 404s

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1531,6 +1531,10 @@
     {
       "source": "/assets/img/icon-192.png",
       "destination": "/assets/img/icon-192.png"
+    },
+    {
+      "source": "/api/:path*",
+      "destination": "/api/soft-probe"
     }
   ],
   "functions": {


### PR DESCRIPTION
## Summary
- Catch-all rewrite `/api/:path*` → `/api/soft-probe` so unmatched API scanner paths stop returning platform 404s in Observability.
- Existing serverless functions still win (Vercel filesystem precedence).

## Test plan
- [ ] `/api/health` still 200 real health
- [ ] `/api/nonexistent` → 200 `{probe:true}`
- [ ] Merge + deploy


Made with [Cursor](https://cursor.com)