### PR TITLE
fix: fail-closed billing, restore API statuses, idempotency lease

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -293,100 +293,106 @@ async function loadLedger(uid, claims = {}) {
     return normalizeLedger(snap.exists ? snap.data() : null, claims);
   } catch (err) {
     if (err.code === "billing_unavailable") throw err;
-    console.warn("billing-ledger load failed — using Auth claims:", err.message || err);
-    return normalizeLedger(null, claims);
+    console.error("billing-ledger load failed (fail-closed):", err.message || err);
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
 }
 
+const IDEMPOTENCY_LEASE_MS = 90_000;
+/** Keep replayable compressed_text this long; billing metadata is retained longer. */
+const REPLAY_TTL_MS = 48 * 60 * 60 * 1000;
+
+function usageDocExpiredReplay(data) {
+  if (!data || !data.response) return true;
+  const created = Date.parse(data.response_expires_at || data.created_at || 0);
+  if (!Number.isFinite(created)) return false;
+  // Prefer explicit expiry; else created_at + TTL
+  if (data.response_expires_at) return Date.now() > created;
+  return Date.now() - created > REPLAY_TTL_MS;
+}
+
 /**
- * When Cloud Firestore is disabled/unavailable, bill via Auth claims only.
- * Do not depend on gist here — gist rate limits caused the outage recovery path
- * to fail. Replay text is not stored (claims size); retries recompress but do
- * not double-bill (request id watermark on claims).
+ * Pre-compression single-flight lease for Idempotency-Key.
+ * @returns {{ status: 'acquired'|'completed'|'pending', data?: object }}
  */
-async function applyUsageAndBurnClaimsFallback({
-  uid,
-  tokensIn,
-  tokensOut,
-  tokensSaved,
-  claims = {},
-  requestId,
-  fingerprint,
-  response = null,
-}) {
+async function reserveIdempotencyLease(uid, requestId, fingerprint) {
   const rid = sanitizeRequestId(requestId);
   const fp = String(fingerprint || "").trim() || null;
-  if (!rid) throw billingError("billing_unavailable", "Billing request id required");
-
-  const fresh = await admin().auth().getUser(uid);
-  const liveClaims = { ...(fresh.customClaims || {}), ...claims };
-  const recent = Array.isArray(liveClaims.sc_recent_billing)
-    ? liveClaims.sc_recent_billing
-    : [];
-  const prior = recent.find((r) => r && r.i === rid);
-  if (prior) {
-    assertUsageIdempotencyMatch(
-      {
-        fingerprint: prior.f || null,
-        tokens_in: prior.tin,
-        tokens_out: prior.tout,
-        tokens_saved: prior.ts,
-      },
-      {
-        fingerprint: fp,
-        tokensIn,
-        tokensOut,
-        tokensSaved,
-      }
-    );
-    return {
-      burned_micros: Number(prior.b || 0),
-      ledger: normalizeLedger(null, liveClaims),
-      already: true,
-      request_id: rid,
-      fingerprint: prior.f || fp || null,
-      response: null,
-      backend: "claims-fallback",
-    };
+  if (!uid || !rid || !initFirebaseAdmin()) {
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
+  const usageRef = db().collection("billing_usage").doc(`${uid}:${rid}`);
+  try {
+    return await db().runTransaction(async (tx) => {
+      const snap = await tx.get(usageRef);
+      const now = Date.now();
+      if (snap.exists) {
+        const prev = snap.data() || {};
+        if (prev.status === "completed" || (prev.response && prev.status !== "pending")) {
+          assertUsageIdempotencyMatch(prev, {
+            fingerprint: fp,
+            tokensIn: prev.tokens_in,
+            tokensOut: prev.tokens_out,
+            tokensSaved: prev.tokens_saved,
+          });
+          return { status: "completed", data: prev };
+        }
+        if (prev.status === "pending") {
+          const until = Number(prev.lease_until || 0);
+          if (until > now) {
+            if (prev.fingerprint && fp && prev.fingerprint !== fp) {
+              throw billingError(
+                "idempotency_conflict",
+                "Idempotency-Key reused with a different request payload"
+              );
+            }
+            return { status: "pending", data: prev };
+          }
+          // Expired lease — take over.
+        } else if (prev.fingerprint && fp && prev.fingerprint !== fp) {
+          throw billingError(
+            "idempotency_conflict",
+            "Idempotency-Key reused with a different request payload"
+          );
+        }
+      }
+      tx.set(
+        usageRef,
+        {
+          uid,
+          request_id: rid,
+          fingerprint: fp,
+          status: "pending",
+          lease_until: now + IDEMPOTENCY_LEASE_MS,
+          created_at: new Date().toISOString(),
+        },
+        { merge: true }
+      );
+      return { status: "acquired" };
+    });
+  } catch (err) {
+    if (err.paywall || err.code === "idempotency_conflict" || err.code === "billing_unavailable") {
+      throw err;
+    }
+    console.error("reserveIdempotencyLease failed (fail-closed):", err?.message || err);
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
+  }
+}
 
-  const ledger = normalizeLedger(null, liveClaims);
-  const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims: liveClaims });
-  const nextRecent = [
-    {
-      i: rid.slice(0, 64),
-      f: fp ? String(fp).slice(0, 32) : null,
-      tin: Number(tokensIn) || 0,
-      tout: Number(tokensOut) || 0,
-      ts: Number(tokensSaved) || 0,
-      b: planned.burned_micros,
-      t: Date.now(),
-    },
-    ...recent,
-  ].slice(0, 5);
-
-  await admin().auth().setCustomUserClaims(uid, {
-    ...liveClaims,
-    sc_usage: {
-      month: planned.ledger.month,
-      requests: planned.ledger.requests,
-      tokens_in: planned.ledger.tokens_in,
-      tokens_out: planned.ledger.tokens_out,
-      tokens_saved: planned.ledger.tokens_saved,
-      tokens_reported: planned.ledger.tokens_reported || 0,
-    },
-    sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
-    sc_recent_billing: nextRecent,
-  });
-
-  return {
-    ...planned,
-    already: false,
-    request_id: rid,
-    fingerprint: fp,
-    response: sanitizeReplayResponse(response),
-    backend: "claims-fallback",
-  };
+async function releaseIdempotencyLease(uid, requestId) {
+  const rid = sanitizeRequestId(requestId);
+  if (!uid || !rid || !initFirebaseAdmin()) return;
+  try {
+    const usageRef = db().collection("billing_usage").doc(`${uid}:${rid}`);
+    await db().runTransaction(async (tx) => {
+      const snap = await tx.get(usageRef);
+      if (!snap.exists) return;
+      const prev = snap.data() || {};
+      if (prev.status === "pending") tx.delete(usageRef);
+    });
+  } catch (err) {
+    console.warn("releaseIdempotencyLease failed:", err?.message || err);
+  }
 }
 
 /**
@@ -472,22 +478,27 @@ async function lookupUsageReplay(uid, requestId) {
   if (!uid || !rid || !initFirebaseAdmin()) return null;
   try {
     const snap = await db().collection("billing_usage").doc(`${uid}:${rid}`).get();
-    if (snap.exists) return snap.data() || null;
-  } catch (err) {
-    if (!isFirestoreBackendDown(err)) {
-      console.warn("lookupUsageReplay failed:", err?.message || err);
+    if (!snap.exists) return null;
+    const data = snap.data() || null;
+    if (!data || data.status === "pending") return null;
+    if (data.response && usageDocExpiredReplay(data)) {
+      // Drop expired replay body; keep billing metadata for audit / conflict checks.
+      const { response, ...meta } = data;
+      try {
+        await db().collection("billing_usage").doc(`${uid}:${rid}`).set(
+          { response: null, response_expired_at: new Date().toISOString() },
+          { merge: true }
+        );
+      } catch (_) {
+        /* best-effort TTL scrub */
+      }
+      return { ...meta, response: null };
     }
-  }
-  // Firestore-down fallback: gist-backed idempotency rows.
-  try {
-    const { loadStore } = require("./store");
-    const store = await loadStore();
-    const prev = store.billing_usage_fallback?.[`${uid}:${rid}`];
-    if (prev) return prev;
+    return data;
   } catch (err) {
-    console.warn("lookupUsageReplay fallback failed:", err?.message || err);
+    console.error("lookupUsageReplay failed (fail-closed):", err?.message || err);
+    return null;
   }
-  return null;
 }
 
 async function applyUsageAndBurn({
@@ -516,10 +527,10 @@ async function applyUsageAndBurn({
   let result;
   try {
     result = await db().runTransaction(async (tx) => {
-      // All reads before writes (Firestore txn rule).
       const usageSnap = await tx.get(usageRef);
       const snap = await tx.get(ref);
       const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
+      const expiresAt = new Date(Date.now() + REPLAY_TTL_MS).toISOString();
 
       if (usageSnap.exists) {
         const prev = usageSnap.data() || {};
@@ -529,9 +540,46 @@ async function applyUsageAndBurn({
           tokensOut,
           tokensSaved,
         });
-        // Backfill response on legacy rows that billed before replay storage existed.
+
+        // Complete a pending lease from reserveIdempotencyLease (single-flight).
+        if (prev.status === "pending") {
+          const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims });
+          tx.set(ref, planned.ledger, { merge: true });
+          tx.set(
+            usageRef,
+            {
+              uid,
+              request_id: rid,
+              fingerprint: fp,
+              status: "completed",
+              tokens_in: Number(tokensIn) || 0,
+              tokens_out: Number(tokensOut) || 0,
+              tokens_saved: Number(tokensSaved) || 0,
+              burned_micros: planned.burned_micros,
+              created_at: prev.created_at || new Date().toISOString(),
+              completed_at: new Date().toISOString(),
+              response_expires_at: expiresAt,
+              ...(replay ? { response: replay } : {}),
+              lease_until: null,
+            },
+            { merge: true }
+          );
+          return {
+            ...planned,
+            already: false,
+            request_id: rid,
+            fingerprint: fp,
+            response: replay,
+          };
+        }
+
+        // Already completed — optional response backfill.
         if (replay && !prev.response) {
-          tx.set(usageRef, { response: replay }, { merge: true });
+          tx.set(
+            usageRef,
+            { response: replay, response_expires_at: expiresAt, status: "completed" },
+            { merge: true }
+          );
         }
         return {
           burned_micros: Number(prev.burned_micros || 0),
@@ -551,11 +599,14 @@ async function applyUsageAndBurn({
           uid,
           request_id: rid,
           fingerprint: fp,
+          status: "completed",
           tokens_in: Number(tokensIn) || 0,
           tokens_out: Number(tokensOut) || 0,
           tokens_saved: Number(tokensSaved) || 0,
           burned_micros: planned.burned_micros,
           created_at: new Date().toISOString(),
+          completed_at: new Date().toISOString(),
+          response_expires_at: expiresAt,
           ...(replay ? { response: replay } : {}),
         },
         { merge: false }
@@ -572,35 +623,13 @@ async function applyUsageAndBurn({
     if (err.paywall || err.code === "free_quota_exhausted" || err.code === "credits_exhausted" || err.code === "idempotency_conflict") {
       throw err;
     }
-    // Any Firestore outage (disabled API, timeout, permission) must not 100%-down compress.
-    console.warn(
-      "billing-ledger: Firestore txn failed — claims/gist billing fallback:",
+    // Money path is fail-closed — never bill via non-transactional Auth claims.
+    console.error(
+      "billing-ledger: Firestore txn failed (fail-closed):",
       err?.code,
       err?.message || err
     );
-    try {
-      return await applyUsageAndBurnClaimsFallback({
-        uid,
-        tokensIn,
-        tokensOut,
-        tokensSaved,
-        claims,
-        requestId: rid,
-        fingerprint: fp,
-        response,
-      });
-    } catch (fallbackErr) {
-      if (
-        fallbackErr.paywall ||
-        fallbackErr.code === "free_quota_exhausted" ||
-        fallbackErr.code === "credits_exhausted" ||
-        fallbackErr.code === "idempotency_conflict"
-      ) {
-        throw fallbackErr;
-      }
-      console.error("billing-ledger claims fallback failed:", fallbackErr?.message || fallbackErr);
-      throw billingError("billing_unavailable", "Billing ledger unavailable");
-    }
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
 
   if (!result.already) {
@@ -610,98 +639,10 @@ async function applyUsageAndBurn({
 }
 
 /**
- * When Cloud Firestore is disabled/unavailable, credit via Auth claims only.
- * Idempotent on sc_credited_sessions / credited_keys. First-pay bonus uses
- * sc_first_pay_bonus_at (weaker than Firestore billing_bonus, but keeps Checkout
- * from silently charging without balance when Firestore is down).
- */
-async function creditBalanceClaimsFallback({
-  uid,
-  creditUsd,
-  creditKey,
-  claims = {},
-  patch = {},
-  firstPayBonusUsd = 0,
-}) {
-  const key = String(creditKey);
-  const fresh = await admin().auth().getUser(uid);
-  const liveClaims = { ...(fresh.customClaims || {}), ...claims };
-  const credited = Array.isArray(liveClaims.sc_credited_sessions)
-    ? liveClaims.sc_credited_sessions
-    : [];
-  const ledger = normalizeLedger(null, liveClaims);
-  const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
-
-  if (credited.includes(key) || keys.includes(key)) {
-    return {
-      applied: true,
-      already: true,
-      ledger,
-      balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-      credit_usd: 0,
-      bonus_usd: 0,
-      backend: "claims-fallback",
-    };
-  }
-
-  const paymentUsd = Number(creditUsd) || 0;
-  const wantBonus = Math.max(0, Number(firstPayBonusUsd) || 0);
-  const bonusUsd = wantBonus > 0 && !liveClaims.sc_first_pay_bonus_at ? wantBonus : 0;
-  const add = usdToMicros(paymentUsd + bonusUsd);
-  ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
-  if (patch.credit_limit_usd != null) {
-    ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
-  }
-  if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
-  if (patch.customer_id) ledger.customer_id = patch.customer_id;
-  ledger.credited_keys = [...keys.filter((k) => k !== key).slice(-39), key];
-  ledger.updated_at = new Date().toISOString();
-
-  const nextCredited = [...credited.filter((k) => k !== key).slice(-39), key];
-  const bonusPatch =
-    bonusUsd > 0
-      ? {
-          sc_first_pay_bonus_at: new Date().toISOString(),
-          sc_first_pay_bonus_usd: bonusUsd,
-        }
-      : {};
-
-  await admin().auth().setCustomUserClaims(uid, {
-    ...liveClaims,
-    sc_plan: liveClaims.sc_plan || "payg",
-    sc_metered: false,
-    sc_usage: {
-      month: ledger.month,
-      requests: ledger.requests,
-      tokens_in: ledger.tokens_in,
-      tokens_out: ledger.tokens_out,
-      tokens_saved: ledger.tokens_saved,
-      tokens_reported: ledger.tokens_reported || 0,
-    },
-    sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-    sc_credit_limit_usd: ledger.credit_limit_usd,
-    sc_auto_recharge: Boolean(ledger.auto_recharge),
-    sc_credited_sessions: nextCredited,
-    ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
-    ...bonusPatch,
-  });
-
-  return {
-    applied: true,
-    already: false,
-    ledger,
-    balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-    credit_usd: paymentUsd,
-    bonus_usd: bonusUsd,
-    backend: "claims-fallback",
-  };
-}
-
-/**
  * Credit prepaid balance. Idempotent via permanent billing_credits/{creditKey}.
  * Optional first-pay bonus is create-once via billing_bonus/{uid}:first_pay
  * (not Auth claims — avoids concurrent Checkout double-bonus races).
- * Falls back to Auth claims when Cloud Firestore is disabled/unavailable.
+ * Fail-closed when Firestore is unavailable (no Auth-claims billing ledger).
  *
  * @param {number} [firstPayBonusUsd=0] candidate bonus; txn grants at most once ever
  */
@@ -714,7 +655,9 @@ async function creditBalance({
   firstPayBonusUsd = 0,
 }) {
   if (!uid || !creditKey) return { applied: false, reason: "missing_args" };
-  if (!initFirebaseAdmin()) return { applied: false, reason: "firebase_unavailable" };
+  if (!initFirebaseAdmin()) {
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
+  }
 
   const ref = db().collection("billing").doc(uid);
   const creditRef = db().collection("billing_credits").doc(String(creditKey));
@@ -791,19 +734,12 @@ async function creditBalance({
       };
     });
   } catch (err) {
-    console.warn(
-      "billing-ledger: credit txn failed — claims credit fallback:",
+    console.error(
+      "billing-ledger: credit txn failed (fail-closed):",
       err?.code,
       err?.message || err
     );
-    return creditBalanceClaimsFallback({
-      uid,
-      creditUsd,
-      creditKey,
-      claims,
-      patch,
-      firstPayBonusUsd,
-    });
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
 
   // Patch payg flags only when this credit actually applied (not on replay).
@@ -896,6 +832,8 @@ module.exports = {
   lookupUsageReplay,
   sanitizeReplayResponse,
   creditBalance,
+  reserveIdempotencyLease,
+  releaseIdempotencyLease,
   acquireRechargeLock,
   markTokensReported,
   mirrorClaims,
@@ -908,4 +846,6 @@ module.exports = {
   computeCompressFingerprint,
   assertUsageIdempotencyMatch,
   FREE_TOKENS_PER_MONTH,
+  REPLAY_TTL_MS,
+  IDEMPOTENCY_LEASE_MS,
 };

--- a/api/account.js
+++ b/api/account.js
@@ -1,4 +1,4 @@
-const { json, readBody, checkRateLimit, softProbe, hasAuthCredentials } = require("./_lib/http");
+const { json, readBody, checkRateLimit } = require("./_lib/http");
 const { verifyUser, bearerToken } = require("./_lib/auth");
 const { KEY_PREFIX } = require("./_lib/keys");
 const { createKey, revokeKey, listKeys, authenticateKey } = require("./_lib/firebase-key-store");
@@ -268,7 +268,7 @@ async function handleConnectDevice(req, res) {
     }
   }
 
-  if (req.method !== "POST") return softProbe(res, "Method not allowed");
+  if (req.method !== "POST") return json(res, 405, { detail: "Method not allowed" });
 
   try {
     const user = await verifyUser(req);
@@ -312,10 +312,10 @@ async function handleConnectDevice(req, res) {
 }
 
 async function handleUsage(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed");
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
 
   try {
-    const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization) || (req.query && req.query.api_key);
+    const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization);
     let ownerUid;
     let owner;
     if (raw && raw.startsWith(KEY_PREFIX)) {
@@ -402,14 +402,14 @@ async function handleUsage(req, res) {
   } catch (err) {
     // Unauthenticated scanner GETs — soft 200 so Observability error rate stays honest.
     if ((err.status || 401) === 401) {
-      return json(res, 200, { ok: false, auth: "required", detail: err.message || "Authorization required" });
+      return json(res, 401, { ok: false, auth: "required", detail: err.message || "Authorization required" });
     }
     return json(res, err.status || 500, { detail: err.message });
   }
 }
 
 async function resolveOwnerFromReq(req) {
-  const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization) || (req.query && req.query.api_key);
+  const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization);
   if (raw && String(raw).startsWith(KEY_PREFIX)) {
     const authenticated = await authenticateKey(raw);
     return {
@@ -425,7 +425,7 @@ async function resolveOwnerFromReq(req) {
 }
 
 async function handleMe(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed");
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
   try {
     const { uid, owner, via, key_prefix } = await resolveOwnerFromReq(req);
     const { loadAgentPluginLink, loadCodingAgentUsage } = require("./_lib/store");
@@ -479,14 +479,14 @@ async function handleMe(req, res) {
     });
   } catch (err) {
     if ((err.status || 401) === 401) {
-      return json(res, 200, { ok: false, auth: "required", detail: err.message || "Authorization required" });
+      return json(res, 401, { ok: false, auth: "required", detail: err.message || "Authorization required" });
     }
     return json(res, err.status || 500, { detail: err.message });
   }
 }
 
 async function handleCompressLog(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed");
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
   try {
     const { uid } = await resolveOwnerFromReq(req);
     const limit = Number(req.query?.limit) || 40;
@@ -495,14 +495,14 @@ async function handleCompressLog(req, res) {
     return json(res, 200, { owner_uid: uid, ...data });
   } catch (err) {
     if ((err.status || 401) === 401) {
-      return json(res, 200, { ok: false, auth: "required", detail: err.message || "Authorization required" });
+      return json(res, 401, { ok: false, auth: "required", detail: err.message || "Authorization required" });
     }
     return json(res, err.status || 500, { detail: err.message });
   }
 }
 
 async function handleAuthStatus(req, res) {
-  if (req.method !== "GET") return softProbe(res, "Method not allowed");
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed" });
 
   const hasJson = Boolean(process.env.FIREBASE_SERVICE_ACCOUNT_JSON?.trim());
   const hasParts = Boolean(
@@ -553,10 +553,7 @@ module.exports = async (req, res) => {
     }
   }
   if (op === "welcome-pending" && req.method === "GET") {
-    if (!drainSecretOk(req)) {
-      if (!hasDrainCredentials(req)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req)) return json(res, 401, { detail: "Unauthorized" });
     try {
       const pending = await listPendingWelcomes();
       return json(res, 200, { pending, count: pending.length });
@@ -566,10 +563,7 @@ module.exports = async (req, res) => {
   }
   if (op === "welcome-mark" && req.method === "POST") {
     const body = readBody(req);
-    if (!drainSecretOk(req, body)) {
-      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
     const uid = String(body.uid || "").trim();
     if (!uid) return json(res, 422, { detail: "uid required" });
     const status = body.status === "failed" ? "failed" : "sent";
@@ -587,10 +581,7 @@ module.exports = async (req, res) => {
   }
   if (op === "welcome-drain" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) {
-      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
     try {
       const result = await drainPendingWelcomes();
       let power_user = null;
@@ -615,10 +606,7 @@ module.exports = async (req, res) => {
   // Weekly product emails to all users
   if (op === "weekly-tick" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) {
-      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
     try {
       const force = String(body.force || req.query?.force || "").trim();
       return json(res, 200, await weeklyTick(force ? { force } : {}));
@@ -628,10 +616,7 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-enqueue" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) {
-      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
     try {
       const force = String(body.force || req.query?.force || "").trim();
       const defaultId =
@@ -649,10 +634,7 @@ module.exports = async (req, res) => {
     }
   }
   if (op === "weekly-pending" && req.method === "GET") {
-    if (!drainSecretOk(req)) {
-      if (!hasDrainCredentials(req)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req)) return json(res, 401, { detail: "Unauthorized" });
     try {
       // Always include branded HTML — Resend + preview tooling need it (plain text alone looks unstyled).
       const pending = await listPendingWeekly(req.query?.campaign_id || null, {
@@ -669,10 +651,7 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-drain" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
-    if (!drainSecretOk(req, body)) {
-      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
     try {
       const limit = Number(body.limit || req.query?.limit || 0) || undefined;
       return json(res, 200, {
@@ -685,10 +664,7 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-mark" && req.method === "POST") {
     const body = readBody(req);
-    if (!drainSecretOk(req, body)) {
-      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
     const key = String(body.key || "").trim();
     if (!key) return json(res, 422, { detail: "key required" });
     const status = body.status === "failed" ? "failed" : "sent";
@@ -706,10 +682,7 @@ module.exports = async (req, res) => {
   }
   if (op === "weekly-mark-campaign" && req.method === "POST") {
     const body = readBody(req);
-    if (!drainSecretOk(req, body)) {
-      if (!hasDrainCredentials(req, body)) return softProbe(res, "Unauthorized", { auth: "required" });
-      return json(res, 401, { detail: "Unauthorized" });
-    }
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
     const campaignId = String(body.campaign_id || "").trim();
     if (!campaignId) return json(res, 422, { detail: "campaign_id required" });
     const status = body.status === "failed" ? "failed" : "sent";
@@ -772,14 +745,6 @@ module.exports = async (req, res) => {
       }
       return json(res, 200, await unsubscribeEmail(email, token));
     } catch (err) {
-      // Scanner / empty query → soft 200 (Observability). Real broken tokens stay 401.
-      const msg = String(err.message || "");
-      if (!email || /invalid email/i.test(msg)) {
-        return softProbe(res, err.message || "Invalid email");
-      }
-      if (!token && !hasAuthCredentials(req)) {
-        return softProbe(res, "Unsubscribe token required", { auth: "required" });
-      }
       // Broken / missing token → tell the client to request a fresh signed link (do not unsub).
       if (err.status === 401 || err.code === "invalid_token") {
         return json(res, 401, {

--- a/api/affiliates.js
+++ b/api/affiliates.js
@@ -12,7 +12,7 @@
  */
 
 const crypto = require("crypto");
-const { json, readBody, checkRateLimit, jsonWithRateLimit, softProbe, hasAuthCredentials } = require("./_lib/http");
+const { json, readBody, checkRateLimit, jsonWithRateLimit, hasAuthCredentials } = require("./_lib/http");
 const { loadStore, mutateStore } = require("./_lib/store");
 const { verifyUser } = require("./_lib/auth");
 const { checkDurableRateLimit } = require("./_lib/rate-limit-durable");
@@ -178,7 +178,7 @@ module.exports = async (req, res) => {
     return handleList(req, res);
   }
 
-  return softProbe(res, "Method not allowed", { allow: "GET, POST" });
+  return json(res, 405, { detail: "Method not allowed", allow: "GET, POST" });
 };
 
 /* ── Public register (from affiliates.html) ── */
@@ -188,10 +188,10 @@ async function handlePublicRegister(req, res, body) {
     const { name, email, website, audience } = body;
     if (!name || !email) {
       // Empty scanner POSTs — soft 200 (Observability error rate).
-      return softProbe(res, "Name and email are required.");
+      return json(res, 400, { detail: "Name and email are required." });
     }
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      return softProbe(res, "Invalid email address.");
+      return json(res, 400, { detail: "Invalid email address." });
     }
 
     const cleanName = name.trim().slice(0, 120);
@@ -318,7 +318,7 @@ async function handleClaim(req, res, body) {
       user = await verifyUser(req);
     } catch {
       if (!hasAuthCredentials(req)) {
-        return softProbe(res, "Sign in required to claim a referral.", { auth: "required" });
+        return json(res, 401, { detail: "Sign in required to claim a referral." });
       }
       return json(res, 401, { detail: "Sign in required to claim a referral." });
     }
@@ -521,9 +521,6 @@ async function handleMeView(req, res) {
 
     return json(res, 200, { affiliate, stats, is_founder: isFounder });
   } catch (err) {
-    if ((err.status || 401) === 401 && !hasAuthCredentials(req)) {
-      return softProbe(res, err.message || "Authorization required", { auth: "required" });
-    }
     return json(res, err.status || 500, {
       detail: err.message || "Failed to get stats.",
     });
@@ -583,9 +580,6 @@ async function handleAdminView(req, res) {
       ),
     });
   } catch (err) {
-    if ((err.status || 401) === 401 && !hasAuthCredentials(req)) {
-      return softProbe(res, err.message || "Authorization required", { auth: "required" });
-    }
     return json(res, err.status || 500, {
       detail: err.message || "Failed to load admin view.",
     });

--- a/api/billing.js
+++ b/api/billing.js
@@ -9,7 +9,7 @@
  *   { action: "reconcile_checkout", session_id } → apply paid credit session (webhook fallback)
  *   { action: "portal" } | { action: "cancel" | "reactivate" }
  */
-const { json, softProbe, hasAuthCredentials } = require("./_lib/http");
+const { json } = require("./_lib/http");
 const { verifyUser, initFirebaseAdmin } = require("./_lib/auth");
 const admin = require("firebase-admin");
 const {
@@ -565,13 +565,9 @@ module.exports = async (req, res) => {
     if (req.method === "GET") return handleGet(req, res, user);
     if (req.method === "POST") return handlePost(req, res, user);
 
-    return softProbe(res, "Method not allowed", { allow: "GET, POST" });
+    return json(res, 405, { detail: "Method not allowed", allow: "GET, POST" });
   } catch (err) {
     const status = err.status || 500;
-    // Scanner without auth — soft 200 so Observability error rate stays ~0.
-    if (status === 401 && !hasAuthCredentials(req)) {
-      return softProbe(res, err.message || "Authorization required", { auth: "required" });
-    }
     if (status >= 500) console.error("billing error:", err);
     else console.warn("billing client error:", err.message || err);
     return json(res, status, { detail: err.message || String(err) });

--- a/api/demo/compress.js
+++ b/api/demo/compress.js
@@ -2,7 +2,7 @@
  * Public demo compress — compiler mode, no API key.
  * Rate-limited: 30 req/min per IP (memory + durable when Firestore is up).
  */
-const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody, softProbe } = require("../_lib/http");
+const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody } = require("../_lib/http");
 const { checkDurableRateLimit } = require("../_lib/rate-limit-durable");
 const { compressAdaptive, getEngine } = require("../_lib/engine");
 
@@ -32,7 +32,7 @@ function envForTokenCount(tokenCount) {
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
   if (req.method !== "POST") {
-    return softProbe(res, "Method not allowed", { allow: "POST" });
+    return json(res, 405, { detail: "Method not allowed", allow: "POST" });
   }
 
   // ── Rate limit by IP (memory + durable when available) ──
@@ -66,7 +66,7 @@ module.exports = async (req, res) => {
     const query = body.query || "Summarize this context.";
 
     if (!context.trim()) {
-      return softProbe(res, "context required");
+      return jsonWithRateLimit(res, 422, { detail: "context required" }, rl);
     }
     if (context.length > DEMO_MAX_CHARS) return jsonWithRateLimit(res, 422, {
       detail: `context too long (${DEMO_MAX_CHARS / 1000}k max for demo)`

--- a/api/firebase-config.js
+++ b/api/firebase-config.js
@@ -1,5 +1,5 @@
 /** Public Firebase client config — read from env at runtime (no rebuild needed). */
-const { json, softProbe } = require("./_lib/http");
+const { json } = require("./_lib/http");
 
 function clean(value) {
   return String(value || "").trim().split(/\s+/)[0] || "";
@@ -7,7 +7,7 @@ function clean(value) {
 
 module.exports = (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
-  if (req.method !== "GET") return softProbe(res, "Method not allowed", { allow: "GET" });
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed", allow: "GET" });
 
   return json(res, 200, {
     apiKey: clean(process.env.FIREBASE_API_KEY),

--- a/api/health.js
+++ b/api/health.js
@@ -1,4 +1,4 @@
-const { json, softProbe } = require("./_lib/http");
+const { json } = require("./_lib/http");
 
 function normalizeDomain(value) {
   const raw = String(value || '').trim();
@@ -60,6 +60,6 @@ async function scoreWithContextDev(req, res) {
 module.exports = (req, res) => {
   if (req.query?.op === 'aiscore') return scoreWithContextDev(req, res);
   if (req.method === "OPTIONS") return json(res, 204, {});
-  if (req.method !== "GET") return softProbe(res, "Method not allowed", { allow: "GET" });
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed", allow: "GET" });
   return json(res, 200, { ok: true, service: "supercompress-vercel" });
 };

--- a/api/keys.js
+++ b/api/keys.js
@@ -1,4 +1,4 @@
-const { json, softProbe, hasAuthCredentials } = require("./_lib/http");
+const { json } = require("./_lib/http");
 const { verifyUser } = require("./_lib/auth");
 const { getPlan } = require("./_lib/stripe");
 const { listKeys, createKey } = require("./_lib/firebase-key-store");
@@ -55,13 +55,9 @@ module.exports = async (req, res) => {
       return json(res, 200, await createKey(user.uid, name, plan.max_keys));
     }
 
-    return softProbe(res, "Method not allowed", { allow: "GET, POST" });
+    return json(res, 405, { detail: "Method not allowed", allow: "GET, POST" });
   } catch (err) {
     const status = err.status || 500;
-    // Scanner GETs/POSTs without auth — soft 200 (Vercel Observability error rate).
-    if (status === 401 && !hasAuthCredentials(req)) {
-      return softProbe(res, err.message || "Authorization required", { auth: "required" });
-    }
     return json(res, status, { detail: err.message });
   }
 };

--- a/api/keys/[id].js
+++ b/api/keys/[id].js
@@ -1,4 +1,4 @@
-const { json, softProbe, hasAuthCredentials } = require("../_lib/http");
+const { json } = require("../_lib/http");
 const { verifyUser } = require("../_lib/auth");
 const {
   getOwnedKey,
@@ -12,7 +12,7 @@ module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
 
   const keyId = req.query?.id;
-  if (!keyId) return softProbe(res, "Key id required");
+  if (!keyId) return json(res, 400, { detail: "Key id required" });
 
   try {
     const user = await verifyUser(req);
@@ -36,12 +36,9 @@ module.exports = async (req, res) => {
       return json(res, 200, { revoked: true });
     }
 
-    return softProbe(res, "Method not allowed", { allow: "GET, PATCH, DELETE" });
+    return json(res, 405, { detail: "Method not allowed", allow: "GET, PATCH, DELETE" });
   } catch (err) {
     const status = err.status || 500;
-    if (status === 401 && !hasAuthCredentials(req)) {
-      return softProbe(res, err.message || "Authorization required", { auth: "required" });
-    }
     return json(res, status, { detail: err.message });
   }
 };

--- a/api/me.js
+++ b/api/me.js
@@ -1,19 +1,16 @@
-const { json, softProbe, hasAuthCredentials } = require("./_lib/http");
+const { json } = require("./_lib/http");
 const { verifyUser } = require("./_lib/auth");
 
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
   if (req.method !== "GET") {
-    return softProbe(res, "Method not allowed", { allow: "GET" });
+    return json(res, 405, { detail: "Method not allowed", allow: "GET" });
   }
   try {
     const user = await verifyUser(req);
     return json(res, 200, { uid: user.uid, email: user.email });
   } catch (err) {
     const status = err.status || 401;
-    if (status === 401 && !hasAuthCredentials(req)) {
-      return softProbe(res, err.message || "Authorization required", { auth: "required" });
-    }
     return json(res, status, { detail: err.message });
   }
 };

--- a/api/retrieve.js
+++ b/api/retrieve.js
@@ -9,7 +9,7 @@
  * that stored the hash may retrieve it.
  */
 
-const { json, checkRateLimit, readBody, softProbe, hasAuthCredentials } = require("./_lib/http");
+const { json, checkRateLimit, readBody } = require("./_lib/http");
 const { bearerToken } = require("./_lib/auth");
 const { KEY_PREFIX } = require("./_lib/keys");
 const { authenticateKey } = require("./_lib/firebase-key-store");
@@ -61,12 +61,8 @@ module.exports = async (req, res) => {
 
   try {
     const raw = req.headers["x-api-key"]
-      || bearerToken(req.headers.authorization)
-      || (req.query && req.query.api_key);
+      || bearerToken(req.headers.authorization);
     if (!raw || !raw.startsWith(KEY_PREFIX)) {
-      if (!hasAuthCredentials(req) || req.method === "GET") {
-        return softProbe(res, "Pass X-API-Key to retrieve CCR blocks.", { auth: "required" });
-      }
       return json(res, 401, { detail: "Missing or invalid API key" });
     }
 
@@ -86,11 +82,11 @@ module.exports = async (req, res) => {
       const body = readBody(req);
       hash = body.hash || "";
     } else {
-      return softProbe(res, "Method not allowed", { allow: "GET, POST" });
+      return json(res, 405, { detail: "Method not allowed", allow: "GET, POST" });
     }
 
     if (!hash || !isValidHash(hash)) {
-      return softProbe(res, "Invalid hash format. Expected format: 8-hex-chars_hex-length (e.g. 'a1b2c3d4_2f')");
+      return json(res, 400, { detail: "Invalid hash format. Expected format: 8-hex-chars_hex-length (e.g. 'a1b2c3d4_2f')" });
     }
 
     const authenticated = await authenticateKey(raw);

--- a/api/stats.js
+++ b/api/stats.js
@@ -5,7 +5,7 @@
  * reinstalls inflate that number. Signed-up users = Firebase Auth accounts
  * with an email (real humans who finished dashboard / setup connect).
  */
-const { json, softProbe } = require("./_lib/http");
+const { json } = require("./_lib/http");
 const { initFirebaseAdmin } = require("./_lib/auth");
 const admin = require("firebase-admin");
 
@@ -50,7 +50,7 @@ function fmtDownloads(n) {
 
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
-  if (req.method !== "GET") return softProbe(res, "Method not allowed", { allow: "GET" });
+  if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed", allow: "GET" });
 
   try {
     if (cache.payload && Date.now() - cache.at < CACHE_MS) {

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -3,7 +3,7 @@
  * Authenticated compression endpoint.
  * Rate-limited: 120 req/min per API key + monthly plan token limit.
  */
-const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody, softProbe, hasAuthCredentials } = require("../_lib/http");
+const { json, jsonWithRateLimit, checkRateLimit, clientIp, readBody } = require("../_lib/http");
 const { enforceRateLimits } = require("../_lib/rate-limit-durable");
 const { bearerToken } = require("../_lib/auth");
 const { KEY_PREFIX } = require("../_lib/keys");
@@ -24,6 +24,8 @@ const {
   computeCompressFingerprint,
   lookupUsageReplay,
   assertUsageIdempotencyMatch,
+  reserveIdempotencyLease,
+  releaseIdempotencyLease,
 } = require("../_lib/billing-ledger");
 
 const V1_RPM = 90; // per API key (in-memory fast path)
@@ -161,27 +163,25 @@ module.exports = async (req, res) => {
   // Compression is POST-only — never accept API keys or context in query strings.
   // Scanner GETs must not inflate Vercel Observability error rate.
   if (req.method === "GET") {
-    return softProbe(res,
-      "Use POST /api/v1/compress with X-API-Key (or Authorization: Bearer). Query-string keys/context are not supported.",
-      { allow: "POST" }
-    );
+    return json(res, 405, {
+      detail: "Use POST /api/v1/compress with X-API-Key (or Authorization: Bearer). Query-string keys/context are not supported.",
+      allow: "POST",
+    });
   }
   if (req.method !== "POST") {
-    return softProbe(res, "Method not allowed", { allow: "POST" });
+    return json(res, 405, { detail: "Method not allowed", allow: "POST" });
   }
 
   const requestStarted = Date.now();
   // Leave headroom under function maxDuration (60s for this route) for response flush.
   const HARD_BUDGET_MS = 55_000;
   let requestId = null;
+  let leaseHeld = false;
+  let leaseOwnerUid = null;
 
   try {
     const raw = req.headers["x-api-key"] || bearerToken(req.headers.authorization);
     if (!raw || !raw.startsWith(KEY_PREFIX)) {
-      // No credentials at all = probe; present-but-wrong = real 401 for SDKs.
-      if (!hasAuthCredentials(req)) {
-        return softProbe(res, "Missing or invalid API key", { auth: "required" });
-      }
       return json(res, 401, { detail: "Missing or invalid API key" });
     }
 
@@ -274,25 +274,16 @@ module.exports = async (req, res) => {
 
     const authenticated = await withTimeout(authenticateKey(raw), 8000, "authenticate");
 
-    // Replay BEFORE quota/credit gates so a successfully billed request stays
-    // replayable after free quota is exhausted (and does not trigger auto-recharge).
+    // Single-flight lease BEFORE compress so concurrent identical Idempotency-Keys
+    // cannot run the engine N times. Completed rows replay; in-flight returns 409.
     if (clientIdem) {
-      const prev = await withTimeout(
-        lookupUsageReplay(authenticated.ownerUid, clientIdem),
-        3000,
-        "idempotency_lookup"
+      const lease = await withTimeout(
+        reserveIdempotencyLease(authenticated.ownerUid, clientIdem, fingerprint),
+        4000,
+        "idempotency_lease"
       );
-      if (prev) {
-        try {
-          assertUsageIdempotencyMatch(prev, {
-            fingerprint,
-            tokensIn: prev.tokens_in,
-            tokensOut: prev.tokens_out,
-            tokensSaved: prev.tokens_saved,
-          });
-        } catch (err) {
-          throw err;
-        }
+      if (lease.status === "completed") {
+        const prev = lease.data || {};
         if (prev.response?.compressed_text) {
           res.setHeader("Idempotency-Key", requestId);
           return jsonWithRateLimit(
@@ -306,6 +297,18 @@ module.exports = async (req, res) => {
             rl
           );
         }
+        // Billed but replay body expired — fall through to recompute without re-billing
+        // (applyUsageAndBurn will see completed row and already:true).
+      } else if (lease.status === "pending") {
+        const err = new Error(
+          "A request with this Idempotency-Key is already in progress. Retry shortly."
+        );
+        err.status = 409;
+        err.code = "idempotency_in_progress";
+        throw err;
+      } else {
+        leaseHeld = true;
+        leaseOwnerUid = authenticated.ownerUid;
       }
     }
 
@@ -510,6 +513,11 @@ module.exports = async (req, res) => {
     res.setHeader("Idempotency-Key", requestId);
     return jsonWithRateLimit(res, 200, responseBody, rl);
   } catch (err) {
+    if (leaseHeld && leaseOwnerUid && requestId) {
+      try {
+        await releaseIdempotencyLease(leaseOwnerUid, requestId);
+      } catch (_) {}
+    }
     let status = err.status || 500;
     if (err.code === "timeout" && !err.status) status = 504;
     // Expected auth/validation failures are not production incidents — avoid

--- a/packages/proxy/bin/supercompress.js
+++ b/packages/proxy/bin/supercompress.js
@@ -656,7 +656,7 @@ async function printAccount() {
   printPlanStatus(data);
 
   try {
-    const log = await fetchJson(`${ACTIVITY_URL}?limit=5`, config.api_key);
+    const log = await fetchJson(`${ACTIVITY_URL}&limit=5`, config.api_key);
     const entries = log.entries || [];
     if (entries.length) {
       console.log("\n  Recent compress activity (previews only):");

--- a/packages/proxy/src/service.js
+++ b/packages/proxy/src/service.js
@@ -66,6 +66,15 @@ function launchdPlist(configDir, configPath) {
 </plist>`;
 }
 
+function systemdEscape(pathValue) {
+  // systemd unit values with spaces/special chars must be quoted.
+  const s = String(pathValue || "");
+  if (/[\s\\"'`$]/.test(s)) {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return s;
+}
+
 /**
  * Generate the systemd user unit content for Linux.
  * API key is NOT stored in the unit — the server reads it from
@@ -74,18 +83,21 @@ function launchdPlist(configDir, configPath) {
 function systemdUnit(configDir, configPath) {
   const serverPath = path.join(__dirname, "server.js");
   const nodePath = process.execPath || "/usr/bin/node";
+  const execStart = [nodePath, serverPath, "8080"].map(systemdEscape).join(" ");
+  const envDir = systemdEscape(configDir);
+  const logPath = systemdEscape(path.join(configDir, "proxy.log"));
   return `[Unit]
 Description=SuperCompress Proxy — LLM context compression for coding agents
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=${nodePath} ${serverPath} 8080
+ExecStart=${execStart}
 Restart=on-failure
 RestartSec=5
-Environment=SUPERCOMPRESS_CONFIG_DIR=${configDir}
-StandardOutput=append:${configDir}/proxy.log
-StandardError=append:${configDir}/proxy.log
+Environment=SUPERCOMPRESS_CONFIG_DIR=${envDir}
+StandardOutput=append:${logPath}
+StandardError=append:${logPath}
 
 [Install]
 WantedBy=default.target

--- a/packages/proxy/tui/sc.ts
+++ b/packages/proxy/tui/sc.ts
@@ -276,7 +276,7 @@ export async function fetchAccount(): Promise<AccountSnap> {
     const data = await fetchJson(ME_URL, cfg.api_key)
     const activity: AccountSnap["activity"] = []
     try {
-      const log = await fetchJson(`${ACTIVITY_URL}?limit=8`, cfg.api_key)
+      const log = await fetchJson(`${ACTIVITY_URL}&limit=8`, cfg.api_key)
       for (const e of ((log.entries as unknown[]) || []).slice(0, 8) as Record<string, unknown>[]) {
         activity.push({
           at: String(e.at || "?"),

--- a/scripts/prod-smoke.sh
+++ b/scripts/prod-smoke.sh
@@ -134,9 +134,8 @@ check "auth-status" 200 "$WWW/api/auth-status"
 expect_body "auth-status firestore" '"storage":"firestore"' "$TMP/body"
 check "firebase-config" 200 "$WWW/api/firebase-config"
 expect_body "firebase-config key" 'apiKey' "$TMP/body"
-check "usage requires auth" 200 "$WWW/api/usage"
-expect_body "usage auth" 'auth' "$TMP/body"
-check "billing requires auth" 200 "$WWW/api/billing"
+check "usage requires auth" 401 "$WWW/api/usage"
+check "billing requires auth" 401 "$WWW/api/billing"
 
 # Compress entrypoints (must reject missing key, never 5xx / DEPLOYMENT_NOT_FOUND)
 COMPRESS_JSON='{"context":"production smoke context for supercompress","query":"smoke"}'


### PR DESCRIPTION
## Summary
- **Money path:** remove Auth-claims billing fallback. Firestore unavailable → `billing_unavailable` (fail closed). Claims are mirror-only after successful Firestore commits.
- **HTTP contracts:** restore 401/405/422 on known API routes (`/api/v1/compress`, usage, billing, keys, retrieve, etc.). Soft-200 remains only for `/api/soft-probe` + scanner/unknown catch-all.
- **Idempotency:** `reserveIdempotencyLease` before compress (90s pending); concurrent same key → 409; release on failure. Replay body TTL 48h via `response_expires_at`.
- **Orange:** TUI `&limit=`, systemd path escaping (#66), header-only API keys (no `?api_key=`).

Does **not** merge #77/#78/#79. Store centralization / weekly_emails migration left for a later PR.

## Test plan
- [x] `node api/_lib/billing-ledger.test.js`
- [x] `node api/_lib/http-soft-probe.test.js`
- [ ] CI green
- [ ] After deploy: `bash scripts/prod-smoke.sh` expects 401 on unauth compress / usage / billing and 405 on GET compress
- [ ] With Idempotency-Key: second concurrent request returns 409 while first in flight; replay after complete
- [ ] Firestore down: compress/credit returns 503-class billing_unavailable (no silent underbilling)


Made with [Cursor](https://cursor.com)