### PR TITLE
fix: cache-first analytics grow-in and dithered billing bar

### DIFF
--- a/web/assets/js/dashboard-analytics.js
+++ b/web/assets/js/dashboard-analytics.js
@@ -18,6 +18,9 @@
 
   let loadedOnce = false;
   let loading = false;
+  let paintGen = 0;
+  let paintedUid = null;
+  const cancelFns = [];
 
   function setPill(mode, text) {
     const pill = $("an-data-pill");
@@ -38,18 +41,38 @@
     if (message) el.textContent = message;
   }
 
-  function animateNumber(el, to, { suffix = "", compact = false } = {}) {
+  function cancelPaints() {
+    while (cancelFns.length) {
+      const fn = cancelFns.pop();
+      try {
+        fn();
+      } catch (_) {}
+    }
+  }
+
+  function animateNumber(el, to, { suffix = "", compact = false, duration = 900, gen = 0 } = {}) {
     const kit = DK();
     if (!el) return;
     const n = Number(to);
     const v = Number.isFinite(n) ? Math.max(0, n) : 0;
-    el.textContent = (compact && kit ? kit.formatCompact(v) : String(Math.round(v))) + suffix;
+    const fmt = (x) => (compact && kit ? kit.formatCompact(x) : String(Math.round(x))) + suffix;
+    if (!kit?.animateChart) {
+      el.textContent = fmt(v);
+      return;
+    }
+    const cancel = kit.animateChart((p) => {
+      if (gen !== paintGen) return;
+      el.textContent = fmt(v * p);
+    }, duration);
+    cancelFns.push(cancel);
   }
 
   function paint(series) {
     const kit = DK();
     const data = DATA();
     if (!kit || !data) return;
+    const gen = ++paintGen;
+    cancelPaints();
 
     setPill(series.live ? "live" : "err", series.live ? "Live · your account" : "Could not load live usage");
 
@@ -61,10 +84,10 @@
     }
     if ($("an-chip-delta")) $("an-chip-delta").textContent = series.deltaLabel;
 
-    animateNumber($("an-kpi-cut"), series.cut, { suffix: "%" });
-    animateNumber($("an-kpi-saved"), series.totalSaved, { compact: true });
-    animateNumber($("an-kpi-in"), series.totalIn, { compact: true });
-    animateNumber($("an-kpi-req"), series.totalReq, { compact: true });
+    animateNumber($("an-kpi-cut"), series.cut, { suffix: "%", gen });
+    animateNumber($("an-kpi-saved"), series.totalSaved, { compact: true, gen });
+    animateNumber($("an-kpi-in"), series.totalIn, { compact: true, gen });
+    animateNumber($("an-kpi-req"), series.totalReq, { compact: true, gen });
 
     for (const [id, opts] of washes) {
       const el = $(id);
@@ -89,29 +112,56 @@
       yMax: areaMax,
       empty: !series.areaData.some((d) => d.y > 0),
       emptyLabel: "No daily savings yet",
-      data: series.areaData,
-      interactive: true,
     };
-    kit.renderAreaChart(areaEl, areaOpts);
-    kit.startChartDitherLoop(areaEl, { kind: "area", ...areaOpts });
+    cancelFns.push(
+      kit.animateChart((p) => {
+        if (gen !== paintGen) return;
+        kit.renderAreaChart(areaEl, {
+          ...areaOpts,
+          data: series.areaData.map((d) => ({ x: d.x, y: d.y * p })),
+          interactive: false,
+        });
+        if (p > 0.98) {
+          kit.renderAreaChart(areaEl, {
+            ...areaOpts,
+            data: series.areaData,
+            interactive: true,
+          });
+          kit.startChartDitherLoop(areaEl, {
+            kind: "area",
+            ...areaOpts,
+            data: series.areaData,
+            interactive: true,
+          });
+        }
+      }, 1100)
+    );
 
-    const barOpts = {
-      data: series.reqs.map((r) => ({ label: r.label, value: r.value, full: r.full })),
-      orientation: "vertical",
-      color: "brand",
-      variant: "gradient",
-      bloom: "aura",
-      maxBars: 30,
-      progress: 1,
-      yMax: reqMax,
-      unit: "requests",
-      tooltipTitle: "Requests",
-      interactive: true,
-      empty: !series.reqs.some((r) => r.value > 0),
-      emptyLabel: "No requests yet",
-    };
-    kit.renderBarChart(barsEl, barOpts);
-    kit.startChartDitherLoop(barsEl, { kind: "bar", ...barOpts });
+    cancelFns.push(
+      kit.animateChart((p) => {
+        if (gen !== paintGen) return;
+        const done = p > 0.98;
+        const barOpts = {
+          data: series.reqs.map((r) => ({ label: r.label, value: r.value, full: r.full })),
+          orientation: "vertical",
+          color: "brand",
+          variant: "gradient",
+          bloom: "aura",
+          maxBars: 30,
+          progress: done ? 1 : p,
+          yMax: reqMax,
+          unit: "requests",
+          tooltipTitle: "Requests",
+          interactive: done,
+          empty: !series.reqs.some((r) => r.value > 0),
+          emptyLabel: "No requests yet",
+        };
+        kit.renderBarChart(barsEl, barOpts);
+        if (done) {
+          kit.startChartDitherLoop(barsEl, { kind: "bar", ...barOpts, progress: 1, interactive: true });
+        }
+      }, 1100)
+    );
 
     const esc = data.escapeHtml;
     const agentTotal = series.agents.reduce((s, a) => s + a.value, 0) || 1;
@@ -162,13 +212,20 @@
     loadedOnce = true;
   }
 
-  async function fetchKeys(idToken) {
-    const res = await fetch(`/api/keys?fresh=1&_=${Date.now()}`, {
+  async function fetchKeys(idToken, { fresh = false } = {}) {
+    const q = fresh ? `/api/keys?fresh=1&_=${Date.now()}` : `/api/keys?_=${Date.now()}`;
+    const res = await fetch(q, {
       headers: { Authorization: `Bearer ${idToken}` },
       cache: "no-store",
     });
     if (!res.ok) throw new Error(`keys ${res.status}`);
     return res.json();
+  }
+
+  function reset() {
+    loadedOnce = false;
+    paintedUid = null;
+    cancelPaints();
   }
 
   async function show({ getIdToken, force = false } = {}) {
@@ -180,6 +237,19 @@
       return;
     }
     if (loading) return;
+
+    const uid = window.SCDashboardKeysCache?.uid?.() || "";
+    if (paintedUid && uid && paintedUid !== uid) {
+      reset();
+    }
+
+    const apply = (payload) => {
+      paint(data.bundleToSeries(data.aggregateUsage(payload)));
+      setLoading(false);
+      loadedOnce = true;
+      paintedUid = uid || paintedUid;
+    };
+
     if (loadedOnce && !force) {
       const areaH = $("an-area")?.querySelector("canvas")?.getBoundingClientRect().height || 0;
       if (areaH >= 80) {
@@ -189,15 +259,17 @@
         }
         return;
       }
-      // First paint happened while the panel was 0×0 — do a full redraw.
     }
 
+    const cached = !force ? window.SCDashboardKeysCache?.peek?.() : null;
     loading = true;
-    setLoading(true, "Loading your live usage…");
-    setPill("load", "Live · loading…");
+    if (!cached) {
+      setLoading(true, "Loading your live usage…");
+      setPill("load", "Live · loading…");
+    }
     try {
       await new Promise((resolve) => {
-        let n = 16;
+        let n = 8;
         const tick = () => {
           const w = $("an-area")?.getBoundingClientRect().width || 0;
           if (w > 40 || n-- <= 0) return resolve();
@@ -205,11 +277,15 @@
         };
         requestAnimationFrame(tick);
       });
+      if (cached) {
+        apply(cached);
+        return;
+      }
       const token = await getIdToken();
       if (!token) throw new Error("Not signed in");
-      const payload = await fetchKeys(token);
-      paint(data.bundleToSeries(data.aggregateUsage(payload)));
-      setLoading(false);
+      const payload = await fetchKeys(token, { fresh: !!force });
+      window.SCDashboardKeysCache?.remember?.(payload);
+      apply(payload);
     } catch (err) {
       console.error(err);
       setPill("err", "Load failed");
@@ -228,5 +304,5 @@
     }
   });
 
-  window.SCDashboardAnalytics = { show, paint };
+  window.SCDashboardAnalytics = { show, paint, reset };
 })();

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -67,6 +67,48 @@ let lastCreatedSecret = null;
 let defaultKeyProvisioning = false;
 let lastBillingSub = null;
 
+function keysCacheUid() {
+  if (currentUser?.uid) return String(currentUser.uid);
+  if (typeof idToken === "string" && idToken.startsWith("dev:")) {
+    const part = idToken.split(":")[1];
+    if (part) return `dev:${part}`;
+  }
+  if (currentUser?.email) return `email:${currentUser.email}`;
+  return null;
+}
+
+function rememberKeysPayload(data) {
+  window.SCDashboardKeysCache?.remember?.(data);
+}
+
+function clearKeysCache() {
+  window.SCDashboardKeysCache?.clear?.();
+}
+
+window.SCDashboardKeysCache = {
+  _payload: null,
+  _uid: null,
+  remember(data) {
+    const uid = keysCacheUid();
+    if (!uid || !data || typeof data !== "object") return;
+    this._uid = uid;
+    this._payload = data;
+  },
+  peek() {
+    const uid = keysCacheUid();
+    if (!uid || this._uid !== uid) return null;
+    return this._payload;
+  },
+  uid() {
+    return keysCacheUid();
+  },
+  clear() {
+    this._payload = null;
+    this._uid = null;
+    window.SCDashboardAnalytics?.reset?.();
+  },
+};
+
 const AUTH_NETWORK_MESSAGE =
   "Signed in, but Firebase could not issue a session token. Check your network/ad blocker/VPN and refresh, then try again.";
 
@@ -394,6 +436,7 @@ async function loadKeysFresh(retries = 6) {
       accountUsage = data.account_usage || null;
       codingAgentUsage = data.coding_agent_usage || {};
       agentPluginLink = data.agent_plugin || { linked: false };
+      rememberKeysPayload(data);
       renderKeys();
       renderUsage();
       renderCodingAgents();
@@ -510,6 +553,7 @@ async function loadKeys() {
     accountUsage = data.account_usage || null;
     codingAgentUsage = data.coding_agent_usage || {};
     agentPluginLink = data.agent_plugin || { linked: false };
+    rememberKeysPayload(data);
     renderKeys();
     renderUsage();
     renderCodingAgents();
@@ -743,6 +787,9 @@ async function triggerWelcomeEmail(user, { isNewUser = false } = {}) {
 
 async function enterDashboard(user, { isNewUser = false } = {}) {
   authResolved = true;
+  const prevUid = keysCacheUid();
+  const nextUid = user?.uid || null;
+  if (prevUid && nextUid && prevUid !== nextUid) clearKeysCache();
   idToken = await getUserToken(user);
   currentUser = user;
   saveSession({
@@ -874,6 +921,27 @@ function renderActivationChecklist() {
   /* Activation checklist removed from dashboard UI. */
 }
 
+function paintBillingUsageMeter(track) {
+  const kit = window.DitherKitLite;
+  if (!track || !kit?.renderDitherMeter) return;
+  const pct = Number(track.dataset.usagePct);
+  const color = track.dataset.usageColor || "brand";
+  let tries = 20;
+  const paint = () => {
+    if (!track.isConnected) return;
+    const w = track.getBoundingClientRect().width;
+    if (w < 8 && tries-- > 0) {
+      requestAnimationFrame(paint);
+      return;
+    }
+    kit.renderDitherMeter(track, {
+      progress: (Number.isFinite(pct) ? pct : 0) / 100,
+      color,
+    });
+  };
+  requestAnimationFrame(paint);
+}
+
 function renderSubscription(sub) {
   const statusCard = $("billing-status-card");
   if (!statusCard) return;
@@ -884,6 +952,7 @@ function renderSubscription(sub) {
   const freeUsed = Math.min(used, freeCap);
   const pct = Math.min(100, Math.round((freeUsed / freeCap) * 10000) / 100);
   const fillClass = pct >= 90 ? "dash-billing-usage-fill--full" : pct >= 70 ? "dash-billing-usage-fill--high" : "";
+  const meterColor = pct >= 90 ? "red" : pct >= 70 ? "orange" : "brand";
   const payg = !!(sub.payg_enabled || sub.unlimited || (sub.plan && sub.plan !== "free"));
   const creditWallet = !!(sub.credit_wallet || (payg && sub.credit_balance_usd != null));
   const creditBalance = Number(sub.credit_balance_usd);
@@ -944,7 +1013,7 @@ function renderSubscription(sub) {
         <span><strong>${formatNum(freeUsed)}</strong> / ${formatNum(freeCap)} free tokens used</span>
         <span>${pct}%</span>
       </div>
-      <div class="dash-billing-usage-track">
+      <div class="dash-billing-usage-track" data-usage-pct="${pct}" data-usage-color="${meterColor}">
         <div class="dash-billing-usage-fill ${fillClass}" style="width:${pct}%"></div>
       </div>
     </div>
@@ -961,6 +1030,7 @@ function renderSubscription(sub) {
   `;
 
   $("btn-paywall-unlock")?.addEventListener("click", () => handleEnablePayg());
+  paintBillingUsageMeter(statusCard.querySelector(".dash-billing-usage-track"));
   // Update plan cards
   document.querySelectorAll(".dash-plan-card").forEach((card) => {
     const plan = card.dataset.plan;
@@ -1714,7 +1784,11 @@ function openDashboardPanel(panel, { updateUrl = true } = {}) {
   const panelEl = $(`panel-${panel}`);
   if (panelEl) panelEl.classList.remove("hidden");
 
-  if (panel === "billing") loadSubscription();
+  if (panel === "billing") {
+    loadSubscription();
+    const track = document.querySelector("#panel-billing .dash-billing-usage-track");
+    if (track) paintBillingUsageMeter(track);
+  }
   if (panel === "keys") {
     requestAnimationFrame(() => renderKeysSummary());
   }
@@ -1830,6 +1904,7 @@ function initDevAuth(message) {
   $("dash-signout").addEventListener("click", () => {
     idToken = null;
     currentUser = null;
+    clearKeysCache();
     clearSession();
     showAuth();
   });
@@ -1972,6 +2047,7 @@ async function initFirebaseAuth() {
         console.error("Firebase token acquisition failed", err);
         idToken = null;
         currentUser = null;
+        clearKeysCache();
         clearSession();
         await signOut(auth).catch(() => {});
         showAuth();
@@ -1980,6 +2056,7 @@ async function initFirebaseAuth() {
     } else {
       idToken = null;
       currentUser = null;
+      clearKeysCache();
       clearSession();
       showAuth();
     }
@@ -1988,10 +2065,12 @@ async function initFirebaseAuth() {
   const signOutBtn = $("dash-signout");
   if (signOutBtn) {
     signOutBtn.addEventListener("click", async () => {
+      clearKeysCache();
       clearSession();
       if (auth) await signOut(auth);
       else {
         idToken = null;
+        currentUser = null;
         showAuth();
       }
     });
@@ -2038,6 +2117,12 @@ async function init() {
   initModals();
   initSnippetTabs();
   initBilling();
+  window.addEventListener("resize", () => {
+    const track = document.querySelector("#panel-billing .dash-billing-usage-track");
+    if (track && !document.getElementById("panel-billing")?.classList.contains("hidden")) {
+      paintBillingUsageMeter(track);
+    }
+  });
   show(viewAuth);
   setError("");
   hide(viewDash);

--- a/web/assets/js/dither-kit-lite.js
+++ b/web/assets/js/dither-kit-lite.js
@@ -596,19 +596,72 @@
     };
   }
 
-  /** Ease-out grow for charts. fn(progress 0→1) called each frame. */
+  /** Ease-out grow for charts. fn(progress 0→1) called each frame. Returns cancel(). */
   function animateChart(fn, duration = 900) {
-    if (typeof fn !== "function") return;
+    if (typeof fn !== "function") return () => {};
+    let raf = 0;
+    let stopped = false;
     const t0 = performance.now();
     const ease = (t) => 1 - Math.pow(1 - t, 3);
     const frame = (now) => {
+      if (stopped) return;
       let p = (now - t0) / Math.max(1, duration);
       if (!Number.isFinite(p) || p < 0) p = 1;
       p = Math.min(1, p);
       fn(ease(p));
-      if (p < 1) requestAnimationFrame(frame);
+      if (p < 1) raf = requestAnimationFrame(frame);
     };
-    requestAnimationFrame(frame);
+    raf = requestAnimationFrame(frame);
+    return () => {
+      stopped = true;
+      if (raf) cancelAnimationFrame(raf);
+      raf = 0;
+    };
+  }
+
+  /** Horizontal Bayer usage meter (billing free-allowance bar). */
+  function renderDitherMeter(el, options = {}) {
+    if (!el) return;
+    let canvas = el.querySelector("canvas.dk-meter");
+    if (!canvas) {
+      el.querySelectorAll(".dash-billing-usage-fill").forEach((n) => n.remove());
+      canvas = document.createElement("canvas");
+      canvas.className = "dk-meter";
+      canvas.setAttribute("aria-hidden", "true");
+      el.appendChild(canvas);
+    }
+    const rect = el.getBoundingClientRect();
+    const cssW = Math.max(8, Math.round(rect.width || el.clientWidth || 240));
+    const cssH = Math.max(6, Math.round(rect.height || el.clientHeight || 8));
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = Math.round(cssW * dpr);
+    canvas.height = Math.round(cssH * dpr);
+    canvas.style.width = cssW + "px";
+    canvas.style.height = cssH + "px";
+    const ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssW, cssH);
+
+    const pct = clamp01((Number(options.progress) || 0) / (options.max || 1));
+    const colorName = options.color || (pct >= 0.9 ? "red" : pct >= 0.7 ? "orange" : "brand");
+    const seed = seedOf(colorName);
+    const { cols, rows } = backingSize(cssW, cssH);
+    const off = document.createElement("canvas");
+    off.width = cols;
+    off.height = rows;
+    const octx = off.getContext("2d");
+    const fillCols = Math.round(cols * pct);
+    octx.fillStyle = "rgba(15,23,42,0.06)";
+    octx.fillRect(0, 0, cols, rows);
+    for (let x = 0; x < fillCols; x++) {
+      paintColumn(octx, x, 0, rows, seed, {
+        variant: "gradient",
+        intensity: 0.55,
+        dim: 1,
+      });
+    }
+    ctx.imageSmoothingEnabled = false;
+    ctx.drawImage(off, 0, 0, cssW, cssH);
   }
 
   function ensureWashCanvas(el) {
@@ -759,6 +812,7 @@
     startChartDitherLoop,
     stopChartDitherLoop,
     animateChart,
+    renderDitherMeter,
     formatCompact,
     seedOf,
   };

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -130,6 +130,12 @@
       overflow: hidden;
     }
 
+    .dash-billing-usage-track canvas.dk-meter {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
     .dash-billing-usage-fill {
       height: 100%;
       border-radius: 4px;
@@ -1118,10 +1124,10 @@ npm exec supercompress setup</pre>
   </footer>
   <script src="assets/js/firebase-config.js?v=3"></script>
   <script src="assets/js/supercompress.js?v=1"></script>
-  <script src="/assets/js/dither-kit-lite.js?v=12"></script>
+  <script src="/assets/js/dither-kit-lite.js?v=13"></script>
   <script src="/assets/js/analytics-data.js?v=3"></script>
-  <script src="/assets/js/dashboard-analytics.js?v=5"></script>
-  <script type="module" src="assets/js/dashboard-api.js?v=36"></script>
+  <script src="/assets/js/dashboard-analytics.js?v=6"></script>
+  <script type="module" src="assets/js/dashboard-api.js?v=37"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- Analytics paints immediately from the same-account `/api/keys` payload already loaded for Keys (uid-keyed cache; cleared on sign-out / account switch). No second `fresh=1` Firestore round-trip unless you hit Refresh.
- Charts and KPIs grow in via `animateChart`; overlapping RAF is cancelled so a stale series cannot overwrite a fresh paint (the two reasons PR #78 was closed).
- Billing free-allowance bar is a Bayer dither meter (brand / orange / red), with the solid CSS fill as fallback.

Dashboard JS/CSS only. No billing API, compress, `vercel.json`, or Auth-claims changes.

## Test plan
- [ ] Sign in → Analytics: KPIs/charts animate in without a long spinner (uses Keys payload)
- [ ] Sign out, sign in as a different account → Analytics never flashes the previous account
- [ ] Refresh on Analytics still fetches live usage
- [ ] Billing: usage bar is dithered (not a solid CSS fill); 70%+ orange, 90%+ red
- [ ] Compress still 200 with a paid key (this PR does not touch `/compress`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive, visually enhanced usage meters to billing displays.
  * Dashboard analytics now animates KPI values and charts more smoothly.
  * Added support for cached dashboard data and optional refreshes.
  * Added a reset option for dashboard analytics state.

* **Bug Fixes**
  * Prevented outdated or canceled updates from overwriting current dashboard content.
  * Improved cache cleanup when switching users or signing out.
  * Billing usage meters now retry rendering when layout information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->