### PR TITLE
fix: scale without Firestore — Auth ledger, no gist on compress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
         run: node api/_lib/coding-agent-usage.test.js
       - name: Soft-probe unit tests
         run: node api/_lib/http-soft-probe.test.js
+      - name: Firestore skip default
+        run: node api/_lib/firebase-off.test.js
       - name: Power-user milestone unit tests
         run: node api/_lib/power-user.test.js
       - name: Analytics aggregation unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Public page: https://www.supercompress.dev/changelog
 - Soft-200 scanner/probe noise (`softProbe`) so Vercel Observability error rate stays ~0; real clients with credentials still get proper 4xx
 - Auto branded **power-user email** when someone hits 1M tokens (once ever). Delivery is Auth-claim + Resend idempotency, not Firestore; welcome-drain backfills anyone already over 1M. Free users at 1M are paywalled from Auth claims even if Firestore is down.
 - Welcome-drain no longer aborts on gist/store errors before sending 1M power-user mail; `op=power-user-drain` can run that lane alone.
+- **No Firestore on the hot path** (default). Billing, keys, welcome/weekly mail, and rate limits use Auth claims + Resend idempotency. Gist is optional/cold only. Set `SUPERCOMPRESS_USE_FIRESTORE=1` to opt back in after the API is enabled.
 - **Dashboard Analytics panel** (dither charts): live usage from `/api/keys` after sign-in — tokens saved, requests, coding agents, and key breakdown. `/analytics` stays inside `/dashboard?panel=analytics`.
 - Fix Analytics chart paint: Bayer wells + stacked dither canvases, wait for layout before draw, no demo/fake flash on production.
 - Align `/api/account?op=usage` + dashboard `account_usage` with the billing ledger (CLI no longer under-counts vs dashboard)

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -326,7 +326,12 @@ async function withFirestoreTimeout(work, timeoutMs = 1200) {
 }
 
 async function loadLedger(uid, claims = {}) {
-  if (!uid || !initFirebaseAdmin()) {
+  if (!uid) {
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
+  }
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore()) return normalizeLedger(null, claims);
+  if (!initFirebaseAdmin()) {
     throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
   try {
@@ -356,8 +361,7 @@ function claimsByteLength(claims) {
 
 /** Firebase custom claims cap at 1000 bytes — drop bulky non-ledger fields to fit.
  * Never delete sc_recent_billing entirely (idempotency watermarks). Never delete
- * sc_power_mail (1M power-user email stamp). Prefer trimming agent/key metadata
- * and compacting watermark entries. */
+ * sc_power_mail, sc_welcome, sc_wk, sc_unsub, or sc_ku. */
 function fitCustomClaims(claims) {
   const next = { ...(claims || {}) };
   const steps = [
@@ -542,6 +546,42 @@ function usageDocExpiredReplay(data) {
   return Date.now() - created > REPLAY_TTL_MS;
 }
 
+async function claimsIdempotencyLease(uid, rid, fp) {
+  const fresh = await admin().auth().getUser(uid);
+  const live = mergeLiveClaims(fresh.customClaims, {});
+  const recent = Array.isArray(live.sc_recent_billing) ? live.sc_recent_billing : [];
+  const prior = recent.find((r) => r && r.i === rid);
+  if (prior) {
+    assertUsageIdempotencyMatch(
+      {
+        fingerprint: prior.f || null,
+        tokens_in: prior.tin,
+        tokens_out: prior.tout,
+        tokens_saved: prior.ts,
+      },
+      {
+        fingerprint: fp,
+        tokensIn: prior.tin,
+        tokensOut: prior.tout,
+        tokensSaved: prior.ts,
+      }
+    );
+    return {
+      status: "completed",
+      data: {
+        fingerprint: prior.f || fp,
+        tokens_in: prior.tin,
+        tokens_out: prior.tout,
+        tokens_saved: prior.ts,
+        burned_micros: prior.b,
+        response: null,
+      },
+      backend: "claims-fallback",
+    };
+  }
+  return { status: "acquired", backend: "claims-fallback" };
+}
+
 /**
  * Pre-compression single-flight lease for Idempotency-Key.
  * @returns {{ status: 'acquired'|'completed'|'pending', data?: object }}
@@ -551,6 +591,10 @@ async function reserveIdempotencyLease(uid, requestId, fingerprint) {
   const fp = String(fingerprint || "").trim() || null;
   if (!uid || !rid || !initFirebaseAdmin()) {
     throw billingError("billing_unavailable", "Billing ledger unavailable");
+  }
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore()) {
+    return claimsIdempotencyLease(uid, rid, fp);
   }
   try {
     return await withFirestoreTimeout(() => {
@@ -610,38 +654,7 @@ async function reserveIdempotencyLease(uid, requestId, fingerprint) {
     markFirestoreDown(err);
     console.warn("reserveIdempotencyLease unavailable — claims fallback:", err?.message || err);
     try {
-      const fresh = await admin().auth().getUser(uid);
-      const live = mergeLiveClaims(fresh.customClaims, {});
-      const recent = Array.isArray(live.sc_recent_billing) ? live.sc_recent_billing : [];
-      const prior = recent.find((r) => r && r.i === rid);
-      if (prior) {
-        assertUsageIdempotencyMatch(
-          {
-            fingerprint: prior.f || null,
-            tokens_in: prior.tin,
-            tokens_out: prior.tout,
-            tokens_saved: prior.ts,
-          },
-          {
-            fingerprint: fp,
-            tokensIn: prior.tin,
-            tokensOut: prior.tout,
-            tokensSaved: prior.ts,
-          }
-        );
-        return {
-          status: "completed",
-          data: {
-            fingerprint: prior.f || fp,
-            tokens_in: prior.tin,
-            tokens_out: prior.tout,
-            tokens_saved: prior.ts,
-            burned_micros: prior.b,
-            response: null,
-          },
-          backend: "claims-fallback",
-        };
-      }
+      return await claimsIdempotencyLease(uid, rid, fp);
     } catch (fallbackErr) {
       if (fallbackErr.code === "idempotency_conflict") throw fallbackErr;
     }
@@ -746,7 +759,10 @@ function sanitizeReplayResponse(response) {
  */
 async function lookupUsageReplay(uid, requestId) {
   const rid = sanitizeRequestId(requestId);
-  if (!uid || !rid || !initFirebaseAdmin()) return null;
+  if (!uid || !rid) return null;
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore()) return null;
+  if (!initFirebaseAdmin()) return null;
   try {
     const snap = await db().collection("billing_usage").doc(`${uid}:${rid}`).get();
     if (!snap.exists) return null;
@@ -793,6 +809,20 @@ async function applyUsageAndBurn({
   const replay = sanitizeReplayResponse(response);
   if (!initFirebaseAdmin()) {
     throw billingError("billing_unavailable", "Billing ledger unavailable");
+  }
+
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore()) {
+    return applyUsageAndBurnClaimsFallback({
+      uid,
+      tokensIn,
+      tokensOut,
+      tokensSaved,
+      claims,
+      requestId: rid,
+      fingerprint: fp,
+      response,
+    });
   }
 
   let result;
@@ -1054,6 +1084,18 @@ async function creditBalance({
 }) {
   if (!uid || !creditKey) return { applied: false, reason: "missing_args" };
   if (!initFirebaseAdmin()) return { applied: false, reason: "firebase_unavailable" };
+
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore()) {
+    return creditBalanceClaimsFallback({
+      uid,
+      creditUsd,
+      creditKey,
+      claims,
+      patch,
+      firstPayBonusUsd,
+    });
+  }
 
   const wantBonus = Math.max(0, Number(firstPayBonusUsd) || 0);
 

--- a/api/_lib/compress-log.js
+++ b/api/_lib/compress-log.js
@@ -170,6 +170,10 @@ async function loadViaStore(ownerUid) {
 
 async function appendCompressLog(ownerUid, entry) {
   if (!ownerUid) return { ok: false, reason: "no_owner" };
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore()) {
+    return { ok: false, reason: "firestore_skipped" };
+  }
   try {
     await appendViaFirestore(ownerUid, entry);
     return { ok: true, storage: "firestore", entry: normalizeEntry(entry) };
@@ -200,6 +204,16 @@ async function appendCompressLog(ownerUid, entry) {
 
 async function listCompressLog(ownerUid, { limit = 40 } = {}) {
   if (!ownerUid) return { entries: [], updated_at: null };
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore()) {
+    return {
+      entries: [],
+      updated_at: null,
+      storage: "skipped",
+      caps: { max_entries: MAX_ENTRIES, preview_chars: PREVIEW_MAX },
+      note: "Previews only — full dumps are never stored.",
+    };
+  }
   const lim = Math.max(1, Math.min(MAX_ENTRIES, Number(limit) || MAX_ENTRIES));
   try {
     const fromFs = await loadViaFirestore(ownerUid);

--- a/api/_lib/engine.js
+++ b/api/_lib/engine.js
@@ -108,6 +108,8 @@ function ccrOwnerDocPath(ownerUid, hash) {
  */
 async function ccrStoreFirestore(hash, originalText, meta = {}) {
   try {
+    const { skipFirestore } = require("./firebase-off");
+    if (skipFirestore()) return false;
     const admin = require("firebase-admin");
     const { initFirebaseAdmin } = require("./auth");
     initFirebaseAdmin();

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -125,7 +125,12 @@ async function findAuthBackedKey(secret) {
 }
 
 async function listKeys(ownerUid) {
-  const store = await loadStore({ forceRemote: true });
+  let store = { keys: {}, usage: {} };
+  try {
+    store = await loadStore({ forceRemote: true });
+  } catch (err) {
+    console.warn("listKeys: store skipped:", err.message);
+  }
 
   // One-time pull of any remaining Auth-indexed keys for this owner.
   try {
@@ -135,14 +140,32 @@ async function listKeys(ownerUid) {
       if (store.keys[uid]) continue;
       const user = await auth().getUser(uid).catch(() => null);
       if (user?.customClaims?.sc_api_key) {
-        await migrateAuthKeyToStore(user, null);
+        try {
+          await migrateAuthKeyToStore(user, null);
+        } catch (migErr) {
+          store.keys[uid] = {
+            id: uid,
+            user_id: ownerUid,
+            name: user.customClaims.sc_name || "API key",
+            prefix: user.customClaims.sc_prefix || "",
+            created_at: user.customClaims.sc_created || user.metadata?.creationTime,
+            last_used_at: user.customClaims.sc_last || null,
+            revoked: Boolean(user.disabled),
+          };
+          console.warn("listKeys: Auth migrate skipped:", migErr.message);
+        }
       }
     }
   } catch (err) {
     console.warn("listKeys: Auth migration skipped:", err.message);
   }
 
-  const fresh = await loadStore({ forceRemote: true });
+  let fresh = store;
+  try {
+    fresh = await loadStore({ forceRemote: true });
+  } catch (_) {
+    fresh = store;
+  }
   const keys = listUserKeys(fresh, ownerUid).map(publicKey);
   let usage = userUsage(fresh, ownerUid);
 
@@ -240,34 +263,42 @@ async function listKeys(ownerUid) {
 }
 
 async function createKey(ownerUid, name, maxKeys) {
-  await ownerRecord(ownerUid); // ensure real account exists
+  await ownerRecord(ownerUid);
+  const { skipFirestore } = require("./firebase-off");
+  if (!skipFirestore()) {
+    try {
+      return await mutateStore((store) => {
+        const active = listUserKeys(store, ownerUid);
+        if (active.length >= maxKeys) {
+          const err = new Error(`Plan limit reached: ${maxKeys} API keys. Upgrade to increase this limit.`);
+          err.status = 429;
+          throw err;
+        }
 
-  return mutateStore((store) => {
-    const active = listUserKeys(store, ownerUid);
-    if (active.length >= maxKeys) {
-      const err = new Error(`Plan limit reached: ${maxKeys} API keys. Upgrade to increase this limit.`);
-      err.status = 429;
-      throw err;
+        const gen = generateApiKey();
+        const id = `key_${crypto.randomBytes(12).toString("hex")}`;
+        const created = new Date().toISOString();
+        const rec = {
+          id,
+          user_id: ownerUid,
+          name: String(name || "Production").trim().slice(0, 80) || "Production",
+          prefix: gen.prefix,
+          key_hash: gen.key_hash,
+          created_at: created,
+          last_used_at: null,
+          revoked: false,
+        };
+        store.keys[id] = rec;
+        store.hash_index[gen.key_hash] = id;
+        store.usage[id] = {};
+        return { key: publicKey(rec), secret: gen.full_key };
+      });
+    } catch (err) {
+      console.warn("createKey: store skipped, Auth stub:", err.message);
     }
-
-    const gen = generateApiKey();
-    const id = `key_${crypto.randomBytes(12).toString("hex")}`;
-    const created = new Date().toISOString();
-    const rec = {
-      id,
-      user_id: ownerUid,
-      name: String(name || "Production").trim().slice(0, 80) || "Production",
-      prefix: gen.prefix,
-      key_hash: gen.key_hash,
-      created_at: created,
-      last_used_at: null,
-      revoked: false,
-    };
-    store.keys[id] = rec;
-    store.hash_index[gen.key_hash] = id;
-    store.usage[id] = {};
-    return { key: publicKey(rec), secret: gen.full_key };
-  });
+  }
+  const { createAuthPluginKey } = require("./auth-connect");
+  return createAuthPluginKey(ownerUid, name || "Production");
 }
 
 async function getOwnedKey(ownerUid, keyUid) {
@@ -536,43 +567,46 @@ async function recordUsage(keyRec, owner, compressed, opts = {}) {
       console.warn("recordUsage: durable key_usage skipped:", err.message);
     }
 
-    try {
-      await mutateStore((store) => {
-        if (!store.keys[keyId]) {
-          store.keys[keyId] = {
-            id: keyId,
-            user_id: ownerUid,
-            name: keyRec.name || "API key",
-            prefix: keyRec.prefix || "",
-            key_hash: keyRec.key_hash || null,
-            created_at: keyRec.created_at || now,
-            last_used_at: now,
-            revoked: false,
-          };
-          if (keyRec.key_hash) store.hash_index[keyRec.key_hash] = keyId;
-        } else {
-          store.keys[keyId].last_used_at = now;
-        }
-        if (durableOk) return store.keys[keyId];
-        if (!store.usage[keyId]) store.usage[keyId] = {};
-        if (!store.usage[keyId][day]) {
-          store.usage[keyId][day] = {
-            key_id: keyId,
-            requests: 0,
-            tokens_in: 0,
-            tokens_out: 0,
-            tokens_saved: 0,
-          };
-        }
-        const u = store.usage[keyId][day];
-        u.requests += 1;
-        u.tokens_in += compressed.original_tokens;
-        u.tokens_out += compressed.kept_tokens;
-        u.tokens_saved += tokensSaved;
-        return u;
-      });
-    } catch (err) {
-      console.warn("recordUsage: store update skipped:", err.message);
+    const { skipFirestore } = require("./firebase-off");
+    if (!skipFirestore()) {
+      try {
+        await mutateStore((store) => {
+          if (!store.keys[keyId]) {
+            store.keys[keyId] = {
+              id: keyId,
+              user_id: ownerUid,
+              name: keyRec.name || "API key",
+              prefix: keyRec.prefix || "",
+              key_hash: keyRec.key_hash || null,
+              created_at: keyRec.created_at || now,
+              last_used_at: now,
+              revoked: false,
+            };
+            if (keyRec.key_hash) store.hash_index[keyRec.key_hash] = keyId;
+          } else {
+            store.keys[keyId].last_used_at = now;
+          }
+          if (durableOk) return store.keys[keyId];
+          if (!store.usage[keyId]) store.usage[keyId] = {};
+          if (!store.usage[keyId][day]) {
+            store.usage[keyId][day] = {
+              key_id: keyId,
+              requests: 0,
+              tokens_in: 0,
+              tokens_out: 0,
+              tokens_saved: 0,
+            };
+          }
+          const u = store.usage[keyId][day];
+          u.requests += 1;
+          u.tokens_in += compressed.original_tokens;
+          u.tokens_out += compressed.kept_tokens;
+          u.tokens_saved += tokensSaved;
+          return u;
+        });
+      } catch (err) {
+        console.warn("recordUsage: store update skipped:", err.message);
+      }
     }
 
     if (String(keyId).startsWith(KEY_UID_PREFIX)) {

--- a/api/_lib/firebase-off.js
+++ b/api/_lib/firebase-off.js
@@ -1,0 +1,13 @@
+/**
+ * Cloud Firestore is disabled on this project (API never enabled).
+ * Default: skip every Firestore probe so compress/billing/mail do not pay
+ * 1.2s timeouts or 403 gist fallbacks on the hot path.
+ *
+ * Opt back in with SUPERCOMPRESS_USE_FIRESTORE=1 after the API is enabled.
+ */
+function skipFirestore() {
+  const v = String(process.env.SUPERCOMPRESS_USE_FIRESTORE || "").trim().toLowerCase();
+  return !(v === "1" || v === "true" || v === "yes");
+}
+
+module.exports = { skipFirestore };

--- a/api/_lib/firebase-off.test.js
+++ b/api/_lib/firebase-off.test.js
@@ -1,0 +1,20 @@
+const assert = require("assert");
+const { skipFirestore } = require("./firebase-off");
+
+const prev = process.env.SUPERCOMPRESS_USE_FIRESTORE;
+delete process.env.SUPERCOMPRESS_USE_FIRESTORE;
+assert.strictEqual(skipFirestore(), true);
+
+process.env.SUPERCOMPRESS_USE_FIRESTORE = "1";
+assert.strictEqual(skipFirestore(), false);
+
+process.env.SUPERCOMPRESS_USE_FIRESTORE = "true";
+assert.strictEqual(skipFirestore(), false);
+
+process.env.SUPERCOMPRESS_USE_FIRESTORE = "";
+assert.strictEqual(skipFirestore(), true);
+
+if (prev == null) delete process.env.SUPERCOMPRESS_USE_FIRESTORE;
+else process.env.SUPERCOMPRESS_USE_FIRESTORE = prev;
+
+console.log("firebase-off.test.js: ok");

--- a/api/_lib/mail.js
+++ b/api/_lib/mail.js
@@ -533,12 +533,15 @@ async function sendViaResend({
   return { ok: true, provider: "resend", id: body?.id || null };
 }
 
-async function sendWelcomeEmail({ email, firstName }) {
+async function sendWelcomeEmail({ email, firstName, idempotencyKey }) {
   if (!email || !String(email).includes("@")) {
     return { ok: false, error: "missing email" };
   }
   const copy = welcomeCopy({ firstName, email: String(email).trim() });
-  const result = await sendViaResend(copy);
+  const result = await sendViaResend({
+    ...copy,
+    idempotencyKey: idempotencyKey || null,
+  });
   return { ...result, subject: copy.subject, text: copy.text, html: copy.html };
 }
 

--- a/api/_lib/rate-limit-durable.js
+++ b/api/_lib/rate-limit-durable.js
@@ -15,6 +15,9 @@
 const crypto = require("crypto");
 const admin = require("firebase-admin");
 const { initFirebaseAdmin } = require("./auth");
+const { skipFirestore } = require("./firebase-off");
+
+const memoryBuckets = new Map();
 
 function bucketId(key, windowMs) {
   const bucket = Math.floor(Date.now() / windowMs);
@@ -41,6 +44,27 @@ function sanitizeHitId(raw) {
   return s;
 }
 
+function memoryRateLimit(key, maxRequests, windowMs) {
+  const id = bucketId(key, windowMs);
+  const resetMs = Math.ceil(Date.now() / windowMs) * windowMs;
+  const prev = memoryBuckets.get(id) || { count: 0, resetMs };
+  const count = prev.resetMs === resetMs ? prev.count + 1 : 1;
+  memoryBuckets.set(id, { count, resetMs });
+  if (memoryBuckets.size > 4000) {
+    const now = Date.now();
+    for (const [k, v] of memoryBuckets) {
+      if (v.resetMs < now) memoryBuckets.delete(k);
+    }
+  }
+  return {
+    allowed: count <= maxRequests,
+    remaining: Math.max(0, maxRequests - count),
+    resetMs,
+    limit: maxRequests,
+    backend: "memory",
+  };
+}
+
 /**
  * @param {string} key
  * @param {number} maxRequests
@@ -50,16 +74,12 @@ function sanitizeHitId(raw) {
  */
 async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000, opts = {}) {
   const resetMs = Math.ceil(Date.now() / windowMs) * windowMs;
+  if (skipFirestore()) {
+    return memoryRateLimit(key, maxRequests, windowMs);
+  }
   const firestore = db();
   if (!firestore) {
-    return {
-      allowed: false,
-      remaining: 0,
-      resetMs,
-      limit: maxRequests,
-      backend: "firestore-unavailable",
-      error: "firebase_unavailable",
-    };
+    return memoryRateLimit(key, maxRequests, windowMs);
   }
 
   const id = bucketId(key, windowMs);
@@ -124,14 +144,7 @@ async function checkDurableRateLimit(key, maxRequests, windowMs = 60_000, opts =
     };
   } catch (err) {
     console.warn("durable rate limit unavailable", err?.message || err);
-    return {
-      allowed: false,
-      remaining: 0,
-      resetMs,
-      limit: maxRequests,
-      backend: "firestore-unavailable",
-      error: err?.message || "firestore_unavailable",
-    };
+    return memoryRateLimit(key, maxRequests, windowMs);
   }
 }
 

--- a/api/_lib/store.js
+++ b/api/_lib/store.js
@@ -15,12 +15,13 @@
 const { initFirebaseAdmin } = require("./auth");
 const { gistConfigured, loadGistStore, saveGistStore } = require("./gist-store");
 const { agentUsageForMonth } = require("./coding-agent-usage");
+const { skipFirestore } = require("./firebase-off");
 
 let /** @type {import("firebase-admin").firestore.Firestore | null} */ _db = null;
 
 /** In-process write-through cache — same warm lambda sees updates immediately. */
 let writeCache = null;
-let firestoreUnavailable = false;
+let firestoreUnavailable = skipFirestore();
 let useGistStore = false;
 
 /** Gist is the real prod store while Firestore API is disabled on this project.
@@ -208,8 +209,9 @@ async function loadStoreFromAuth() {
 // ---------------------------------------------------------------------------
 
 async function loadStoreRemote() {
-  // Prefer Firestore whenever Admin credentials exist. Gist is emergency-only —
-  // using it for every write burns GitHub rate limits and breaks connect/setup.
+  if (skipFirestore()) firestoreUnavailable = true;
+  // Prefer Firestore whenever Admin credentials exist AND it is opted in.
+  // Gist is emergency-only — using it for every write burns GitHub rate limits.
   if (!firestoreUnavailable) {
     try {
       const snap = await db().doc("config/store").get();
@@ -475,6 +477,34 @@ function mergeKeySnaps(a = {}, b = {}) {
 }
 
 /**
+ * Durable per-key usage — Auth stub claims when Firestore is off (no gist).
+ * Compact `sc_ku` on the sck_* key user: { m, r, tin, tout, ts }.
+ */
+async function trackKeyUsageOnAuth(keyId, stats = {}) {
+  if (!String(keyId || "").startsWith("sck_")) return false;
+  if (!initFirebaseAdmin()) return false;
+  const month = new Date().toISOString().slice(0, 7);
+  const user = await require("firebase-admin").auth().getUser(keyId).catch(() => null);
+  if (!user || user.disabled) return false;
+  const prev = user.customClaims || {};
+  const ku =
+    prev.sc_ku && prev.sc_ku.m === month
+      ? { ...prev.sc_ku }
+      : { m: month, r: 0, tin: 0, tout: 0, ts: 0 };
+  ku.r = (Number(ku.r) || 0) + 1;
+  ku.tin = (Number(ku.tin) || 0) + Math.max(0, Number(stats.original_tokens) || 0);
+  ku.tout = (Number(ku.tout) || 0) + Math.max(0, Number(stats.kept_tokens) || 0);
+  ku.ts = (Number(ku.ts) || 0) + Math.max(0, Number(stats.tokens_saved) || 0);
+  const { setBillingClaims } = require("./billing-ledger");
+  await setBillingClaims(keyId, {
+    ...prev,
+    sc_ku: ku,
+    sc_last: stats.now || new Date().toISOString(),
+  });
+  return true;
+}
+
+/**
  * Durable per-key usage — dedicated Firestore doc (same pattern as coding_agent_usage).
  * The monolithic config/store was dropping key meters while Auth sc_usage (billing) kept growing.
  */
@@ -490,6 +520,21 @@ async function trackKeyUsage(ownerUid, keyRec, stats = {}) {
     Number(stats.tokens_saved) || Math.max(0, tokensIn - tokensOut)
   );
   const now = new Date().toISOString();
+
+  const { skipFirestore } = require("./firebase-off");
+  if (skipFirestore() || firestoreUnavailable) {
+    try {
+      return await trackKeyUsageOnAuth(keyId, {
+        original_tokens: tokensIn,
+        kept_tokens: tokensOut,
+        tokens_saved: tokensSaved,
+        now,
+      });
+    } catch (err) {
+      console.warn("store: auth key_usage skipped:", err.message);
+      return false;
+    }
+  }
 
   const bump = (prev = {}) => {
     const byDay = { ...(prev.by_day || {}) };
@@ -519,43 +564,6 @@ async function trackKeyUsage(ownerUid, keyRec, stats = {}) {
     };
   };
 
-  if (firestoreUnavailable) {
-    await mutateStore((store) => {
-      if (!store.keys[keyId]) {
-        store.keys[keyId] = {
-          id: keyId,
-          user_id: ownerUid,
-          name: keyRec.name || "API key",
-          prefix: keyRec.prefix || "",
-          key_hash: keyRec.key_hash || null,
-          created_at: keyRec.created_at || now,
-          last_used_at: now,
-          revoked: false,
-        };
-        if (keyRec.key_hash) store.hash_index[keyRec.key_hash] = keyId;
-      } else {
-        store.keys[keyId].last_used_at = now;
-      }
-      if (!store.usage[keyId]) store.usage[keyId] = {};
-      if (!store.usage[keyId][day]) {
-        store.usage[keyId][day] = {
-          key_id: keyId,
-          requests: 0,
-          tokens_in: 0,
-          tokens_out: 0,
-          tokens_saved: 0,
-        };
-      }
-      const u = store.usage[keyId][day];
-      u.requests += 1;
-      u.tokens_in += tokensIn;
-      u.tokens_out += tokensOut;
-      u.tokens_saved += tokensSaved;
-      return u;
-    });
-    return true;
-  }
-
   const docRef = db().collection("key_usage").doc(ownerUid);
   await db().runTransaction(async (tx) => {
     const snap = await tx.get(docRef);
@@ -570,6 +578,28 @@ async function trackKeyUsage(ownerUid, keyRec, stats = {}) {
 async function loadKeyUsage(ownerUid) {
   if (!ownerUid) return {};
   const out = {};
+  if (skipFirestore()) {
+    try {
+      const owner = await require("firebase-admin").auth().getUser(ownerUid);
+      const ids = Array.isArray(owner.customClaims?.sc_key_ids) ? owner.customClaims.sc_key_ids : [];
+      const month = new Date().toISOString().slice(0, 7);
+      for (const id of ids) {
+        const user = await require("firebase-admin").auth().getUser(id).catch(() => null);
+        const ku = user?.customClaims?.sc_ku;
+        if (!ku || ku.m !== month) continue;
+        out[id] = {
+          total_requests: Number(ku.r) || 0,
+          total_tokens_in: Number(ku.tin) || 0,
+          total_tokens_out: Number(ku.tout) || 0,
+          total_tokens_saved: Number(ku.ts) || 0,
+          by_day: {},
+        };
+      }
+    } catch (err) {
+      console.warn("store: auth key_usage read skipped:", err.message);
+    }
+    return out;
+  }
   if (!firestoreUnavailable) {
     try {
       const snap = await db().collection("key_usage").doc(ownerUid).get();

--- a/api/_lib/weekly.js
+++ b/api/_lib/weekly.js
@@ -8,6 +8,15 @@ const { mutateStore, loadStore } = require("./store");
 const { sendWeeklyEmail, weeklyEmailCopy, campaignKind } = require("./mail");
 const { drainSecretOk } = require("./welcome");
 
+async function loadStoreSafe() {
+  try {
+    return await loadStore();
+  } catch (err) {
+    console.warn("weekly: store skipped:", err.message);
+    return { weekly_emails: {}, weekly_unsubscribes: {} };
+  }
+}
+
 const BATCH_SIZE = Math.max(
   5,
   Math.min(40, Number(process.env.WEEKLY_EMAIL_BATCH || 25) || 25)
@@ -157,23 +166,30 @@ async function listAuthRecipients() {
         uid: user.uid,
         email: String(user.email).trim().toLowerCase(),
         first_name: firstNameFromUser(user),
+        sc_wk: (user.customClaims || {}).sc_wk || "",
+        sc_unsub: (user.customClaims || {}).sc_unsub || "",
       });
     }
     pageToken = page.pageToken;
   } while (pageToken);
 
-  // Also include anyone who got a welcome email (covers edge cases)
-  const store = await loadStore();
-  for (const rec of Object.values(store.welcome_emails || {})) {
-    if (!rec?.email || !rec?.uid || isStubUid(rec.uid)) continue;
-    const email = String(rec.email).trim().toLowerCase();
-    if (!email.includes("@")) continue;
-    if (out.some((r) => r.uid === rec.uid || r.email === email)) continue;
-    out.push({
-      uid: rec.uid,
-      email,
-      first_name: rec.first_name || "",
-    });
+  try {
+    const store = await loadStore();
+    for (const rec of Object.values(store.welcome_emails || {})) {
+      if (!rec?.email || !rec?.uid || isStubUid(rec.uid)) continue;
+      const email = String(rec.email).trim().toLowerCase();
+      if (!email.includes("@")) continue;
+      if (out.some((r) => r.uid === rec.uid || r.email === email)) continue;
+      out.push({
+        uid: rec.uid,
+        email,
+        first_name: rec.first_name || "",
+        sc_wk: "",
+        sc_unsub: "",
+      });
+    }
+  } catch (err) {
+    console.warn("weekly: gist recipient merge skipped:", err.message);
   }
   return out;
 }
@@ -187,6 +203,7 @@ async function enqueueWeeklyCampaign(campaignId = isoWeekCampaignId()) {
   let queued = 0;
   let skipped = 0;
 
+  try {
   for (let i = 0; i < recipients.length; i += ENQUEUE_CHUNK) {
     const chunk = recipients.slice(i, i + ENQUEUE_CHUNK);
     const result = await mutateStore((store) => {
@@ -226,10 +243,15 @@ async function enqueueWeeklyCampaign(campaignId = isoWeekCampaignId()) {
     skipped += result?.chunkSkipped || 0;
   }
 
-  const store = await loadStore();
-  const pending = Object.values(store.weekly_emails || {}).filter(
-    (r) => r.campaign_id === campaignId && r.status === "pending"
-  ).length;
+  let pending = 0;
+  try {
+    const store = await loadStore();
+    pending = Object.values(store.weekly_emails || {}).filter(
+      (r) => r.campaign_id === campaignId && r.status === "pending"
+    ).length;
+  } catch (_) {
+    pending = recipients.filter((r) => r.sc_wk !== campaignId && !r.sc_unsub).length;
+  }
   return {
     campaign_id: campaignId,
     recipients: recipients.length,
@@ -237,6 +259,17 @@ async function enqueueWeeklyCampaign(campaignId = isoWeekCampaignId()) {
     skipped,
     pending,
   };
+  } catch (err) {
+    console.warn("enqueueWeeklyCampaign: store skipped:", err.message);
+    return {
+      campaign_id: campaignId,
+      recipients: recipients.length,
+      queued,
+      skipped,
+      pending: recipients.filter((r) => r.sc_wk !== campaignId && !r.sc_unsub).length,
+      store_error: err.message,
+    };
+  }
 }
 
 async function markWeekly(key, patch) {
@@ -249,7 +282,7 @@ async function markWeekly(key, patch) {
 }
 
 async function listPendingWeekly(campaignId, { includeHtml = true } = {}) {
-  const store = await loadStore();
+  const store = await loadStoreSafe();
   const cid = campaignId || null;
   return Object.values(store.weekly_emails || {})
     .filter((r) => r && r.status === "pending" && r.email && (!cid || r.campaign_id === cid))
@@ -288,7 +321,13 @@ async function drainPendingWeekly({ limit = BATCH_SIZE, campaignId } = {}) {
     };
   }
 
-  const store = await loadStore();
+  let store;
+  try {
+    store = await loadStore();
+  } catch (err) {
+    console.warn("drainPendingWeekly: store skipped:", err.message);
+    return { batch: 0, sent: 0, failed: 0, remaining: 0, errors: [], mode: "auth_tick" };
+  }
   const cid = campaignId || null;
   const pending = Object.values(store.weekly_emails || {})
     .filter(
@@ -332,7 +371,7 @@ async function drainPendingWeekly({ limit = BATCH_SIZE, campaignId } = {}) {
     }
   }
 
-  const remainingStore = await loadStore();
+  const remainingStore = await loadStoreSafe();
   const remaining = Object.values(remainingStore.weekly_emails || {}).filter(
     (r) => r.status === "pending" && r.email
   ).length;
@@ -412,7 +451,12 @@ async function weeklyTick(opts = {}) {
   }
 
   const recipients = await listAuthRecipients();
-  const store = await loadStore();
+  let store = { weekly_emails: {}, weekly_unsubscribes: {} };
+  try {
+    store = await loadStore();
+  } catch (err) {
+    console.warn("weeklyTick: store skipped:", err.message);
+  }
   const unsubs = store.weekly_unsubscribes || {};
   const records = store.weekly_emails || {};
 
@@ -424,11 +468,11 @@ async function weeklyTick(opts = {}) {
   for (const r of recipients) {
     if (sent + failed >= BATCH_SIZE) break;
     const key = `${campaignId}:${r.uid}`;
-    if (isUnsubscribed({ weekly_unsubscribes: unsubs }, r.email)) {
+    if (isUnsubscribed({ weekly_unsubscribes: unsubs }, r.email) || r.sc_unsub) {
       skipped += 1;
       continue;
     }
-    if (records[key]?.status === "sent") {
+    if (records[key]?.status === "sent" || r.sc_wk === campaignId) {
       skipped += 1;
       continue;
     }
@@ -442,6 +486,14 @@ async function weeklyTick(opts = {}) {
     });
 
     if (result.ok) {
+      try {
+        const admin = require("firebase-admin");
+        const { setBillingClaims } = require("./billing-ledger");
+        const fresh = await admin.auth().getUser(r.uid);
+        await setBillingClaims(r.uid, { ...(fresh.customClaims || {}), sc_wk: String(campaignId).slice(0, 24) });
+      } catch (stampErr) {
+        errors.push({ email: r.email, error: `sent_but_stamp_failed: ${stampErr.message}` });
+      }
       try {
         await markWeekly(key, {
           key,
@@ -484,7 +536,7 @@ async function weeklyTick(opts = {}) {
     }
   }
 
-  const remainingStore = await loadStore();
+  const remainingStore = await loadStoreSafe();
   const remaining = Object.values(remainingStore.weekly_emails || {}).filter(
     (r) => r.status === "pending" && r.email
   ).length;
@@ -525,21 +577,37 @@ async function unsubscribeEmail(email, token, { confirmOnly = false } = {}) {
     err.status = 401;
     throw err;
   }
-  await mutateStore((store) => {
-    if (!store.weekly_unsubscribes) store.weekly_unsubscribes = {};
-    store.weekly_unsubscribes[clean] = {
-      email: clean,
-      at: new Date().toISOString(),
-      via: confirmOnly && !token ? "confirm" : "token",
-    };
-    // Cancel pending for this email
-    for (const [key, rec] of Object.entries(store.weekly_emails || {})) {
-      if (rec && String(rec.email || "").trim().toLowerCase() === clean && rec.status === "pending") {
-        store.weekly_emails[key] = { ...rec, status: "unsubscribed" };
+  try {
+    const admin = require("firebase-admin");
+    const { initFirebaseAdmin } = require("./auth");
+    const { setBillingClaims } = require("./billing-ledger");
+    if (initFirebaseAdmin()) {
+      const user = await admin.auth().getUserByEmail(clean).catch(() => null);
+      if (user) {
+        await setBillingClaims(user.uid, { ...(user.customClaims || {}), sc_unsub: "1" });
       }
     }
-    return { ok: true };
-  });
+  } catch (err) {
+    console.warn("unsubscribe: auth stamp skipped:", err.message);
+  }
+  try {
+    await mutateStore((store) => {
+      if (!store.weekly_unsubscribes) store.weekly_unsubscribes = {};
+      store.weekly_unsubscribes[clean] = {
+        email: clean,
+        at: new Date().toISOString(),
+        via: confirmOnly && !token ? "confirm" : "token",
+      };
+      for (const [key, rec] of Object.entries(store.weekly_emails || {})) {
+        if (rec && String(rec.email || "").trim().toLowerCase() === clean && rec.status === "pending") {
+          store.weekly_emails[key] = { ...rec, status: "unsubscribed" };
+        }
+      }
+      return { ok: true };
+    });
+  } catch (err) {
+    console.warn("unsubscribe: store skipped:", err.message);
+  }
   return { ok: true, email: clean };
 }
 

--- a/api/_lib/welcome.js
+++ b/api/_lib/welcome.js
@@ -102,8 +102,26 @@ async function handleSignupWelcome(req, body, user) {
   const createdAt = body.creation_time || null;
   const recent = forceNew || isRecentlyCreated(createdAt);
 
-  const existingStore = await loadStore();
-  const prior = existingStore.welcome_emails?.[user.uid];
+  const admin = require("firebase-admin");
+  const { initFirebaseAdmin } = require("./auth");
+  let liveClaims = {};
+  if (initFirebaseAdmin() && user.uid) {
+    try {
+      const fresh = await admin.auth().getUser(user.uid);
+      liveClaims = fresh.customClaims || {};
+    } catch (_) {}
+  }
+  if (String(liveClaims.sc_welcome || "") === "sent") {
+    return { ok: true, sent: false, reason: "already_sent" };
+  }
+
+  let prior = null;
+  try {
+    const existingStore = await loadStore();
+    prior = existingStore.welcome_emails?.[user.uid];
+  } catch (err) {
+    console.warn("welcome: store lookup skipped:", err.message);
+  }
   if (prior?.status === "sent") {
     return { ok: true, sent: false, reason: "already_sent" };
   }
@@ -123,19 +141,33 @@ async function handleSignupWelcome(req, body, user) {
     email,
     firstName,
     body.source || "dashboard_signup"
-  );
+  ).catch((err) => {
+    console.warn("welcome: store claim skipped:", err.message);
+    return { claimed: true, record: { uid: user.uid, email, first_name: firstName } };
+  });
   if (!claimed) {
     return { ok: true, sent: false, reason: "already_queued" };
   }
 
-  const result = await sendWelcomeEmail({ email, firstName });
+  const result = await sendWelcomeEmail({
+    email,
+    firstName,
+    idempotencyKey: `welcome-${user.uid}`,
+  });
   if (result.ok) {
+    try {
+      const { setBillingClaims } = require("./billing-ledger");
+      const fresh = await admin.auth().getUser(user.uid);
+      await setBillingClaims(user.uid, { ...(fresh.customClaims || liveClaims), sc_welcome: "sent" });
+    } catch (err) {
+      console.warn("welcome: claim stamp skipped:", err.message);
+    }
     await markWelcome(user.uid, {
       status: "sent",
       sent_at: new Date().toISOString(),
       provider: result.provider || "resend",
       error: null,
-    });
+    }).catch((err) => console.warn("welcome: store mark skipped:", err.message));
     return { ok: true, sent: true, provider: result.provider };
   }
 
@@ -143,7 +175,7 @@ async function handleSignupWelcome(req, body, user) {
     status: "pending",
     provider: null,
     error: result.error || "queued_for_drain",
-  });
+  }).catch((err) => console.warn("welcome: store queue skipped:", err.message));
   return {
     ok: true,
     sent: false,
@@ -154,28 +186,38 @@ async function handleSignupWelcome(req, body, user) {
 }
 
 async function listPendingWelcomes() {
-  const store = await loadStore();
-  return Object.values(store.welcome_emails || {})
-    .filter((r) => r && r.status === "pending" && r.email)
-    .map((r) => {
-      const copy = welcomeCopy({ firstName: r.first_name, email: r.email });
-      return {
-        uid: r.uid,
-        email: r.email,
-        first_name: r.first_name || "",
-        subject: copy.subject,
-        body: copy.text,
-        html: copy.html,
-        queued_at: r.queued_at || null,
-      };
-    });
+  try {
+    const store = await loadStore();
+    return Object.values(store.welcome_emails || {})
+      .filter((r) => r && r.status === "pending" && r.email)
+      .map((r) => {
+        const copy = welcomeCopy({ firstName: r.first_name, email: r.email });
+        return {
+          uid: r.uid,
+          email: r.email,
+          first_name: r.first_name || "",
+          subject: copy.subject,
+          body: copy.text,
+          html: copy.html,
+          queued_at: r.queued_at || null,
+        };
+      });
+  } catch (err) {
+    console.warn("welcome list: store skipped:", err.message);
+    return [];
+  }
 }
 
 async function drainPendingWelcomes() {
-  const store = await loadStore();
-  const pending = Object.values(store.welcome_emails || {}).filter(
-    (r) => r && r.status === "pending" && r.email
-  );
+  let pending = [];
+  try {
+    const store = await loadStore();
+    pending = Object.values(store.welcome_emails || {}).filter(
+      (r) => r && r.status === "pending" && r.email
+    );
+  } catch (err) {
+    console.warn("welcome drain: store skipped:", err.message);
+  }
 
   let sent = 0;
   let failed = 0;
@@ -183,6 +225,7 @@ async function drainPendingWelcomes() {
     const result = await sendWelcomeEmail({
       email: rec.email,
       firstName: rec.first_name || "",
+      idempotencyKey: `welcome-${rec.uid}`,
     });
     if (result.ok) {
       await markWelcome(rec.uid, {
@@ -190,13 +233,56 @@ async function drainPendingWelcomes() {
         sent_at: new Date().toISOString(),
         provider: result.provider || "resend",
         error: null,
-      });
+      }).catch(() => {});
+      try {
+        const admin = require("firebase-admin");
+        const { setBillingClaims } = require("./billing-ledger");
+        const fresh = await admin.auth().getUser(rec.uid);
+        await setBillingClaims(rec.uid, { ...(fresh.customClaims || {}), sc_welcome: "sent" });
+      } catch (_) {}
       sent += 1;
     } else {
       failed += 1;
     }
   }
-  return { pending: pending.length, sent, failed };
+
+  let authMailed = 0;
+  try {
+    const admin = require("firebase-admin");
+    const { initFirebaseAdmin } = require("./auth");
+    if (initFirebaseAdmin()) {
+      const NEW_MS = 24 * 60 * 60 * 1000;
+      let pageToken;
+      do {
+        const page = await admin.auth().listUsers(1000, pageToken);
+        for (const user of page.users) {
+          if (authMailed >= 20) break;
+          if (!user.email || user.disabled || /^(sck_|sc_at_|sc_ac_|sc_aff_)/.test(user.uid)) continue;
+          if (String((user.customClaims || {}).sc_welcome || "") === "sent") continue;
+          const created = Date.parse(user.metadata?.creationTime || 0);
+          if (!Number.isFinite(created) || Date.now() - created > NEW_MS) continue;
+          const firstName = firstNameFromUser(user);
+          const result = await sendWelcomeEmail({
+            email: user.email,
+            firstName,
+            idempotencyKey: `welcome-${user.uid}`,
+          });
+          if (result.ok) {
+            try {
+              const { setBillingClaims } = require("./billing-ledger");
+              await setBillingClaims(user.uid, { ...(user.customClaims || {}), sc_welcome: "sent" });
+            } catch (_) {}
+            authMailed += 1;
+          }
+        }
+        pageToken = authMailed >= 20 ? null : page.pageToken;
+      } while (pageToken);
+    }
+  } catch (err) {
+    console.warn("welcome drain: auth scan skipped:", err.message);
+  }
+
+  return { pending: pending.length, sent, failed, auth: { mailed: authMailed } };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- Firestore is **off by default** (`skipFirestore()`). Compress/billing no longer probe a disabled API (1.2s timeouts) or write the GitHub gist on every request.
- Billing, idempotency watermarks, wallet credits, 1M mail, welcome, weekly unsub, and per-key usage live on **Auth claims** + Resend idempotency.
- Rate limits use in-memory buckets instead of fail-closed Firestore.
- New API keys mint as Auth `sck_*` stubs when the store is down. Dashboard `listKeys` survives gist 403.
- Opt back in later with `SUPERCOMPRESS_USE_FIRESTORE=1`.

## Test plan
- [x] `node api/_lib/firebase-off.test.js`
- [x] `node api/_lib/billing-ledger.test.js`
- [x] `node --check` on edited JS
- [ ] CI smoke green
- [ ] After prod: `POST https://api.supercompress.dev/compress` is **401, not 3xx**
- [ ] Authenticated compress still 200 (prod smoke)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firestore is now bypassed by default for core operations, with an opt-in setting available when needed.
  * Usage tracking, API keys, rate limits, billing, and campaign status continue operating through fallback storage.
  * Welcome and campaign emails now use idempotency protection to prevent duplicate sends.
* **Bug Fixes**
  * Improved resilience when storage services are unavailable, including safer key management, welcome emails, campaigns, and unsubscribe handling.
  * Unsubscribed recipients are excluded from future campaign sends.
* **Documentation**
  * Added release notes describing the updated storage behavior and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->