### PR TITLE
fix: default auto-recharge ON (works without Firestore)

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -141,7 +141,14 @@ function emptyLedger(claims = {}) {
       claims.sc_credit_limit_usd,
       DEFAULT_CREDIT_LIMIT_USD
     ),
-    auto_recharge: Boolean(claims.sc_auto_recharge),
+    auto_recharge:
+      claims.sc_auto_recharge == null
+        ? Boolean(
+            claims.sc_customer_id ||
+              isCreditWallet(claims) ||
+              isPaygEnabled(claims.sc_plan)
+          )
+        : Boolean(claims.sc_auto_recharge),
     customer_id: claims.sc_customer_id || null,
     // Display-only recent keys; idempotency is billing_credits/{id}
     credited_keys: Array.isArray(claims.sc_credited_sessions)
@@ -1122,31 +1129,42 @@ async function creditBalance({
 }
 
 async function acquireRechargeLock(uid) {
-  if (!uid || !initFirebaseAdmin()) return { acquired: false, reason: "unavailable" };
-  const ref = db().collection("billing_locks").doc(uid);
-  const now = Date.now();
-  const until = now + 90_000;
+  // Stripe PaymentIntent idempotency keys already dedupe charges — when Firestore
+  // is down, do not block auto-recharge behind a lock we cannot write.
+  const unlocked = {
+    acquired: true,
+    backend: "unlocked",
+    async release() {},
+  };
+  if (!uid || !initFirebaseAdmin()) return unlocked;
   try {
-    const acquired = await db().runTransaction(async (tx) => {
-      const snap = await tx.get(ref);
-      const data = snap.exists ? snap.data() : null;
-      if (data?.until && Number(data.until) > now && data.kind === "recharge") {
-        return false;
-      }
-      tx.set(ref, { kind: "recharge", until, updated_at: new Date().toISOString() });
-      return true;
-    });
-    return {
-      acquired,
-      async release() {
-        try {
-          await ref.delete();
-        } catch {}
-      },
-    };
+    return await withFirestoreTimeout(async () => {
+      const ref = db().collection("billing_locks").doc(uid);
+      const now = Date.now();
+      const until = now + 90_000;
+      const acquired = await db().runTransaction(async (tx) => {
+        const snap = await tx.get(ref);
+        const data = snap.exists ? snap.data() : null;
+        if (data?.until && Number(data.until) > now && data.kind === "recharge") {
+          return false;
+        }
+        tx.set(ref, { kind: "recharge", until, updated_at: new Date().toISOString() });
+        return true;
+      });
+      return {
+        acquired,
+        backend: "firestore",
+        async release() {
+          try {
+            await ref.delete();
+          } catch {}
+        },
+      };
+    }, 1200);
   } catch (err) {
-    console.warn("recharge lock failed:", err.message || err);
-    return { acquired: false, reason: err.message };
+    markFirestoreDown(err);
+    console.warn("recharge lock failed — proceeding (Stripe idempotency):", err.message || err);
+    return unlocked;
   }
 }
 

--- a/api/_lib/credit-topup.js
+++ b/api/_lib/credit-topup.js
@@ -187,12 +187,8 @@ async function applyCreditTopUp(session) {
     };
   }
 
-  const autoRecharge =
-    session.metadata?.auto_recharge === "true"
-      ? true
-      : session.metadata?.auto_recharge === "false"
-        ? false
-        : Boolean(prev.sc_auto_recharge);
+  // Default ON for new purchases; only an explicit "false" in Checkout metadata opts out.
+  const autoRecharge = session.metadata?.auto_recharge !== "false";
 
   let paymentMethod = prev.sc_default_payment_method || null;
   try {

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -462,13 +462,14 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
     }
     // Positive-but-insufficient balance: recharge once, retry same request id.
     if (err.code === "credits_exhausted") {
-      let autoOn = Boolean(ownerClaims.sc_auto_recharge);
-      if (!autoOn) {
-        try {
-          const { loadLedger } = require("./billing-ledger");
-          const led = await loadLedger(owner.uid, ownerClaims);
-          autoOn = Boolean(led.auto_recharge);
-        } catch (_) {}
+      let autoOn = false;
+      try {
+        const { isAutoRechargeEnabled } = require("./stripe");
+        const { loadLedger } = require("./billing-ledger");
+        const led = await loadLedger(owner.uid, ownerClaims);
+        autoOn = isAutoRechargeEnabled(ownerClaims, led);
+      } catch (_) {
+        autoOn = ownerClaims.sc_auto_recharge !== false;
       }
       if (autoOn) {
         const recharge = await attemptAutoRecharge(owner);

--- a/api/_lib/stripe.js
+++ b/api/_lib/stripe.js
@@ -252,7 +252,7 @@ async function createCreditTopUpCheckout({
   customerId,
   userId,
   creditUsd,
-  autoRecharge = false,
+  autoRecharge = true,
   baseUrl = "https://www.supercompress.dev",
   kind = "credit_topup",
 }) {
@@ -307,11 +307,23 @@ async function createCreditTopUpCheckout({
  * On success, credits Auth claims immediately (webhook is idempotent via PI id).
  * Returns { ok, balanceAdd, paymentIntentId, balance } or { ok:false, error }.
  */
+/** Auto-recharge defaults ON for Stripe-linked / credit wallets; explicit false opts out. */
+function isAutoRechargeEnabled(claims = {}, ledger = {}) {
+  if (ledger.auto_recharge === false || claims.sc_auto_recharge === false) return false;
+  if (ledger.auto_recharge === true || claims.sc_auto_recharge === true) return true;
+  return Boolean(
+    claims.sc_customer_id ||
+      ledger.customer_id ||
+      isCreditWallet(claims) ||
+      isPaygEnabled(claims.sc_plan)
+  );
+}
+
 async function attemptAutoRecharge(owner) {
   const claims = owner.customClaims || {};
   const { loadLedger, acquireRechargeLock, creditBalance } = require("./billing-ledger");
   const ledger = await loadLedger(owner.uid, claims);
-  if (!(claims.sc_auto_recharge || ledger.auto_recharge)) {
+  if (!isAutoRechargeEnabled(claims, ledger)) {
     return { ok: false, error: "auto_recharge_disabled" };
   }
   const customerId = claims.sc_customer_id || ledger.customer_id;
@@ -436,4 +448,5 @@ module.exports = {
   isCreditWallet,
   createCreditTopUpCheckout,
   attemptAutoRecharge,
+  isAutoRechargeEnabled,
 };

--- a/api/billing.js
+++ b/api/billing.js
@@ -244,7 +244,11 @@ async function handleGet(req, res, user) {
       ? claims.sc_credit_balance_usd
       : (sub?.credit_balance_usd != null ? sub.credit_balance_usd : (payg && creditWallet ? 0 : null))
   );
-  const autoRecharge = Boolean(claims.sc_auto_recharge ?? sub?.auto_recharge);
+  const { isAutoRechargeEnabled } = require("./_lib/stripe");
+  const autoRecharge = isAutoRechargeEnabled(claims, {
+    auto_recharge: sub?.auto_recharge,
+    customer_id: claims.sc_customer_id || sub?.stripe_customer_id,
+  });
 
   return json(res, 200, {
     plan: plan.id,
@@ -323,7 +327,8 @@ async function handleGet(req, res, user) {
 
 async function startCreditCheckout(req, res, user, body, existingSub, stripeBilling) {
   const creditUsd = normalizeCreditLimitUsd(body.credit_limit_usd, DEFAULT_CREDIT_LIMIT_USD);
-  const autoRecharge = body.auto_recharge === true || body.auto_recharge === "true";
+  // Default ON — only an explicit false opts out (dashboard checkbox is checked by default).
+  const autoRecharge = !(body.auto_recharge === false || body.auto_recharge === "false");
   const kind = body.action === "top_up" ? "credit_topup" : "credit_enable";
 
   const customerId = await ensureCustomer(user, existingSub, stripeBilling);

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -105,7 +105,8 @@ async function enforceUsageLimit(owner) {
   );
   if (balance > 0) return;
 
-  if (claims.sc_auto_recharge || ledger.auto_recharge) {
+  const { isAutoRechargeEnabled } = require("../_lib/stripe");
+  if (isAutoRechargeEnabled(claims, ledger)) {
     const recharge = await attemptAutoRecharge(owner);
     if (recharge.ok) {
       const freshLedger = await loadLedger(owner.uid, owner.customClaims || claims);


### PR DESCRIPTION
## Summary
- Credit Checkout / top-up defaults **auto-recharge ON** (explicit `false` still opts out).
- Stripe-linked / payg wallets treat unset auto-recharge as enabled.
- Firestore-down no longer blocks auto-recharge behind a lock we cannot write (Stripe PI idempotency remains).

## Test plan
- [x] unit tests / syntax
- [ ] smoke after deploy
- [ ] payg wallets with customer_id show auto_recharge enabled; free users unchanged


Made with [Cursor](https://cursor.com)