### PR TITLE
fix: 1M power-user drain must not die on gist 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Public page: https://www.supercompress.dev/changelog
 ### API / dashboard
 - Soft-200 scanner/probe noise (`softProbe`) so Vercel Observability error rate stays ~0; real clients with credentials still get proper 4xx
 - Auto branded **power-user email** when someone hits 1M tokens (once ever). Delivery is Auth-claim + Resend idempotency, not Firestore; welcome-drain backfills anyone already over 1M. Free users at 1M are paywalled from Auth claims even if Firestore is down.
+- Welcome-drain no longer aborts on gist/store errors before sending 1M power-user mail; `op=power-user-drain` can run that lane alone.
 - **Dashboard Analytics panel** (dither charts): live usage from `/api/keys` after sign-in — tokens saved, requests, coding agents, and key breakdown. `/analytics` stays inside `/dashboard?panel=analytics`.
 - Fix Analytics chart paint: Bayer wells + stacked dither canvases, wait for layout before draw, no demo/fake flash on production.
 - Align `/api/account?op=usage` + dashboard `account_usage` with the billing ledger (CLI no longer under-counts vs dashboard)

--- a/api/account.js
+++ b/api/account.js
@@ -582,24 +582,34 @@ module.exports = async (req, res) => {
   if (op === "welcome-drain" && (req.method === "POST" || req.method === "GET")) {
     const body = req.method === "POST" ? readBody(req) : {};
     if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    // Isolate each lane: gist/store 403 must not skip 1M power-user mail.
+    let welcome = { pending: 0, sent: 0, failed: 0 };
     try {
-      const result = await drainPendingWelcomes();
-      let power_user = null;
-      try {
-        power_user = await drainPendingPowerUsers();
-      } catch (powerErr) {
-        power_user = { ok: false, error: powerErr.message || "power_user_drain_failed" };
-      }
-      // Also nudge weekly queue so mid-week backlog clears on the daily cron.
-      let weekly = null;
-      try {
-        weekly = await weeklyTick();
-      } catch (weeklyErr) {
-        weekly = { ok: false, error: weeklyErr.message || "weekly_tick_failed" };
-      }
-      return json(res, 200, { ok: true, ...result, power_user, weekly });
+      welcome = await drainPendingWelcomes();
     } catch (err) {
-      return json(res, err.status || 500, { detail: err.message });
+      welcome = { pending: 0, sent: 0, failed: 0, error: err.message || "welcome_drain_failed" };
+    }
+    let power_user = null;
+    try {
+      power_user = await drainPendingPowerUsers();
+    } catch (powerErr) {
+      power_user = { ok: false, error: powerErr.message || "power_user_drain_failed" };
+    }
+    let weekly = null;
+    try {
+      weekly = await weeklyTick();
+    } catch (weeklyErr) {
+      weekly = { ok: false, error: weeklyErr.message || "weekly_tick_failed" };
+    }
+    return json(res, 200, { ok: true, ...welcome, power_user, weekly });
+  }
+  if (op === "power-user-drain" && (req.method === "POST" || req.method === "GET")) {
+    const body = req.method === "POST" ? readBody(req) : {};
+    if (!drainSecretOk(req, body)) return json(res, 401, { detail: "Unauthorized" });
+    try {
+      return json(res, 200, { ok: true, ...(await drainPendingPowerUsers()) });
+    } catch (err) {
+      return json(res, err.status || 500, { detail: err.message || "power_user_drain_failed" });
     }
   }
 
@@ -793,6 +803,7 @@ module.exports = async (req, res) => {
       "connect-device",
       "welcome",
       "welcome-drain",
+      "power-user-drain",
       "weekly-tick",
       "weekly-drain",
       "weekly-unsubscribe",


### PR DESCRIPTION
## Summary
- Welcome-drain was 503'ing on GitHub gist rate-limit **before** Auth power-user backfill ran, so nobody over 1M got mail.
- Isolate welcome / power-user / weekly lanes. Add `op=power-user-drain` to send the 1M emails without touching gist.

## Test plan
- [x] `node --check api/account.js`
- [ ] CI smoke green
- [ ] After prod deploy: `POST /api/account?op=power-user-drain` returns 200 with `auth.mailed` > 0
- [ ] `POST https://api.supercompress.dev/compress` is **401, not 3xx**


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standalone, authenticated power-user email operation available through both GET and POST requests.
  - Updated the combined welcome-drain process to continue running independent processing lanes when one encounters an error.
  - Added per-lane processing results for clearer operation status reporting.

- **Documentation**
  - Updated the unreleased API/dashboard changelog with the new power-user drain behavior and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->