### PR TITLE
fix: 1M power-user email + free paywall without Firestore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Public page: https://www.supercompress.dev/changelog
 
 ### API / dashboard
 - Soft-200 scanner/probe noise (`softProbe`) so Vercel Observability error rate stays ~0; real clients with credentials still get proper 4xx
-- Auto branded **power-user email** when someone *newly* crosses 1M tokens (once ever; no backfill of current 1M+ accounts)
+- Auto branded **power-user email** when someone hits 1M tokens (once ever). Delivery is Auth-claim + Resend idempotency, not Firestore; welcome-drain backfills anyone already over 1M. Free users at 1M are paywalled from Auth claims even if Firestore is down.
 - **Dashboard Analytics panel** (dither charts): live usage from `/api/keys` after sign-in — tokens saved, requests, coding agents, and key breakdown. `/analytics` stays inside `/dashboard?panel=analytics`.
 - Fix Analytics chart paint: Bayer wells + stacked dither canvases, wait for layout before draw, no demo/fake flash on production.
 - Align `/api/account?op=usage` + dashboard `account_usage` with the billing ledger (CLI no longer under-counts vs dashboard)

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -355,8 +355,9 @@ function claimsByteLength(claims) {
 }
 
 /** Firebase custom claims cap at 1000 bytes — drop bulky non-ledger fields to fit.
- * Never delete sc_recent_billing entirely (idempotency watermarks). Prefer trimming
- * agent/key metadata and compacting watermark entries. */
+ * Never delete sc_recent_billing entirely (idempotency watermarks). Never delete
+ * sc_power_mail (1M power-user email stamp). Prefer trimming agent/key metadata
+ * and compacting watermark entries. */
 function fitCustomClaims(claims) {
   const next = { ...(claims || {}) };
   const steps = [
@@ -1268,4 +1269,6 @@ module.exports = {
   FREE_TOKENS_PER_MONTH,
   REPLAY_TTL_MS,
   IDEMPOTENCY_LEASE_MS,
+  fitCustomClaims,
+  setBillingClaims,
 };

--- a/api/_lib/billing-ledger.test.js
+++ b/api/_lib/billing-ledger.test.js
@@ -9,6 +9,7 @@ const {
   tokensToMicros,
   computeCompressFingerprint,
   assertUsageIdempotencyMatch,
+  fitCustomClaims,
 } = require("./billing-ledger");
 
 function ledger(partial = {}) {
@@ -205,5 +206,23 @@ assertUsageIdempotencyMatch(
   { tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
   { fingerprint: "newfp", tokensIn: 10, tokensOut: 5, tokensSaved: 5 }
 );
+
+{
+  const fitted = fitCustomClaims({
+    sc_power_mail: "sent",
+    sc_plan: "free",
+    sc_usage: { month: "2026-08", tokens_in: 1, requests: 1 },
+    sc_recent_billing: Array.from({ length: 8 }, (_, i) => ({
+      i: `id${i}${"x".repeat(36)}`,
+      f: "f".repeat(16),
+      tin: 9999,
+      tout: 9999,
+      ts: 1,
+      b: 0,
+      t: 1786630000000,
+    })),
+  });
+  assert.strictEqual(fitted.sc_power_mail, "sent");
+}
 
 console.log("billing-ledger.test.js: ok");

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -434,6 +434,7 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
         tokensSaved: extra.tokensSaved != null ? extra.tokensSaved : tokensSaved,
         requests: extra.requests != null ? extra.requests : Number(ownerClaims.sc_usage?.requests || 0) + 1,
         source: extra.source || "compress",
+        claims: owner.customClaims || ownerClaims,
       });
     } catch (err) {
       console.warn("power-user email skipped:", err.message || err);

--- a/api/_lib/power-user.js
+++ b/api/_lib/power-user.js
@@ -1,12 +1,12 @@
 /**
- * Once-ever power-user email when usage newly crosses 1M tokens.
- * Never backfills people already over the threshold.
+ * Once-ever power-user email when usage reaches 1M tokens.
+ * Durable on Auth claims (`sc_power_mail`) + Resend Idempotency-Key so it
+ * still sends when Firestore / config-store is down.
  */
 
-const { mutateStore } = require("./store");
-const { sendPowerUserEmail } = require("./mail");
-
 const POWER_USER_TOKENS = 1_000_000;
+const POWER_MAIL_CLAIM = "sc_power_mail";
+const DRAIN_AUTH_CAP = 40;
 
 function firstNameFromUser(user = {}) {
   const raw = user.displayName || user.name || "";
@@ -25,6 +25,18 @@ function crossedPowerUser(prevTokens, nextTokens, threshold = POWER_USER_TOKENS)
   return prev < threshold && next >= threshold;
 }
 
+function powerMailAlreadySent(claims = {}) {
+  return String(claims?.[POWER_MAIL_CLAIM] || "") === "sent";
+}
+
+/** True if they are at/over 1M and we have not stamped a successful send. */
+function shouldNotifyPowerUser(prevTokens, nextTokens, claims = {}, threshold = POWER_USER_TOKENS) {
+  if (powerMailAlreadySent(claims)) return false;
+  const prev = Number(prevTokens) || 0;
+  const next = Number(nextTokens) || 0;
+  return next >= threshold || prev >= threshold;
+}
+
 function statsFromUsage({ tokensIn, tokensSaved, requests } = {}) {
   const tin = Math.max(0, Number(tokensIn) || 0);
   const saved = Math.max(0, Number(tokensSaved) || 0);
@@ -35,35 +47,74 @@ function statsFromUsage({ tokensIn, tokensSaved, requests } = {}) {
   return { tokensIn: tin, tokensSaved: saved, requests: reqs, cutPct, morePct };
 }
 
+function powerUserIdempotencyKey(uid) {
+  return `power-user-${String(uid || "").trim()}`;
+}
+
 async function claimPowerUser(uid, extra = {}) {
   if (!uid) return { claimed: false, record: null, reason: "no_uid" };
-  return mutateStore((store) => {
-    if (!store.power_user_emails) store.power_user_emails = {};
-    const existing = store.power_user_emails[uid];
-    if (existing && existing.status && existing.status !== "failed") {
-      return { claimed: false, record: existing, reason: existing.status };
-    }
+  try {
+    const { mutateStore } = require("./store");
+    return await mutateStore((store) => {
+      if (!store.power_user_emails) store.power_user_emails = {};
+      const existing = store.power_user_emails[uid];
+      if (existing && existing.status && existing.status !== "failed") {
+        return { claimed: false, record: existing, reason: existing.status };
+      }
+      const record = {
+        ...(existing || {}),
+        uid,
+        status: "pending",
+        claimed_at: existing?.claimed_at || new Date().toISOString(),
+        retried_at: existing ? new Date().toISOString() : null,
+        idempotency_key: existing?.idempotency_key || powerUserIdempotencyKey(uid),
+        ...extra,
+      };
+      store.power_user_emails[uid] = record;
+      return { claimed: true, record };
+    });
+  } catch (err) {
     const record = {
-      ...(existing || {}),
       uid,
       status: "pending",
-      claimed_at: existing?.claimed_at || new Date().toISOString(),
-      retried_at: existing ? new Date().toISOString() : null,
-      idempotency_key: existing?.idempotency_key || `power-user-${uid}`,
+      claimed_at: new Date().toISOString(),
+      idempotency_key: powerUserIdempotencyKey(uid),
+      store_error: err.message || "store_unavailable",
       ...extra,
     };
-    store.power_user_emails[uid] = record;
-    return { claimed: true, record };
-  });
+    return { claimed: true, record, reason: "claims_fallback" };
+  }
 }
 
 async function markPowerUser(uid, patch) {
-  return mutateStore((store) => {
-    if (!store.power_user_emails) store.power_user_emails = {};
-    const prev = store.power_user_emails[uid] || { uid };
-    store.power_user_emails[uid] = { ...prev, ...patch };
-    return store.power_user_emails[uid];
-  });
+  try {
+    const { mutateStore } = require("./store");
+    return await mutateStore((store) => {
+      if (!store.power_user_emails) store.power_user_emails = {};
+      const prev = store.power_user_emails[uid] || { uid };
+      store.power_user_emails[uid] = { ...prev, ...patch };
+      return store.power_user_emails[uid];
+    });
+  } catch (err) {
+    return { uid, ...patch, store_error: err.message || "store_unavailable" };
+  }
+}
+
+async function stampPowerMailSent(uid) {
+  if (!uid) return false;
+  const { initFirebaseAdmin } = require("./auth");
+  const admin = require("firebase-admin");
+  if (!initFirebaseAdmin()) return false;
+  const { setBillingClaims } = require("./billing-ledger");
+  for (let i = 0; i < 3; i++) {
+    const user = await admin.auth().getUser(uid);
+    const prev = user.customClaims || {};
+    if (prev[POWER_MAIL_CLAIM] === "sent") return true;
+    await setBillingClaims(uid, { ...prev, [POWER_MAIL_CLAIM]: "sent" });
+    const after = await admin.auth().getUser(uid);
+    if ((after.customClaims || {})[POWER_MAIL_CLAIM] === "sent") return true;
+  }
+  return false;
 }
 
 function isDrainablePowerUser(rec) {
@@ -75,10 +126,9 @@ function isDrainablePowerUser(rec) {
 }
 
 async function deliverPowerUser(rec) {
+  const { sendPowerUserEmail } = require("./mail");
   const uid = rec.uid;
-  const idempotencyKey = rec.idempotency_key || `power-user-${uid}`;
-  // Mark sending before Resend so a crash after delivery does not look "pending"
-  // for a fresh send — drain retries with the same Idempotency-Key.
+  const idempotencyKey = rec.idempotency_key || powerUserIdempotencyKey(uid);
   await markPowerUser(uid, {
     status: "sending",
     send_attempt_at: new Date().toISOString(),
@@ -99,6 +149,11 @@ async function deliverPowerUser(rec) {
   });
 
   if (result.ok) {
+    try {
+      await stampPowerMailSent(uid);
+    } catch (err) {
+      console.warn("power-user claim stamp failed:", err.message || err);
+    }
     await markPowerUser(uid, {
       status: "sent",
       sent_at: new Date().toISOString(),
@@ -117,30 +172,6 @@ async function deliverPowerUser(rec) {
   return { ok: false, error: result.error || "send_failed" };
 }
 
-/**
- * Retry pending/failed/sending crossing emails. Never creates records — so people
- * already over 1M with no row stay unmailed.
- */
-async function drainPendingPowerUsers() {
-  const { loadStore } = require("./store");
-  const store = await loadStore();
-  const pending = Object.values(store.power_user_emails || {}).filter(isDrainablePowerUser);
-
-  let sent = 0;
-  let failed = 0;
-  for (const rec of pending) {
-    const result = await deliverPowerUser(rec);
-    if (result.ok) sent += 1;
-    else failed += 1;
-  }
-  return { pending: pending.length, sent, failed };
-}
-
-/**
- * Send the branded power-user email only on a true 1M crossing (or a failed
- * prior send for that same crossing). People already over 1M with no record
- * are left alone — no backfill.
- */
 async function maybeNotifyPowerUser({
   uid,
   email,
@@ -150,27 +181,43 @@ async function maybeNotifyPowerUser({
   tokensSaved,
   requests,
   source = "compress",
+  claims = null,
 } = {}) {
   if (!uid) return { ok: true, sent: false, reason: "no_uid" };
-  if (!crossedPowerUser(prevTokens, nextTokens)) {
+
+  const { initFirebaseAdmin } = require("./auth");
+  const admin = require("firebase-admin");
+  let live = claims || {};
+  let to = String(email || "").trim();
+  let name = displayName;
+  if (initFirebaseAdmin()) {
+    try {
+      const user = await admin.auth().getUser(uid);
+      live = user.customClaims || live;
+      if (!to) to = String(user.email || "").trim();
+      if (!name) name = user.displayName || "";
+    } catch (_) {
+      /* use caller-provided claims */
+    }
+  }
+
+  if (powerMailAlreadySent(live)) {
+    return { ok: true, sent: false, reason: "already_sent" };
+  }
+  if (!shouldNotifyPowerUser(prevTokens, nextTokens, live)) {
     return { ok: true, sent: false, reason: "not_crossed" };
   }
 
-  const to = String(email || "").trim();
-  const firstName = firstNameFromUser({ displayName, email: to });
-  const { claimed, record, reason } = await claimPowerUser(uid, {
+  const firstName = firstNameFromUser({ displayName: name, email: to });
+  const extra = {
     email: to,
     first_name: firstName,
-    tokens_in: Number(nextTokens) || 0,
-    tokens_saved: Number(tokensSaved) || 0,
-    requests: Number(requests) || 0,
+    tokens_in: Number(nextTokens) || Number(live.sc_usage?.tokens_in || 0),
+    tokens_saved: Number(tokensSaved) || Number(live.sc_usage?.tokens_saved || 0),
+    requests: Number(requests) || Number(live.sc_usage?.requests || 0),
     source,
-  });
-  if (!claimed) {
-    // If a prior attempt died while "sending", drain will finish with same
-    // Idempotency-Key. Do not start a second claim here.
-    return { ok: true, sent: false, reason: reason || "already_claimed", record };
-  }
+  };
+  const { record } = await claimPowerUser(uid, extra);
 
   if (!to.includes("@")) {
     await markPowerUser(uid, {
@@ -180,17 +227,88 @@ async function maybeNotifyPowerUser({
     return { ok: true, sent: false, reason: "no_email" };
   }
 
-  const result = await deliverPowerUser({
-    ...record,
-    email: to,
-    first_name: firstName,
-    tokens_in: Number(nextTokens) || 0,
-    tokens_saved: Number(tokensSaved) || 0,
-    requests: Number(requests) || 0,
-  });
-
+  const result = await deliverPowerUser({ ...record, ...extra, email: to });
   if (result.ok) return { ok: true, sent: true };
   return { ok: false, sent: false, queued: true, reason: result.error || "send_failed" };
+}
+
+function isStubUid(uid) {
+  return /^(sck_|sc_at_|sc_ac_|sc_aff_)/.test(String(uid || ""));
+}
+
+async function drainAuthPowerUsers({ cap = DRAIN_AUTH_CAP } = {}) {
+  const { initFirebaseAdmin } = require("./auth");
+  const admin = require("firebase-admin");
+  if (!initFirebaseAdmin()) return { scanned: 0, mailed: 0, skipped: 0, error: "no_admin" };
+
+  let scanned = 0;
+  let mailed = 0;
+  let skipped = 0;
+  let pageToken;
+  do {
+    const page = await admin.auth().listUsers(1000, pageToken);
+    for (const user of page.users) {
+      if (mailed >= cap) break;
+      if (isStubUid(user.uid) || user.disabled) continue;
+      const email = String(user.email || "").trim().toLowerCase();
+      if (!email.includes("@") || email.includes("noreply")) continue;
+      const claims = user.customClaims || {};
+      if (powerMailAlreadySent(claims)) {
+        skipped += 1;
+        continue;
+      }
+      const tin = Number(claims.sc_usage?.tokens_in || 0);
+      if (tin < POWER_USER_TOKENS) continue;
+      scanned += 1;
+      const result = await maybeNotifyPowerUser({
+        uid: user.uid,
+        email: user.email,
+        displayName: user.displayName || "",
+        prevTokens: tin,
+        nextTokens: tin,
+        tokensSaved: claims.sc_usage?.tokens_saved,
+        requests: claims.sc_usage?.requests,
+        source: "drain",
+        claims,
+      });
+      if (result.sent) mailed += 1;
+    }
+    pageToken = mailed >= cap ? null : page.pageToken;
+  } while (pageToken);
+
+  return { scanned, mailed, skipped };
+}
+
+/**
+ * Retry store-queued sends, then mail anyone already over 1M with no sent stamp.
+ */
+async function drainPendingPowerUsers() {
+  let storePending = 0;
+  let storeSent = 0;
+  let storeFailed = 0;
+  let storeError = null;
+  try {
+    const { loadStore } = require("./store");
+    const store = await loadStore();
+    const pending = Object.values(store.power_user_emails || {}).filter(isDrainablePowerUser);
+    storePending = pending.length;
+    for (const rec of pending) {
+      const result = await deliverPowerUser(rec);
+      if (result.ok) storeSent += 1;
+      else storeFailed += 1;
+    }
+  } catch (err) {
+    storeError = err.message || "store_unavailable";
+  }
+
+  const authDrain = await drainAuthPowerUsers();
+  return {
+    pending: storePending,
+    sent: storeSent,
+    failed: storeFailed,
+    store_error: storeError,
+    auth: authDrain,
+  };
 }
 
 function schedulePowerUserEmail(opts) {
@@ -201,7 +319,10 @@ function schedulePowerUserEmail(opts) {
 
 module.exports = {
   POWER_USER_TOKENS,
+  POWER_MAIL_CLAIM,
   crossedPowerUser,
+  powerMailAlreadySent,
+  shouldNotifyPowerUser,
   statsFromUsage,
   firstNameFromUser,
   isDrainablePowerUser,
@@ -209,5 +330,8 @@ module.exports = {
   markPowerUser,
   maybeNotifyPowerUser,
   drainPendingPowerUsers,
+  drainAuthPowerUsers,
   schedulePowerUserEmail,
+  stampPowerMailSent,
+  powerUserIdempotencyKey,
 };

--- a/api/_lib/power-user.test.js
+++ b/api/_lib/power-user.test.js
@@ -7,6 +7,8 @@ const { powerUserCopy } = require("./mail");
 const {
   POWER_USER_TOKENS,
   crossedPowerUser,
+  powerMailAlreadySent,
+  shouldNotifyPowerUser,
   statsFromUsage,
   firstNameFromUser,
   isDrainablePowerUser,
@@ -20,6 +22,13 @@ assert.strictEqual(crossedPowerUser(1_000_000, 1_000_001), false);
 assert.strictEqual(crossedPowerUser(1_400_000, 1_500_000), false);
 assert.strictEqual(crossedPowerUser(800_000, 1_200_000), true);
 assert.strictEqual(crossedPowerUser("900000", "1000001"), true);
+
+assert.strictEqual(powerMailAlreadySent({ sc_power_mail: "sent" }), true);
+assert.strictEqual(powerMailAlreadySent({}), false);
+assert.strictEqual(shouldNotifyPowerUser(900_000, 1_100_000, {}), true);
+assert.strictEqual(shouldNotifyPowerUser(1_400_000, 1_400_000, {}), true);
+assert.strictEqual(shouldNotifyPowerUser(1_400_000, 1_400_000, { sc_power_mail: "sent" }), false);
+assert.strictEqual(shouldNotifyPowerUser(100, 200, {}), false);
 
 {
   const s = statsFromUsage({ tokensIn: 1_000_000, tokensSaved: 400_000, requests: 12 });

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -58,26 +58,35 @@ async function enforceUsageLimit(owner) {
     // Transition: treat as credit wallet with 0 balance until top-up
   }
 
-  const { loadLedger, microsToUsd } = require("../_lib/billing-ledger");
-  let ledger;
-  try {
-    ledger = await loadLedger(owner.uid, claims);
-  } catch (err) {
-    const e = new Error("Billing unavailable — try again shortly.");
-    e.status = 503;
-    e.code = "billing_unavailable";
-    throw e;
-  }
-  const tokensUsedThisPeriod = Number(ledger.tokens_in || 0);
-
-  if (tokensUsedThisPeriod < FREE_TOKENS_PER_MONTH) return;
-
+  const month = new Date().toISOString().slice(0, 7);
+  const claimUsage = claims.sc_usage?.month === month ? claims.sc_usage : {};
+  const claimUsed = Number(claimUsage.tokens_in || 0);
+  const freeUser = !isPaygEnabled(planId) && !isCreditWallet(claims);
   const upgradeUrl = "https://www.supercompress.dev/dashboard#billing";
-  const usedM = (tokensUsedThisPeriod / 1_000_000).toFixed(2);
-  const freeM = (FREE_TOKENS_PER_MONTH / 1_000_000).toFixed(0);
 
-  // Past free allowance
-  if (!isPaygEnabled(planId) && !isCreditWallet(claims)) {
+  const notifyIfPowerUser = (used) => {
+    try {
+      const { schedulePowerUserEmail } = require("../_lib/power-user");
+      schedulePowerUserEmail({
+        uid: owner.uid,
+        email: owner.email || "",
+        displayName: owner.displayName || "",
+        prevTokens: used,
+        nextTokens: used,
+        tokensSaved: Number(claimUsage.tokens_saved || 0),
+        requests: Number(claimUsage.requests || 0),
+        source: "paywall",
+        claims,
+      });
+    } catch (err) {
+      console.warn("power-user email skipped:", err.message || err);
+    }
+  };
+
+  const throwFreePaywall = (tokensUsedThisPeriod) => {
+    notifyIfPowerUser(tokensUsedThisPeriod);
+    const usedM = (tokensUsedThisPeriod / 1_000_000).toFixed(2);
+    const freeM = (FREE_TOKENS_PER_MONTH / 1_000_000).toFixed(0);
     const err = new Error(
       `PAYWALL: Free ${freeM}M tokens used (${usedM}M this month). Compression is paused. Add credits to unlock — $0.30 per 1M tokens after free (min $10 load). ${upgradeUrl}`
     );
@@ -98,6 +107,32 @@ async function enforceUsageLimit(owner) {
       action: "open_billing",
     };
     throw err;
+  };
+
+  // Claims-first: do not wait on Firestore to block free users already over 1M.
+  if (freeUser && claimUsed >= FREE_TOKENS_PER_MONTH) {
+    throwFreePaywall(claimUsed);
+  }
+
+  const { loadLedger, microsToUsd } = require("../_lib/billing-ledger");
+  let ledger;
+  try {
+    ledger = await loadLedger(owner.uid, claims);
+  } catch (err) {
+    if (freeUser && claimUsed >= FREE_TOKENS_PER_MONTH) throwFreePaywall(claimUsed);
+    if (freeUser) return;
+    const e = new Error("Billing unavailable — try again shortly.");
+    e.status = 503;
+    e.code = "billing_unavailable";
+    throw e;
+  }
+  const tokensUsedThisPeriod = Number(ledger.tokens_in || 0);
+
+  if (tokensUsedThisPeriod < FREE_TOKENS_PER_MONTH) return;
+
+  // Past free allowance
+  if (freeUser) {
+    throwFreePaywall(tokensUsedThisPeriod);
   }
 
   let balance = roundUsd(


### PR DESCRIPTION
## Summary
- Power-user mail no longer depends on Firestore. Auth claim `sc_power_mail=sent` + Resend `Idempotency-Key: power-user-${uid}` is the source of truth; store writes are best-effort.
- `shouldNotifyPowerUser` fires whenever monthly `tokens_in >= 1M` and the claim is not stamped (covers the exact crossing **and** people already over who never got mail).
- Welcome-drain scans Auth (cap 40/run) so the current 1M+ free/PAYG users get the email without waiting for another compress.
- Free users at 1M are **402'd from Auth claims first** — do not wait on Firestore, do not 503. The 402 path also schedules the power-user email.
- Paid compress still fail-opens for free users under cap if ledger load fails; PAYG still 503s. `fitCustomClaims` never drops `sc_power_mail`.

## Test plan
- [x] `node api/_lib/power-user.test.js`
- [x] `node api/_lib/billing-ledger.test.js`
- [x] `node --check` on edited JS
- [ ] CI smoke green
- [ ] After merge + `vercel --prod`: `POST https://api.supercompress.dev/compress` is **401, not 3xx**
- [ ] Trigger `welcome-drain` so existing 1M+ users get mail
- [ ] Known free ≥1M uid would 402 on compress (do not compress as them)


Made with [Cursor](https://cursor.com)