### PR TITLE
fix: billing usage bar actually dithered on production

### DIFF
--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -921,25 +921,38 @@ function renderActivationChecklist() {
   /* Activation checklist removed from dashboard UI. */
 }
 
+function billingMeterOpts(track) {
+  const pct = Number(track?.dataset?.usagePct);
+  return {
+    progress: (Number.isFinite(pct) ? pct : 0) / 100,
+    color: track?.dataset?.usageColor || "brand",
+  };
+}
+
+function watchBillingMeter(track) {
+  if (!track || track._dkMeterObs || typeof ResizeObserver !== "function") return;
+  const obs = new ResizeObserver(() => {
+    if (!track.isConnected) {
+      obs.disconnect();
+      return;
+    }
+    if (document.getElementById("panel-billing")?.classList.contains("hidden")) return;
+    window.DitherKitLite?.renderDitherMeter?.(track, billingMeterOpts(track));
+  });
+  obs.observe(track);
+  track._dkMeterObs = obs;
+}
+
 function paintBillingUsageMeter(track) {
   const kit = window.DitherKitLite;
   if (!track || !kit?.renderDitherMeter) return;
-  const pct = Number(track.dataset.usagePct);
-  const color = track.dataset.usageColor || "brand";
-  let tries = 20;
+  watchBillingMeter(track);
+  if (document.getElementById("panel-billing")?.classList.contains("hidden")) return;
   const paint = () => {
     if (!track.isConnected) return;
-    const w = track.getBoundingClientRect().width;
-    if (w < 8 && tries-- > 0) {
-      requestAnimationFrame(paint);
-      return;
-    }
-    kit.renderDitherMeter(track, {
-      progress: (Number.isFinite(pct) ? pct : 0) / 100,
-      color,
-    });
+    kit.renderDitherMeter(track, billingMeterOpts(track));
   };
-  requestAnimationFrame(paint);
+  requestAnimationFrame(() => requestAnimationFrame(paint));
 }
 
 function renderSubscription(sub) {

--- a/web/assets/js/dither-kit-lite.js
+++ b/web/assets/js/dither-kit-lite.js
@@ -621,23 +621,25 @@
 
   /** Horizontal Bayer usage meter (billing free-allowance bar). */
   function renderDitherMeter(el, options = {}) {
-    if (!el) return;
+    if (!el) return false;
+    el.querySelectorAll(".dash-billing-usage-fill").forEach((n) => n.remove());
     let canvas = el.querySelector("canvas.dk-meter");
     if (!canvas) {
-      el.querySelectorAll(".dash-billing-usage-fill").forEach((n) => n.remove());
       canvas = document.createElement("canvas");
       canvas.className = "dk-meter";
       canvas.setAttribute("aria-hidden", "true");
       el.appendChild(canvas);
     }
     const rect = el.getBoundingClientRect();
-    const cssW = Math.max(8, Math.round(rect.width || el.clientWidth || 240));
-    const cssH = Math.max(6, Math.round(rect.height || el.clientHeight || 8));
+    const cssW = Math.round(rect.width || el.clientWidth || 0);
+    const cssH = Math.round(rect.height || el.clientHeight || 0);
+    // Hidden panels are display:none → 0×0. Never fall back to a fake width.
+    if (cssW < 16 || cssH < 4) return false;
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
     canvas.width = Math.round(cssW * dpr);
     canvas.height = Math.round(cssH * dpr);
-    canvas.style.width = cssW + "px";
-    canvas.style.height = cssH + "px";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
     const ctx = canvas.getContext("2d");
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, cssW, cssH);
@@ -645,23 +647,26 @@
     const pct = clamp01((Number(options.progress) || 0) / (options.max || 1));
     const colorName = options.color || (pct >= 0.9 ? "red" : pct >= 0.7 ? "orange" : "brand");
     const seed = seedOf(colorName);
-    const { cols, rows } = backingSize(cssW, cssH);
+    const cell = 4;
+    const cols = Math.min(MAX_COLS, Math.max(8, Math.round(cssW / cell)));
+    const rows = Math.min(MAX_ROWS, Math.max(4, Math.round(cssH / cell)));
     const off = document.createElement("canvas");
     off.width = cols;
     off.height = rows;
     const octx = off.getContext("2d");
     const fillCols = Math.round(cols * pct);
-    octx.fillStyle = "rgba(15,23,42,0.06)";
+    octx.fillStyle = "rgba(15,23,42,0.08)";
     octx.fillRect(0, 0, cols, rows);
     for (let x = 0; x < fillCols; x++) {
       paintColumn(octx, x, 0, rows, seed, {
-        variant: "gradient",
-        intensity: 0.55,
+        variant: "dotted",
+        intensity: 0.92,
         dim: 1,
       });
     }
     ctx.imageSmoothingEnabled = false;
     ctx.drawImage(off, 0, 0, cssW, cssH);
+    return true;
   }
 
   function ensureWashCanvas(el) {

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -124,16 +124,16 @@
 
     .dash-billing-usage-track {
       width: 100%;
-      height: 8px;
+      height: 16px;
       border-radius: 4px;
-      background: var(--card-border);
+      background: #ecece8;
       overflow: hidden;
     }
 
     .dash-billing-usage-track canvas.dk-meter {
       display: block;
-      width: 100%;
-      height: 100%;
+      width: 100% !important;
+      height: 100% !important;
     }
 
     .dash-billing-usage-fill {
@@ -1124,10 +1124,10 @@ npm exec supercompress setup</pre>
   </footer>
   <script src="assets/js/firebase-config.js?v=3"></script>
   <script src="assets/js/supercompress.js?v=1"></script>
-  <script src="/assets/js/dither-kit-lite.js?v=13"></script>
+  <script src="/assets/js/dither-kit-lite.js?v=14"></script>
   <script src="/assets/js/analytics-data.js?v=3"></script>
   <script src="/assets/js/dashboard-analytics.js?v=6"></script>
-  <script type="module" src="assets/js/dashboard-api.js?v=37"></script>
+  <script type="module" src="/assets/js/dashboard-api.js?v=38"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- Billing panel is `display:none` until opened; the meter was painting at 0×0 and falling back to a 240px solid-looking strip.
- Paint only when the track has a real width, ResizeObserver when the panel unhides, coarser dotted Bayer, 16px track.
- Absolute `/assets/js/dashboard-api.js` + cache-bust `v=14` / `v=38`.

## Test plan
- [ ] Hard-refresh `/dashboard` → Billing: usage bar is a dotted Bayer fill, not a solid CSS bar
- [ ] Resize the window: meter still spans the track
- [ ] POST `/compress` still 401 (no routing change)

Made with [Cursor](https://cursor.com)