### PR TITLE
fix: harden billing fallback without killing availability

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -141,14 +141,8 @@ function emptyLedger(claims = {}) {
       claims.sc_credit_limit_usd,
       DEFAULT_CREDIT_LIMIT_USD
     ),
-    auto_recharge:
-      claims.sc_auto_recharge == null
-        ? Boolean(
-            claims.sc_customer_id ||
-              isCreditWallet(claims) ||
-              isPaygEnabled(claims.sc_plan)
-          )
-        : Boolean(claims.sc_auto_recharge),
+    auto_recharge: Boolean(claims.sc_auto_recharge),
+    auto_recharge_cycle: Number(claims.sc_auto_recharge_cycle || 0) || 0,
     customer_id: claims.sc_customer_id || null,
     // Display-only recent keys; idempotency is billing_credits/{id}
     credited_keys: Array.isArray(claims.sc_credited_sessions)
@@ -195,6 +189,10 @@ function normalizeLedger(raw, claims = {}) {
     ),
     auto_recharge:
       raw.auto_recharge != null ? Boolean(raw.auto_recharge) : Boolean(claims.sc_auto_recharge),
+    auto_recharge_cycle: Math.max(
+      Number(raw.auto_recharge_cycle || 0) || 0,
+      Number(claims.sc_auto_recharge_cycle || 0) || 0
+    ),
     customer_id: raw.customer_id || claims.sc_customer_id || null,
     credited_keys: Array.isArray(raw.credited_keys)
       ? raw.credited_keys.slice(-40)
@@ -352,7 +350,9 @@ function claimsByteLength(claims) {
   return Buffer.byteLength(JSON.stringify(claims || {}));
 }
 
-/** Firebase custom claims cap at 1000 bytes — drop bulky non-ledger fields to fit. */
+/** Firebase custom claims cap at 1000 bytes — drop bulky non-ledger fields to fit.
+ * Never delete sc_recent_billing entirely (idempotency watermarks). Prefer trimming
+ * agent/key metadata and compacting watermark entries. */
 function fitCustomClaims(claims) {
   const next = { ...(claims || {}) };
   const steps = [
@@ -360,10 +360,7 @@ function fitCustomClaims(claims) {
       delete next.sc_agent_plugin;
     },
     () => {
-      if (Array.isArray(next.sc_recent_billing)) next.sc_recent_billing = next.sc_recent_billing.slice(0, 1);
-    },
-    () => {
-      delete next.sc_recent_billing;
+      delete next.sc_plan_updated;
     },
     () => {
       if (Array.isArray(next.sc_key_ids)) next.sc_key_ids = next.sc_key_ids.slice(-2);
@@ -372,12 +369,31 @@ function fitCustomClaims(claims) {
       delete next.sc_key_ids;
     },
     () => {
-      delete next.sc_plan_updated;
+      if (Array.isArray(next.sc_credited_sessions)) {
+        next.sc_credited_sessions = next.sc_credited_sessions.slice(-6);
+      }
     },
     () => {
-      if (Array.isArray(next.sc_credited_sessions)) {
-        next.sc_credited_sessions = next.sc_credited_sessions.slice(-8);
+      if (Array.isArray(next.sc_recent_billing)) {
+        next.sc_recent_billing = next.sc_recent_billing.slice(0, 8).map((r) => ({
+          i: String(r?.i || "").slice(0, 40),
+          f: r?.f ? String(r.f).slice(0, 16) : null,
+          tin: Number(r?.tin) || 0,
+          tout: Number(r?.tout) || 0,
+          ts: Number(r?.ts) || 0,
+          b: Number(r?.b) || 0,
+          t: Number(r?.t) || 0,
+        }));
       }
+    },
+    () => {
+      if (Array.isArray(next.sc_recent_billing)) next.sc_recent_billing = next.sc_recent_billing.slice(0, 4);
+    },
+    () => {
+      if (Array.isArray(next.sc_recent_billing)) next.sc_recent_billing = next.sc_recent_billing.slice(0, 2);
+    },
+    () => {
+      if (Array.isArray(next.sc_recent_billing)) next.sc_recent_billing = next.sc_recent_billing.slice(0, 1);
     },
   ];
   let i = 0;
@@ -397,8 +413,9 @@ async function setBillingClaims(uid, claims) {
 
 /**
  * When Cloud Firestore is disabled/unavailable, bill via Auth claims only.
+ * Optimistic CAS via sc_billing_rev + post-write verify (retry on conflict).
  * Replay text is not stored (claims size); retries recompress but do not
- * double-bill (request id watermark on sc_recent_billing).
+ * double-bill (request id watermark on sc_recent_billing — keep up to 8).
  */
 async function applyUsageAndBurnClaimsFallback({
   uid,
@@ -414,75 +431,97 @@ async function applyUsageAndBurnClaimsFallback({
   const fp = String(fingerprint || "").trim() || null;
   if (!rid) throw billingError("billing_unavailable", "Billing request id required");
 
-  const fresh = await admin().auth().getUser(uid);
-  const liveClaims = mergeLiveClaims(fresh.customClaims, claims);
-  const recent = Array.isArray(liveClaims.sc_recent_billing)
-    ? liveClaims.sc_recent_billing
-    : [];
-  const prior = recent.find((r) => r && r.i === rid);
-  if (prior) {
-    assertUsageIdempotencyMatch(
+  let lastErr = null;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const fresh = await admin().auth().getUser(uid);
+    const liveClaims = mergeLiveClaims(fresh.customClaims, claims);
+    const recent = Array.isArray(liveClaims.sc_recent_billing)
+      ? liveClaims.sc_recent_billing
+      : [];
+    const prior = recent.find((r) => r && r.i === rid);
+    if (prior) {
+      assertUsageIdempotencyMatch(
+        {
+          fingerprint: prior.f || null,
+          tokens_in: prior.tin,
+          tokens_out: prior.tout,
+          tokens_saved: prior.ts,
+        },
+        {
+          fingerprint: fp,
+          tokensIn,
+          tokensOut,
+          tokensSaved,
+        }
+      );
+      return {
+        burned_micros: Number(prior.b || 0),
+        ledger: normalizeLedger(null, liveClaims),
+        already: true,
+        request_id: rid,
+        fingerprint: prior.f || fp || null,
+        response: null,
+        backend: "claims-fallback",
+      };
+    }
+
+    const prevRev = Number(liveClaims.sc_billing_rev || 0) || 0;
+    const ledger = normalizeLedger(null, liveClaims);
+    const planned = planUsageBurn(ledger, {
+      tokensIn,
+      tokensOut,
+      tokensSaved,
+      claims: liveClaims,
+    });
+    const nextRecent = [
       {
-        fingerprint: prior.f || null,
-        tokens_in: prior.tin,
-        tokens_out: prior.tout,
-        tokens_saved: prior.ts,
+        i: rid.slice(0, 40),
+        f: fp ? String(fp).slice(0, 16) : null,
+        tin: Number(tokensIn) || 0,
+        tout: Number(tokensOut) || 0,
+        ts: Number(tokensSaved) || 0,
+        b: planned.burned_micros,
+        t: Date.now(),
       },
-      {
-        fingerprint: fp,
-        tokensIn,
-        tokensOut,
-        tokensSaved,
-      }
-    );
-    return {
-      burned_micros: Number(prior.b || 0),
-      ledger: normalizeLedger(null, liveClaims),
-      already: true,
-      request_id: rid,
-      fingerprint: prior.f || fp || null,
-      response: null,
-      backend: "claims-fallback",
+      ...recent,
+    ].slice(0, 8);
+
+    const nextClaims = {
+      ...liveClaims,
+      sc_billing_rev: prevRev + 1,
+      sc_usage: {
+        month: planned.ledger.month,
+        requests: planned.ledger.requests,
+        tokens_in: planned.ledger.tokens_in,
+        tokens_out: planned.ledger.tokens_out,
+        tokens_saved: planned.ledger.tokens_saved,
+        tokens_reported: planned.ledger.tokens_reported || 0,
+      },
+      sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
+      sc_recent_billing: nextRecent,
     };
+
+    await setBillingClaims(uid, nextClaims);
+
+    // Verify our write stuck (last-writer lost → retry from fresh state).
+    const after = await admin().auth().getUser(uid);
+    const afterClaims = after.customClaims || {};
+    const afterRev = Number(afterClaims.sc_billing_rev || 0) || 0;
+    const afterTin = Number(afterClaims.sc_usage?.tokens_in || 0);
+    if (afterRev === prevRev + 1 && afterTin === Number(planned.ledger.tokens_in)) {
+      return {
+        ...planned,
+        already: false,
+        request_id: rid,
+        fingerprint: fp,
+        response: sanitizeReplayResponse(response),
+        backend: "claims-fallback",
+      };
+    }
+    lastErr = new Error("claims_cas_conflict");
   }
-
-  const ledger = normalizeLedger(null, liveClaims);
-  const planned = planUsageBurn(ledger, { tokensIn, tokensOut, tokensSaved, claims: liveClaims });
-  const nextRecent = [
-    {
-      i: rid.slice(0, 64),
-      f: fp ? String(fp).slice(0, 32) : null,
-      tin: Number(tokensIn) || 0,
-      tout: Number(tokensOut) || 0,
-      ts: Number(tokensSaved) || 0,
-      b: planned.burned_micros,
-      t: Date.now(),
-    },
-    ...recent,
-  ].slice(0, 2);
-
-  await setBillingClaims(uid, {
-    ...liveClaims,
-    sc_usage: {
-      month: planned.ledger.month,
-      requests: planned.ledger.requests,
-      tokens_in: planned.ledger.tokens_in,
-      tokens_out: planned.ledger.tokens_out,
-      tokens_saved: planned.ledger.tokens_saved,
-      tokens_reported: planned.ledger.tokens_reported || 0,
-    },
-    sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
-    sc_recent_billing: nextRecent,
-  });
-
-  return {
-    ...planned,
-    already: false,
-    request_id: rid,
-    fingerprint: fp,
-    response: sanitizeReplayResponse(response),
-    backend: "claims-fallback",
-  };
+  console.error("claims billing CAS exhausted:", lastErr?.message || lastErr);
+  throw billingError("billing_unavailable", "Billing ledger unavailable");
 }
 
 const IDEMPOTENCY_LEASE_MS = 90_000;
@@ -645,6 +684,7 @@ async function mirrorClaims(uid, ledger) {
         ? { sc_credit_limit_usd: ledger.credit_limit_usd }
         : {}),
       ...(ledger.auto_recharge != null ? { sc_auto_recharge: Boolean(ledger.auto_recharge) } : {}),
+      sc_auto_recharge_cycle: Number(ledger.auto_recharge_cycle || 0) || 0,
       ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
     });
   } catch (err) {
@@ -760,6 +800,15 @@ async function applyUsageAndBurn({
       const snap = await tx.get(ref);
       const ledger = normalizeLedger(snap.exists ? snap.data() : null, claims);
       const expiresAt = new Date(Date.now() + REPLAY_TTL_MS).toISOString();
+      // Firestore TTL policy field (configure TTL on billing_usage.expireAt in GCP).
+      let expireAt;
+      try {
+        expireAt = require("firebase-admin").firestore.Timestamp.fromMillis(
+          Date.now() + REPLAY_TTL_MS
+        );
+      } catch {
+        expireAt = new Date(Date.now() + REPLAY_TTL_MS);
+      }
 
       if (usageSnap.exists) {
         const prev = usageSnap.data() || {};
@@ -788,6 +837,7 @@ async function applyUsageAndBurn({
               created_at: prev.created_at || new Date().toISOString(),
               completed_at: new Date().toISOString(),
               response_expires_at: expiresAt,
+              expireAt,
               ...(replay ? { response: replay } : {}),
               lease_until: null,
             },
@@ -806,7 +856,7 @@ async function applyUsageAndBurn({
         if (replay && !prev.response) {
           tx.set(
             usageRef,
-            { response: replay, response_expires_at: expiresAt, status: "completed" },
+            { response: replay, response_expires_at: expiresAt, expireAt, status: "completed" },
             { merge: true }
           );
         }
@@ -836,6 +886,7 @@ async function applyUsageAndBurn({
           created_at: new Date().toISOString(),
           completed_at: new Date().toISOString(),
           response_expires_at: expiresAt,
+          expireAt,
           ...(replay ? { response: replay } : {}),
         },
         { merge: false }
@@ -932,6 +983,9 @@ async function creditBalanceClaimsFallback({
     ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
   }
   if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
+  if (patch.auto_recharge_cycle != null) {
+    ledger.auto_recharge_cycle = Math.max(0, Number(patch.auto_recharge_cycle) || 0);
+  }
   if (patch.customer_id) ledger.customer_id = patch.customer_id;
   ledger.credited_keys = [...keys.filter((k) => k !== key).slice(-39), key];
   ledger.updated_at = new Date().toISOString();
@@ -960,6 +1014,7 @@ async function creditBalanceClaimsFallback({
     sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
     sc_credit_limit_usd: ledger.credit_limit_usd,
     sc_auto_recharge: Boolean(ledger.auto_recharge),
+    sc_auto_recharge_cycle: Number(ledger.auto_recharge_cycle || 0) || 0,
     sc_credited_sessions: nextCredited,
     ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
     ...bonusPatch,
@@ -1045,6 +1100,9 @@ async function creditBalance({
         ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
       }
       if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
+      if (patch.auto_recharge_cycle != null) {
+        ledger.auto_recharge_cycle = Math.max(0, Number(patch.auto_recharge_cycle) || 0);
+      }
       if (patch.customer_id) ledger.customer_id = patch.customer_id;
       const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
       ledger.credited_keys = [...keys.filter((k) => k !== creditKey).slice(-39), creditKey];
@@ -1115,6 +1173,7 @@ async function creditBalance({
         sc_credit_balance_usd: roundUsd(microsToUsd(result.ledger.credit_balance_micros)),
         sc_credit_limit_usd: result.ledger.credit_limit_usd,
         sc_auto_recharge: Boolean(result.ledger.auto_recharge),
+        sc_auto_recharge_cycle: Number(result.ledger.auto_recharge_cycle || 0) || 0,
         ...(result.ledger.customer_id ? { sc_customer_id: result.ledger.customer_id } : {}),
         ...bonusPatch,
       });

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -168,6 +168,10 @@ function normalizeLedger(raw, claims = {}) {
           ? normalizeCreditLimitUsd(raw.credit_limit_usd)
           : base.credit_limit_usd,
       auto_recharge: raw.auto_recharge != null ? Boolean(raw.auto_recharge) : base.auto_recharge,
+      auto_recharge_cycle: Math.max(
+        Number(raw.auto_recharge_cycle || 0) || 0,
+        Number(claims.sc_auto_recharge_cycle || 0) || 0
+      ),
       customer_id: raw.customer_id || base.customer_id,
       credited_keys: Array.isArray(raw.credited_keys) ? raw.credited_keys.slice(-40) : base.credited_keys,
     };

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -469,7 +469,7 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
         const led = await loadLedger(owner.uid, ownerClaims);
         autoOn = isAutoRechargeEnabled(ownerClaims, led);
       } catch (_) {
-        autoOn = ownerClaims.sc_auto_recharge !== false;
+        autoOn = ownerClaims.sc_auto_recharge === true;
       }
       if (autoOn) {
         const recharge = await attemptAutoRecharge(owner);

--- a/api/_lib/mail.js
+++ b/api/_lib/mail.js
@@ -44,18 +44,83 @@ const PRIVATE_EMAIL_CONTENT_DIR = path.join(
 function parseJsonObject(raw) {
   try {
     const data = JSON.parse(raw);
-    if (!data || typeof data !== "object") return null;
+    if (!data || typeof data !== "object" || Array.isArray(data)) return null;
     return data;
   } catch {
     return null;
   }
 }
 
+/** Tip entries need subject + tipBody (or tip_body) before we render a campaign. */
+function isValidTipEntry(entry) {
+  if (!entry || typeof entry !== "object") return false;
+  const subject = String(entry.subject || "").trim();
+  const body = String(entry.tipBody || entry.tip_body || entry.body || "").trim();
+  return subject.length >= 3 && body.length >= 8;
+}
+
+function sanitizeTipsCatalog(data) {
+  if (!data || typeof data !== "object") return null;
+  const seed = Array.isArray(data.seed) ? data.seed.filter(isValidTipEntry) : [];
+  const byCampaign = {};
+  if (data.byCampaign && typeof data.byCampaign === "object") {
+    for (const [k, v] of Object.entries(data.byCampaign)) {
+      if (isValidTipEntry(v)) byCampaign[k] = v;
+    }
+  }
+  if (!seed.length && !Object.keys(byCampaign).length) return null;
+  return { ...data, seed, byCampaign };
+}
+
+function isValidShipEntry(entry) {
+  if (!entry || typeof entry !== "object") return false;
+  const subject = String(entry.subject || "").trim();
+  const bullets = entry.bullets || entry.items;
+  const hasBullets = Array.isArray(bullets) && bullets.some((b) => String(b || "").trim().length > 4);
+  const body = String(entry.body || entry.digest || "").trim();
+  return subject.length >= 3 && (hasBullets || body.length >= 8);
+}
+
+function sanitizeShipCatalog(data) {
+  if (!data || typeof data !== "object") return null;
+  // Accept either { campaigns: { id: entry } } or flat by-id maps used locally.
+  if (data.campaigns && typeof data.campaigns === "object") {
+    const campaigns = {};
+    for (const [k, v] of Object.entries(data.campaigns)) {
+      if (isValidShipEntry(v)) campaigns[k] = v;
+    }
+    if (!Object.keys(campaigns).length) return null;
+    return { ...data, campaigns };
+  }
+  // Pass through if it looks like a digest object with required fields.
+  if (isValidShipEntry(data)) return data;
+  // Or a map of week ids
+  const keys = Object.keys(data).filter((k) => k !== "seed" && k !== "byCampaign");
+  if (keys.length && keys.every((k) => typeof data[k] === "object")) {
+    const out = {};
+    for (const k of keys) {
+      if (isValidShipEntry(data[k])) out[k] = data[k];
+    }
+    if (!Object.keys(out).length) return null;
+    return out;
+  }
+  return null;
+}
+
 function loadCampaignJson(envName, fileName) {
   const fromEnv = (process.env[envName] || "").trim();
   if (fromEnv) {
     const parsed = parseJsonObject(fromEnv);
-    if (parsed) return parsed;
+    if (parsed) {
+      const sanitized =
+        envName === "WEEKLY_TIPS_JSON"
+          ? sanitizeTipsCatalog(parsed)
+          : envName === "WEEKLY_SHIP_JSON"
+            ? sanitizeShipCatalog(parsed)
+            : parsed;
+      if (sanitized) return sanitized;
+      console.warn(`${envName} failed schema validation — ignoring`);
+    }
   }
   const dirs = [];
   const contentDir = (process.env.SUPERCOMPRESS_EMAIL_CONTENT_DIR || "").trim();
@@ -65,7 +130,14 @@ function loadCampaignJson(envName, fileName) {
     try {
       const raw = fs.readFileSync(path.join(dir, fileName), "utf8");
       const parsed = parseJsonObject(raw);
-      if (parsed) return parsed;
+      if (!parsed) continue;
+      const sanitized =
+        envName === "WEEKLY_TIPS_JSON"
+          ? sanitizeTipsCatalog(parsed)
+          : envName === "WEEKLY_SHIP_JSON"
+            ? sanitizeShipCatalog(parsed)
+            : parsed;
+      if (sanitized) return sanitized;
     } catch {
       /* try next */
     }
@@ -413,6 +485,7 @@ async function sendViaResend({
   from = DEFAULT_FROM,
   unsubUrl,
   listUnsubscribeUrl,
+  idempotencyKey,
 }) {
   const apiKey = (process.env.RESEND_API_KEY || "").trim();
   if (!apiKey) {
@@ -427,12 +500,17 @@ async function sendViaResend({
     headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click";
   }
 
+  const reqHeaders = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+  if (idempotencyKey) {
+    reqHeaders["Idempotency-Key"] = String(idempotencyKey).slice(0, 256);
+  }
+
   const res = await fetch("https://api.resend.com/emails", {
     method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
+    headers: reqHeaders,
     body: JSON.stringify({
       from,
       to: [to],
@@ -585,7 +663,10 @@ async function sendPowerUserEmail(opts) {
     return { ok: false, error: "missing email" };
   }
   const copy = powerUserCopy(opts);
-  const result = await sendViaResend(copy);
+  const result = await sendViaResend({
+    ...copy,
+    idempotencyKey: opts.idempotencyKey || null,
+  });
   return { ...result, subject: copy.subject, text: copy.text, html: copy.html };
 }
 

--- a/api/_lib/power-user.js
+++ b/api/_lib/power-user.js
@@ -49,6 +49,7 @@ async function claimPowerUser(uid, extra = {}) {
       status: "pending",
       claimed_at: existing?.claimed_at || new Date().toISOString(),
       retried_at: existing ? new Date().toISOString() : null,
+      idempotency_key: existing?.idempotency_key || `power-user-${uid}`,
       ...extra,
     };
     store.power_user_emails[uid] = record;
@@ -67,12 +68,57 @@ async function markPowerUser(uid, patch) {
 
 function isDrainablePowerUser(rec) {
   if (!rec || !rec.uid) return false;
-  if (rec.status !== "pending" && rec.status !== "failed") return false;
+  if (rec.status !== "pending" && rec.status !== "failed" && rec.status !== "sending") {
+    return false;
+  }
   return String(rec.email || "").includes("@");
 }
 
+async function deliverPowerUser(rec) {
+  const uid = rec.uid;
+  const idempotencyKey = rec.idempotency_key || `power-user-${uid}`;
+  // Mark sending before Resend so a crash after delivery does not look "pending"
+  // for a fresh send — drain retries with the same Idempotency-Key.
+  await markPowerUser(uid, {
+    status: "sending",
+    send_attempt_at: new Date().toISOString(),
+    idempotency_key: idempotencyKey,
+  });
+
+  const firstName =
+    rec.first_name || firstNameFromUser({ email: rec.email, displayName: rec.display_name });
+  const result = await sendPowerUserEmail({
+    email: rec.email,
+    firstName,
+    idempotencyKey,
+    ...statsFromUsage({
+      tokensIn: rec.tokens_in,
+      tokensSaved: rec.tokens_saved,
+      requests: rec.requests,
+    }),
+  });
+
+  if (result.ok) {
+    await markPowerUser(uid, {
+      status: "sent",
+      sent_at: new Date().toISOString(),
+      provider: result.provider || "resend",
+      provider_id: result.id || null,
+      error: null,
+    });
+    return { ok: true };
+  }
+
+  await markPowerUser(uid, {
+    status: "pending",
+    error: result.error || "send_failed",
+    failed_at: new Date().toISOString(),
+  });
+  return { ok: false, error: result.error || "send_failed" };
+}
+
 /**
- * Retry pending/failed crossing emails. Never creates records — so people
+ * Retry pending/failed/sending crossing emails. Never creates records — so people
  * already over 1M with no row stay unmailed.
  */
 async function drainPendingPowerUsers() {
@@ -83,33 +129,9 @@ async function drainPendingPowerUsers() {
   let sent = 0;
   let failed = 0;
   for (const rec of pending) {
-    const firstName =
-      rec.first_name || firstNameFromUser({ email: rec.email, displayName: rec.display_name });
-    const result = await sendPowerUserEmail({
-      email: rec.email,
-      firstName,
-      ...statsFromUsage({
-        tokensIn: rec.tokens_in,
-        tokensSaved: rec.tokens_saved,
-        requests: rec.requests,
-      }),
-    });
-    if (result.ok) {
-      await markPowerUser(rec.uid, {
-        status: "sent",
-        sent_at: new Date().toISOString(),
-        provider: result.provider || "resend",
-        error: null,
-      });
-      sent += 1;
-    } else {
-      failed += 1;
-      await markPowerUser(rec.uid, {
-        status: "pending",
-        error: result.error || "send_failed",
-        failed_at: new Date().toISOString(),
-      });
-    }
+    const result = await deliverPowerUser(rec);
+    if (result.ok) sent += 1;
+    else failed += 1;
   }
   return { pending: pending.length, sent, failed };
 }
@@ -145,6 +167,8 @@ async function maybeNotifyPowerUser({
     source,
   });
   if (!claimed) {
+    // If a prior attempt died while "sending", drain will finish with same
+    // Idempotency-Key. Do not start a second claim here.
     return { ok: true, sent: false, reason: reason || "already_claimed", record };
   }
 
@@ -156,33 +180,16 @@ async function maybeNotifyPowerUser({
     return { ok: true, sent: false, reason: "no_email" };
   }
 
-  const result = await sendPowerUserEmail({
+  const result = await deliverPowerUser({
+    ...record,
     email: to,
-    firstName,
-    ...statsFromUsage({
-      tokensIn: nextTokens,
-      tokensSaved,
-      requests,
-    }),
+    first_name: firstName,
+    tokens_in: Number(nextTokens) || 0,
+    tokens_saved: Number(tokensSaved) || 0,
+    requests: Number(requests) || 0,
   });
 
-  if (result.ok) {
-    await markPowerUser(uid, {
-      status: "sent",
-      sent_at: new Date().toISOString(),
-      provider: result.provider || "resend",
-      error: null,
-    });
-    return { ok: true, sent: true };
-  }
-
-  // Stay pending so welcome-drain can retry. Do not mark failed — that would
-  // strand the crossing if this lambda dies before drain.
-  await markPowerUser(uid, {
-    status: "pending",
-    error: result.error || "send_failed",
-    failed_at: new Date().toISOString(),
-  });
+  if (result.ok) return { ok: true, sent: true };
   return { ok: false, sent: false, queued: true, reason: result.error || "send_failed" };
 }
 

--- a/api/_lib/stripe.js
+++ b/api/_lib/stripe.js
@@ -307,16 +307,11 @@ async function createCreditTopUpCheckout({
  * On success, credits Auth claims immediately (webhook is idempotent via PI id).
  * Returns { ok, balanceAdd, paymentIntentId, balance } or { ok:false, error }.
  */
-/** Auto-recharge defaults ON for Stripe-linked / credit wallets; explicit false opts out. */
+/** Explicit true only. Legacy unset stays OFF until checkout consent. */
 function isAutoRechargeEnabled(claims = {}, ledger = {}) {
-  if (ledger.auto_recharge === false || claims.sc_auto_recharge === false) return false;
   if (ledger.auto_recharge === true || claims.sc_auto_recharge === true) return true;
-  return Boolean(
-    claims.sc_customer_id ||
-      ledger.customer_id ||
-      isCreditWallet(claims) ||
-      isPaygEnabled(claims.sc_plan)
-  );
+  if (ledger.auto_recharge === false || claims.sc_auto_recharge === false) return false;
+  return false;
 }
 
 async function attemptAutoRecharge(owner) {
@@ -341,9 +336,11 @@ async function attemptAutoRecharge(owner) {
   }
 
   const stripe = getStripe();
-  // Hour-bucketed key so concurrent compressions share one PI attempt.
-  const hourBucket = new Date().toISOString().slice(0, 13).replace(/[-:T]/g, "");
-  const idempotencyKey = `sc_ar_${owner.uid}_${Math.round(amount * 100)}_${hourBucket}`.slice(0, 255);
+  // Cycle id advances after each successful recharge so a user who burns
+  // through multiple packs in one hour can recharge again. Concurrent
+  // compressions with the same cycle still share one Stripe PI.
+  const cycle = Number(ledger.auto_recharge_cycle || claims.sc_auto_recharge_cycle || 0) || 0;
+  const idempotencyKey = `sc_ar_${owner.uid}_${Math.round(amount * 100)}_c${cycle}`.slice(0, 255);
 
   try {
     const customer = await stripe.customers.retrieve(customerId);
@@ -397,6 +394,7 @@ async function attemptAutoRecharge(owner) {
       patch: {
         credit_limit_usd: amount,
         auto_recharge: true,
+        auto_recharge_cycle: cycle + 1,
         customer_id: customerId,
       },
     });

--- a/packages/proxy/tui/sc.ts
+++ b/packages/proxy/tui/sc.ts
@@ -346,9 +346,14 @@ export function installPlugin() {
 export function beginConnect() {
   const code = crypto.randomBytes(16).toString("hex")
   const url = `https://www.supercompress.dev/dashboard?connect=${code}&source=tui`
-  const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open"
   try {
-    execFileSync(openCmd, [url], { stdio: "ignore" })
+    if (process.platform === "win32") {
+      // `start` is a cmd.exe builtin — not a standalone executable for execFileSync.
+      execFileSync("cmd.exe", ["/c", "start", "", url], { stdio: "ignore" })
+    } else {
+      const openCmd = process.platform === "darwin" ? "open" : "xdg-open"
+      execFileSync(openCmd, [url], { stdio: "ignore" })
+    }
   } catch {
     /* user can open url manually */
   }


### PR DESCRIPTION
## Summary
- Keep Auth-claims billing available while Firestore is down (no fail-closed 503), but harden it with `sc_billing_rev` CAS + post-write verify, up to 8 idempotency watermarks, and `fitCustomClaims` that never deletes `sc_recent_billing`.
- Treat legacy auto-recharge as **OFF** until explicit `true` (new checkout UI can stay default-checked); cycle-scoped Stripe PI keys so multi-pack/hour recharges work.
- Replay docs get `expireAt` for Firestore TTL; power-user email uses Resend Idempotency-Key + `sending` status; Windows TUI opens via `cmd.exe /c start`; campaign tip/ship JSON is schema-sanitized.
- Also closed #66 (systemdEscape already on main) and set `SUPERCOMPRESS_API_KEY` for scheduled smoke.

## Test plan
- [ ] CI green
- [ ] `node api/_lib/billing-ledger.test.js`
- [ ] `bash scripts/prod-smoke.sh` after deploy — authenticated compress still 200
- [ ] Confirm unset auto-recharge stays off; explicit true still recharges
- [ ] Scheduled smoke can use the new Actions secret


Made with [Cursor](https://cursor.com)