### PR TITLE
fix: merge Auth claims live and enforce API key limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
         run: node api/_lib/firebase-off.test.js
       - name: Power-user milestone unit tests
         run: node api/_lib/power-user.test.js
+      - name: Auth key-limit helpers
+        run: node api/_lib/auth-connect.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
       - name: Proxy package tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Public page: https://www.supercompress.dev/changelog
 - Auto branded **power-user email** when someone hits 1M tokens (once ever). Delivery is Auth-claim + Resend idempotency, not Firestore; welcome-drain backfills anyone already over 1M. Free users at 1M are paywalled from Auth claims even if Firestore is down.
 - Welcome-drain no longer aborts on gist/store errors before sending 1M power-user mail; `op=power-user-drain` can run that lane alone.
 - **No Firestore on the hot path** (default). Billing, keys, welcome/weekly mail, and rate limits use Auth claims + Resend idempotency. Gist is optional/cold only. Set `SUPERCOMPRESS_USE_FIRESTORE=1` to opt back in after the API is enabled.
+- Auth-only wallet writers merge from live claims and stamp `sc_write_id` so overlapping key/mail/credit/usage writes retry instead of clobbering; plan `max_keys` is enforced on Auth key mint (Free 10 / PAYG 25) and the owner index is no longer sliced to 20.
 - **Dashboard Analytics panel** (dither charts): live usage from `/api/keys` after sign-in — tokens saved, requests, coding agents, and key breakdown. `/analytics` stays inside `/dashboard?panel=analytics`.
 - Fix Analytics chart paint: Bayer wells + stacked dither canvases, wait for layout before draw, no demo/fake flash on production.
 - Align `/api/account?op=usage` + dashboard `account_usage` with the billing ledger (CLI no longer under-counts vs dashboard)

--- a/api/_lib/auth-connect.js
+++ b/api/_lib/auth-connect.js
@@ -10,6 +10,22 @@ const { KEY_PREFIX, hashApiKey, verifyApiKey } = require("./keys");
 
 const KEY_UID_PREFIX = "sck_";
 const LINK_UID_PREFIX = "sc_lnk_";
+const DEFAULT_AUTH_KEY_CAP = 20;
+
+function keyLimitCap(maxKeys) {
+  const cap = Number(maxKeys);
+  return Number.isFinite(cap) && cap > 0 ? Math.floor(cap) : DEFAULT_AUTH_KEY_CAP;
+}
+
+function keyLimitReached(activeCount, maxKeys) {
+  return Number(activeCount) >= keyLimitCap(maxKeys);
+}
+
+function nextOwnerKeyIds(existingIds, newId, maxKeys) {
+  const ids = Array.isArray(existingIds) ? existingIds.filter(Boolean) : [];
+  if (newId && !ids.includes(newId)) ids.push(newId);
+  return ids.slice(-keyLimitCap(maxKeys));
+}
 
 function auth() {
   if (!initFirebaseAdmin()) {
@@ -49,9 +65,18 @@ function generateAuthBackedKey() {
 /**
  * Mint a coding-agent / CLI key as an Auth stub user.
  * Survives gist/Firestore outages; authenticateKey already understands sck_* keys.
+ * Enforces plan maxKeys against the owner's Auth index (do not slice below the cap).
  */
-async function createAuthPluginKey(ownerUid, name = "Coding agent") {
+async function createAuthPluginKey(ownerUid, name = "Coding agent", opts = {}) {
+  const cap = keyLimitCap(opts.maxKeys);
   await auth().getUser(ownerUid); // ensure owner exists
+  const existing = await listAuthPluginKeys(ownerUid).catch(() => []);
+  if (keyLimitReached(existing.length, cap)) {
+    const err = new Error(`Plan limit reached: ${cap} API keys. Upgrade to increase this limit.`);
+    err.status = 429;
+    throw err;
+  }
+
   const gen = generateAuthBackedKey();
   const created = new Date().toISOString();
   const displayName = String(name || "Coding agent").trim().slice(0, 80) || "Coding agent";
@@ -71,23 +96,45 @@ async function createAuthPluginKey(ownerUid, name = "Coding agent") {
     sc_plugin: true,
   });
 
-  // Index on owner for dashboard listing when store is down
+  // Index on owner for dashboard listing when store is down.
+  // Merge from live claims so this write cannot revert a concurrent wallet update.
   try {
-    const owner = await auth().getUser(ownerUid);
-    const claims = { ...(owner.customClaims || {}) };
-    const ids = Array.isArray(claims.sc_key_ids) ? claims.sc_key_ids.slice() : [];
-    if (!ids.includes(gen.uid)) ids.push(gen.uid);
-    // Keep last 20 plugin/key ids
-    claims.sc_key_ids = ids.slice(-20);
-    claims.sc_agent_plugin = {
-      linked: true,
-      linked_at: claims.sc_agent_plugin?.linked_at || created,
-      updated_at: created,
-      source: "auth-connect",
-    };
-    await auth().setCustomUserClaims(ownerUid, claims);
+    const { patchUserClaims } = require("./billing-ledger");
+    await patchUserClaims(
+      ownerUid,
+      (live) => ({
+        ...live,
+        sc_key_ids: nextOwnerKeyIds(live.sc_key_ids, gen.uid, cap),
+        sc_agent_plugin: {
+          linked: true,
+          linked_at: live.sc_agent_plugin?.linked_at || created,
+          updated_at: created,
+          source: "auth-connect",
+        },
+      }),
+      {
+        verify: (after) => Array.isArray(after.sc_key_ids) && after.sc_key_ids.includes(gen.uid),
+      }
+    );
   } catch (err) {
-    console.warn("createAuthPluginKey: owner claim update skipped:", err.message);
+    console.warn("createAuthPluginKey: owner claim update failed:", err.message);
+    try {
+      await auth().deleteUser(gen.uid);
+    } catch (_) {}
+    if (err.status === 429) throw err;
+    const fail = new Error("Could not index API key. Retry.");
+    fail.status = 503;
+    throw fail;
+  }
+
+  const listed = await listAuthPluginKeys(ownerUid).catch(() => []);
+  if (listed.length > cap) {
+    try {
+      await revokeAuthPluginKey(ownerUid, gen.uid);
+    } catch (_) {}
+    const err = new Error(`Plan limit reached: ${cap} API keys. Upgrade to increase this limit.`);
+    err.status = 429;
+    throw err;
   }
 
   // Mirror into Firestore store immediately so listKeys/usage attribution work
@@ -146,12 +193,11 @@ async function revokeAuthPluginKey(ownerUid, keyUid) {
     await auth().deleteUser(keyUid);
   } catch (_) {}
   try {
-    const owner = await auth().getUser(ownerUid);
-    const claims = { ...(owner.customClaims || {}) };
-    if (Array.isArray(claims.sc_key_ids)) {
-      claims.sc_key_ids = claims.sc_key_ids.filter((x) => x !== keyUid);
-      await auth().setCustomUserClaims(ownerUid, claims);
-    }
+    const { patchUserClaims } = require("./billing-ledger");
+    await patchUserClaims(ownerUid, (live) => {
+      if (!Array.isArray(live.sc_key_ids)) return live;
+      return { ...live, sc_key_ids: live.sc_key_ids.filter((x) => x !== keyUid) };
+    });
   } catch (_) {}
   return { id: keyUid, revoked: true };
 }
@@ -330,4 +376,7 @@ module.exports = {
   clearDeviceLinkSecret,
   consumeDeviceLinkSecret,
   generateAuthBackedKey,
+  nextOwnerKeyIds,
+  keyLimitReached,
+  keyLimitCap,
 };

--- a/api/_lib/auth-connect.test.js
+++ b/api/_lib/auth-connect.test.js
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for Auth-backed API key index helpers (no Firebase required).
+ * Run: node api/_lib/auth-connect.test.js
+ */
+const assert = require("assert");
+const { nextOwnerKeyIds, keyLimitReached, keyLimitCap } = require("./auth-connect");
+
+assert.strictEqual(keyLimitCap(10), 10);
+assert.strictEqual(keyLimitCap(25), 25);
+assert.strictEqual(keyLimitCap(undefined), 20);
+assert.strictEqual(keyLimitReached(9, 10), false);
+assert.strictEqual(keyLimitReached(10, 10), true);
+assert.strictEqual(keyLimitReached(25, 25), true);
+assert.strictEqual(keyLimitReached(0, 10), false);
+
+{
+  const ids = Array.from({ length: 20 }, (_, i) => `sck_${i}`);
+  const next = nextOwnerKeyIds(ids, "sck_new", 25);
+  assert.strictEqual(next.length, 21);
+  assert.ok(next.includes("sck_new"));
+  assert.ok(next.includes("sck_0"));
+}
+
+{
+  const ids = Array.from({ length: 25 }, (_, i) => `sck_${i}`);
+  const next = nextOwnerKeyIds(ids, "sck_new", 25);
+  assert.strictEqual(next.length, 25);
+  assert.ok(next.includes("sck_new"));
+  assert.ok(!next.includes("sck_0"));
+}
+
+{
+  const ids = Array.from({ length: 9 }, (_, i) => `sck_${i}`);
+  const next = nextOwnerKeyIds(ids, "sck_new", 10);
+  assert.deepStrictEqual(next[next.length - 1], "sck_new");
+  assert.strictEqual(next.length, 10);
+}
+
+console.log("auth-connect.test.js: ok");

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -2,8 +2,9 @@
  * Transactional billing ledger — source of truth for monthly usage + prepaid balance.
  *
  * Auth custom claims (`sc_usage`, `sc_credit_balance_usd`) are mirrored after
- * commit for dashboard/compat reads. Concurrent compressions must not
- * read-modify-write claims directly.
+ * commit for dashboard/compat reads. When Firestore is skipped, claims are the
+ * live wallet — writers must go through `patchUserClaims` (live merge + write_id).
+ * That shrinks lost-update windows; it is not a true compare-and-swap ledger.
  *
  * Firestore:
  *   billing/{uid}                    — monthly usage + wallet balance
@@ -11,6 +12,7 @@
  *   billing_usage/{uid}:{requestId}  — per-request usage burn + compress response replay
  *   billing_bonus/{uid}:first_pay    — one-time first-pay bonus create-once
  */
+const crypto = require("crypto");
 const { initFirebaseAdmin } = require("./auth");
 const {
   FREE_TOKENS_PER_MONTH,
@@ -361,7 +363,7 @@ function claimsByteLength(claims) {
 
 /** Firebase custom claims cap at 1000 bytes — drop bulky non-ledger fields to fit.
  * Never delete sc_recent_billing entirely (idempotency watermarks). Never delete
- * sc_power_mail, sc_welcome, sc_wk, sc_unsub, or sc_ku. */
+ * sc_power_mail, sc_welcome, sc_wk, sc_unsub, sc_ku, or sc_write_id. */
 function fitCustomClaims(claims) {
   const next = { ...(claims || {}) };
   const steps = [
@@ -420,11 +422,86 @@ async function setBillingClaims(uid, claims) {
   await admin().auth().setCustomUserClaims(uid, fitted);
 }
 
+function newClaimsWriteId() {
+  return crypto.randomBytes(6).toString("hex");
+}
+
+function claimsWriteHeld(after, writeId) {
+  return String(after?.sc_write_id || "") === String(writeId || "");
+}
+
+function claimsConflictToken(claims) {
+  return `${Number(claims?.sc_billing_rev || 0)}:${String(claims?.sc_write_id || "")}`;
+}
+
+/**
+ * Read-modify-write Auth custom claims from a live snapshot.
+ * Re-reads once before writing; retries if billing rev/write_id moved.
+ * Stamps `sc_write_id` and verifies it stuck so a stale overlapping write
+ * cannot both "succeed" at the same revision.
+ *
+ * This is not compare-and-swap. Auth has no conditional writes. A writer that
+ * verifies, then gets overwritten, can still lose. Do not add more monetary
+ * state to claims — use a transactional store for a real ledger.
+ */
+async function patchUserClaims(uid, mutator, opts = {}) {
+  const verify = opts.verify;
+  const attempts = Math.max(1, Number(opts.attempts) || 5);
+  let lastErr = null;
+  for (let i = 0; i < attempts; i++) {
+    const first = await admin().auth().getUser(uid);
+    const before = { ...(first.customClaims || {}) };
+    const token = claimsConflictToken(before);
+    const draft = mutator({ ...before });
+    if (!draft || typeof draft !== "object") {
+      throw new Error("patchUserClaims mutator must return a claims object");
+    }
+    const writeId = newClaimsWriteId();
+    const intended = { ...draft, sc_write_id: writeId };
+
+    const second = await admin().auth().getUser(uid);
+    if (claimsConflictToken(second.customClaims || {}) !== token) {
+      lastErr = new Error("claims_patch_conflict");
+      continue;
+    }
+
+    await setBillingClaims(uid, intended);
+    const after = (await admin().auth().getUser(uid)).customClaims || {};
+    const held = claimsWriteHeld(after, writeId);
+    const extraOk = verify ? verify(after, { before, intended }) : true;
+    if (held && extraOk) return after;
+    lastErr = new Error("claims_patch_conflict");
+  }
+  const err = lastErr || new Error("claims_patch_conflict");
+  err.code = "claims_patch_conflict";
+  throw err;
+}
+
+async function stampOwnerClaim(uid, field, value) {
+  if (!uid || !initFirebaseAdmin()) return false;
+  try {
+    await patchUserClaims(
+      uid,
+      (live) => ({ ...live, [field]: value }),
+      { verify: (after) => after[field] === value }
+    );
+    return true;
+  } catch (err) {
+    console.warn("stampOwnerClaim failed:", field, err.message || err);
+    return false;
+  }
+}
+
+function recentBillingRow(recent, rid) {
+  const rows = Array.isArray(recent) ? recent : [];
+  return rows.find((r) => r && r.i === rid) || null;
+}
+
 /**
  * When Cloud Firestore is disabled/unavailable, bill via Auth claims only.
- * Optimistic CAS via sc_billing_rev + post-write verify (retry on conflict).
- * Replay text is not stored (claims size); retries recompress but do not
- * double-bill (request id watermark on sc_recent_billing — keep up to 8).
+ * Uses patchUserClaims (live merge + unique sc_write_id). Replay text is not
+ * stored (claims size); retries recompress but do not double-bill when the
+ * request id is already on sc_recent_billing.
  */
 async function applyUsageAndBurnClaimsFallback({
   uid,
@@ -440,97 +517,92 @@ async function applyUsageAndBurnClaimsFallback({
   const fp = String(fingerprint || "").trim() || null;
   if (!rid) throw billingError("billing_unavailable", "Billing request id required");
 
-  let lastErr = null;
-  for (let attempt = 0; attempt < 4; attempt++) {
-    const fresh = await admin().auth().getUser(uid);
-    const liveClaims = mergeLiveClaims(fresh.customClaims, claims);
-    const recent = Array.isArray(liveClaims.sc_recent_billing)
-      ? liveClaims.sc_recent_billing
-      : [];
-    const prior = recent.find((r) => r && r.i === rid);
-    if (prior) {
-      assertUsageIdempotencyMatch(
-        {
-          fingerprint: prior.f || null,
-          tokens_in: prior.tin,
-          tokens_out: prior.tout,
-          tokens_saved: prior.ts,
-        },
-        {
-          fingerprint: fp,
+  let already = false;
+  try {
+    const after = await patchUserClaims(
+      uid,
+      (live) => {
+        const liveClaims = mergeLiveClaims(live, claims);
+        const recent = Array.isArray(liveClaims.sc_recent_billing)
+          ? liveClaims.sc_recent_billing
+          : [];
+        const prior = recentBillingRow(recent, rid);
+        if (prior) {
+          assertUsageIdempotencyMatch(
+            {
+              fingerprint: prior.f || null,
+              tokens_in: prior.tin,
+              tokens_out: prior.tout,
+              tokens_saved: prior.ts,
+            },
+            { fingerprint: fp, tokensIn, tokensOut, tokensSaved }
+          );
+          already = true;
+          return liveClaims;
+        }
+
+        const prevRev = Number(liveClaims.sc_billing_rev || 0) || 0;
+        const ledger = normalizeLedger(null, liveClaims);
+        const planned = planUsageBurn(ledger, {
           tokensIn,
           tokensOut,
           tokensSaved,
-        }
-      );
-      return {
-        burned_micros: Number(prior.b || 0),
-        ledger: normalizeLedger(null, liveClaims),
-        already: true,
-        request_id: rid,
-        fingerprint: prior.f || fp || null,
-        response: null,
-        backend: "claims-fallback",
-      };
-    }
-
-    const prevRev = Number(liveClaims.sc_billing_rev || 0) || 0;
-    const ledger = normalizeLedger(null, liveClaims);
-    const planned = planUsageBurn(ledger, {
-      tokensIn,
-      tokensOut,
-      tokensSaved,
-      claims: liveClaims,
-    });
-    const nextRecent = [
+          claims: liveClaims,
+        });
+        already = false;
+        return {
+          ...liveClaims,
+          sc_billing_rev: prevRev + 1,
+          sc_usage: {
+            month: planned.ledger.month,
+            requests: planned.ledger.requests,
+            tokens_in: planned.ledger.tokens_in,
+            tokens_out: planned.ledger.tokens_out,
+            tokens_saved: planned.ledger.tokens_saved,
+            tokens_reported: planned.ledger.tokens_reported || 0,
+          },
+          sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
+          sc_recent_billing: [
+            {
+              i: rid.slice(0, 40),
+              f: fp ? String(fp).slice(0, 16) : null,
+              tin: Number(tokensIn) || 0,
+              tout: Number(tokensOut) || 0,
+              ts: Number(tokensSaved) || 0,
+              b: planned.burned_micros,
+              t: Date.now(),
+            },
+            ...recent,
+          ].slice(0, 8),
+        };
+      },
       {
-        i: rid.slice(0, 40),
-        f: fp ? String(fp).slice(0, 16) : null,
-        tin: Number(tokensIn) || 0,
-        tout: Number(tokensOut) || 0,
-        ts: Number(tokensSaved) || 0,
-        b: planned.burned_micros,
-        t: Date.now(),
-      },
-      ...recent,
-    ].slice(0, 8);
-
-    const nextClaims = {
-      ...liveClaims,
-      sc_billing_rev: prevRev + 1,
-      sc_usage: {
-        month: planned.ledger.month,
-        requests: planned.ledger.requests,
-        tokens_in: planned.ledger.tokens_in,
-        tokens_out: planned.ledger.tokens_out,
-        tokens_saved: planned.ledger.tokens_saved,
-        tokens_reported: planned.ledger.tokens_reported || 0,
-      },
-      sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
-      sc_recent_billing: nextRecent,
+        verify: (afterClaims) => Boolean(recentBillingRow(afterClaims.sc_recent_billing, rid)),
+      }
+    );
+    const liveAfter = mergeLiveClaims(after, claims);
+    const prior = recentBillingRow(liveAfter.sc_recent_billing, rid);
+    return {
+      burned_micros: Number(prior?.b || 0),
+      ledger: normalizeLedger(null, liveAfter),
+      already,
+      request_id: rid,
+      fingerprint: prior?.f || fp,
+      response: already ? null : sanitizeReplayResponse(response),
+      backend: "claims-fallback",
     };
-
-    await setBillingClaims(uid, nextClaims);
-
-    // Verify our write stuck (last-writer lost → retry from fresh state).
-    const after = await admin().auth().getUser(uid);
-    const afterClaims = after.customClaims || {};
-    const afterRev = Number(afterClaims.sc_billing_rev || 0) || 0;
-    const afterTin = Number(afterClaims.sc_usage?.tokens_in || 0);
-    if (afterRev === prevRev + 1 && afterTin === Number(planned.ledger.tokens_in)) {
-      return {
-        ...planned,
-        already: false,
-        request_id: rid,
-        fingerprint: fp,
-        response: sanitizeReplayResponse(response),
-        backend: "claims-fallback",
-      };
+  } catch (err) {
+    if (
+      err?.paywall ||
+      err?.code === "free_quota_exhausted" ||
+      err?.code === "credits_exhausted" ||
+      err?.code === "idempotency_conflict"
+    ) {
+      throw err;
     }
-    lastErr = new Error("claims_cas_conflict");
+    console.error("claims billing patch exhausted:", err?.message || err);
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
-  console.error("claims billing CAS exhausted:", lastErr?.message || lastErr);
-  throw billingError("billing_unavailable", "Billing ledger unavailable");
 }
 
 const IDEMPOTENCY_LEASE_MS = 90_000;
@@ -685,9 +757,7 @@ async function releaseIdempotencyLease(uid, requestId) {
 async function mirrorClaims(uid, ledger) {
   if (!uid || !initFirebaseAdmin()) return;
   try {
-    const fresh = await admin().auth().getUser(uid);
-    const prev = { ...(fresh.customClaims || {}) };
-    await admin().auth().setCustomUserClaims(uid, {
+    await patchUserClaims(uid, (prev) => ({
       ...prev,
       sc_usage: {
         month: ledger.month,
@@ -704,7 +774,7 @@ async function mirrorClaims(uid, ledger) {
       ...(ledger.auto_recharge != null ? { sc_auto_recharge: Boolean(ledger.auto_recharge) } : {}),
       sc_auto_recharge_cycle: Number(ledger.auto_recharge_cycle || 0) || 0,
       ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
-    });
+    }));
   } catch (err) {
     console.warn("billing-ledger claim mirror failed:", err.message || err);
   }
@@ -976,9 +1046,17 @@ async function applyUsageAndBurn({
   return result;
 }
 
+function sessionAlreadyCredited(claims, ledger, key) {
+  const credited = Array.isArray(claims?.sc_credited_sessions) ? claims.sc_credited_sessions : [];
+  const keys = Array.isArray(ledger?.credited_keys) ? ledger.credited_keys : [];
+  return credited.includes(key) || keys.includes(key);
+}
+
 /**
  * When Cloud Firestore is disabled/unavailable, credit via Auth claims only.
- * Idempotent on sc_credited_sessions / credited_keys.
+ * Idempotent on sc_credited_sessions / credited_keys. Same patch/write_id
+ * retry as usage burns so two distinct Stripe sessions cannot both read $0
+ * and both write $10.
  */
 async function creditBalanceClaimsFallback({
   uid,
@@ -989,81 +1067,95 @@ async function creditBalanceClaimsFallback({
   firstPayBonusUsd = 0,
 }) {
   const key = String(creditKey);
-  const fresh = await admin().auth().getUser(uid);
-  const liveClaims = mergeLiveClaims(fresh.customClaims, claims);
-  const credited = Array.isArray(liveClaims.sc_credited_sessions)
-    ? liveClaims.sc_credited_sessions
-    : [];
-  const ledger = normalizeLedger(null, liveClaims);
-  const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
+  let already = false;
+  let bonusUsd = 0;
+  const paymentUsd = Number(creditUsd) || 0;
 
-  if (credited.includes(key) || keys.includes(key)) {
+  try {
+    const after = await patchUserClaims(
+      uid,
+      (live) => {
+        const liveClaims = mergeLiveClaims(live, claims);
+        const ledger = normalizeLedger(null, liveClaims);
+        if (sessionAlreadyCredited(liveClaims, ledger, key)) {
+          already = true;
+          bonusUsd = 0;
+          return liveClaims;
+        }
+
+        const credited = Array.isArray(liveClaims.sc_credited_sessions)
+          ? liveClaims.sc_credited_sessions
+          : [];
+        const keys = Array.isArray(ledger.credited_keys) ? ledger.credited_keys : [];
+        const wantBonus = Math.max(0, Number(firstPayBonusUsd) || 0);
+        bonusUsd = wantBonus > 0 && !liveClaims.sc_first_pay_bonus_at ? wantBonus : 0;
+        const add = usdToMicros(paymentUsd + bonusUsd);
+        ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
+        if (patch.credit_limit_usd != null) {
+          ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
+        }
+        if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
+        if (patch.auto_recharge_cycle != null) {
+          ledger.auto_recharge_cycle = Math.max(0, Number(patch.auto_recharge_cycle) || 0);
+        }
+        if (patch.customer_id) ledger.customer_id = patch.customer_id;
+        ledger.credited_keys = [...keys.filter((k) => k !== key).slice(-39), key];
+        ledger.updated_at = new Date().toISOString();
+        already = false;
+        const prevRev = Number(liveClaims.sc_billing_rev || 0) || 0;
+        const bonusPatch =
+          bonusUsd > 0
+            ? {
+                sc_first_pay_bonus_at: new Date().toISOString(),
+                sc_first_pay_bonus_usd: bonusUsd,
+              }
+            : {};
+        return {
+          ...liveClaims,
+          sc_billing_rev: prevRev + 1,
+          sc_plan: liveClaims.sc_plan || "payg",
+          sc_metered: false,
+          sc_usage: {
+            month: ledger.month,
+            requests: ledger.requests,
+            tokens_in: ledger.tokens_in,
+            tokens_out: ledger.tokens_out,
+            tokens_saved: ledger.tokens_saved,
+            tokens_reported: ledger.tokens_reported || 0,
+          },
+          sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
+          sc_credit_limit_usd: ledger.credit_limit_usd,
+          sc_auto_recharge: Boolean(ledger.auto_recharge),
+          sc_auto_recharge_cycle: Number(ledger.auto_recharge_cycle || 0) || 0,
+          sc_credited_sessions: [...credited.filter((k) => k !== key).slice(-39), key],
+          ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
+          ...bonusPatch,
+        };
+      },
+      {
+        verify: (afterClaims) => {
+          const credited = Array.isArray(afterClaims.sc_credited_sessions)
+            ? afterClaims.sc_credited_sessions
+            : [];
+          return credited.includes(key);
+        },
+      }
+    );
+    const liveAfter = mergeLiveClaims(after, claims);
+    const ledger = normalizeLedger(null, liveAfter);
     return {
       applied: true,
-      already: true,
+      already,
       ledger,
       balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-      credit_usd: 0,
-      bonus_usd: 0,
+      credit_usd: already ? 0 : paymentUsd,
+      bonus_usd: already ? 0 : bonusUsd,
       backend: "claims-fallback",
     };
+  } catch (err) {
+    console.error("claims credit patch exhausted:", err?.message || err);
+    throw billingError("billing_unavailable", "Billing ledger unavailable");
   }
-
-  const paymentUsd = Number(creditUsd) || 0;
-  const wantBonus = Math.max(0, Number(firstPayBonusUsd) || 0);
-  const bonusUsd = wantBonus > 0 && !liveClaims.sc_first_pay_bonus_at ? wantBonus : 0;
-  const add = usdToMicros(paymentUsd + bonusUsd);
-  ledger.credit_balance_micros = Number(ledger.credit_balance_micros || 0) + add;
-  if (patch.credit_limit_usd != null) {
-    ledger.credit_limit_usd = normalizeCreditLimitUsd(patch.credit_limit_usd);
-  }
-  if (patch.auto_recharge != null) ledger.auto_recharge = Boolean(patch.auto_recharge);
-  if (patch.auto_recharge_cycle != null) {
-    ledger.auto_recharge_cycle = Math.max(0, Number(patch.auto_recharge_cycle) || 0);
-  }
-  if (patch.customer_id) ledger.customer_id = patch.customer_id;
-  ledger.credited_keys = [...keys.filter((k) => k !== key).slice(-39), key];
-  ledger.updated_at = new Date().toISOString();
-
-  const nextCredited = [...credited.filter((k) => k !== key).slice(-39), key];
-  const bonusPatch =
-    bonusUsd > 0
-      ? {
-          sc_first_pay_bonus_at: new Date().toISOString(),
-          sc_first_pay_bonus_usd: bonusUsd,
-        }
-      : {};
-
-  await setBillingClaims(uid, {
-    ...liveClaims,
-    sc_plan: liveClaims.sc_plan || "payg",
-    sc_metered: false,
-    sc_usage: {
-      month: ledger.month,
-      requests: ledger.requests,
-      tokens_in: ledger.tokens_in,
-      tokens_out: ledger.tokens_out,
-      tokens_saved: ledger.tokens_saved,
-      tokens_reported: ledger.tokens_reported || 0,
-    },
-    sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-    sc_credit_limit_usd: ledger.credit_limit_usd,
-    sc_auto_recharge: Boolean(ledger.auto_recharge),
-    sc_auto_recharge_cycle: Number(ledger.auto_recharge_cycle || 0) || 0,
-    sc_credited_sessions: nextCredited,
-    ...(ledger.customer_id ? { sc_customer_id: ledger.customer_id } : {}),
-    ...bonusPatch,
-  });
-
-  return {
-    applied: true,
-    already: false,
-    ledger,
-    balance: roundUsd(microsToUsd(ledger.credit_balance_micros)),
-    credit_usd: paymentUsd,
-    bonus_usd: bonusUsd,
-    backend: "claims-fallback",
-  };
 }
 
 /**
@@ -1196,8 +1288,6 @@ async function creditBalance({
   // Patch payg flags only when this credit actually applied (not on replay).
   if (result.applied && !result.already) {
     try {
-      const fresh = await admin().auth().getUser(uid);
-      const prev = { ...(fresh.customClaims || {}) };
       const bonusPatch =
         result.bonus_usd > 0
           ? {
@@ -1205,7 +1295,7 @@ async function creditBalance({
               sc_first_pay_bonus_usd: result.bonus_usd,
             }
           : {};
-      await admin().auth().setCustomUserClaims(uid, {
+      await patchUserClaims(uid, (prev) => ({
         ...prev,
         sc_plan: prev.sc_plan || "payg",
         sc_metered: false,
@@ -1223,7 +1313,7 @@ async function creditBalance({
         sc_auto_recharge_cycle: Number(result.ledger.auto_recharge_cycle || 0) || 0,
         ...(result.ledger.customer_id ? { sc_customer_id: result.ledger.customer_id } : {}),
         ...bonusPatch,
-      });
+      }));
     } catch (err) {
       console.warn("credit claim mirror failed:", err.message || err);
       await mirrorClaims(uid, result.ledger);
@@ -1313,4 +1403,8 @@ module.exports = {
   IDEMPOTENCY_LEASE_MS,
   fitCustomClaims,
   setBillingClaims,
+  patchUserClaims,
+  stampOwnerClaim,
+  claimsWriteHeld,
+  claimsConflictToken,
 };

--- a/api/_lib/billing-ledger.test.js
+++ b/api/_lib/billing-ledger.test.js
@@ -10,6 +10,8 @@ const {
   computeCompressFingerprint,
   assertUsageIdempotencyMatch,
   fitCustomClaims,
+  claimsWriteHeld,
+  claimsConflictToken,
 } = require("./billing-ledger");
 
 function ledger(partial = {}) {
@@ -210,6 +212,7 @@ assertUsageIdempotencyMatch(
 {
   const fitted = fitCustomClaims({
     sc_power_mail: "sent",
+    sc_write_id: "abc123def456",
     sc_plan: "free",
     sc_usage: { month: "2026-08", tokens_in: 1, requests: 1 },
     sc_recent_billing: Array.from({ length: 8 }, (_, i) => ({
@@ -223,6 +226,16 @@ assertUsageIdempotencyMatch(
     })),
   });
   assert.strictEqual(fitted.sc_power_mail, "sent");
+  assert.strictEqual(fitted.sc_write_id, "abc123def456");
 }
+
+assert.strictEqual(claimsWriteHeld({ sc_write_id: "aaa" }, "aaa"), true);
+assert.strictEqual(claimsWriteHeld({ sc_write_id: "bbb" }, "aaa"), false);
+assert.strictEqual(claimsWriteHeld({}, "aaa"), false);
+assert.strictEqual(claimsConflictToken({ sc_billing_rev: 10, sc_write_id: "x" }), "10:x");
+assert.notStrictEqual(
+  claimsConflictToken({ sc_billing_rev: 10, sc_write_id: "x" }),
+  claimsConflictToken({ sc_billing_rev: 11, sc_write_id: "x" })
+);
 
 console.log("billing-ledger.test.js: ok");

--- a/api/_lib/credit-topup.js
+++ b/api/_lib/credit-topup.js
@@ -68,29 +68,29 @@ async function markStripeCredited(session) {
 
 async function updateBillingClaims(userId, data) {
   if (!userId || !initFirebaseAdmin()) return;
-  const user = await admin.auth().getUser(userId);
-  const prev = user.customClaims || {};
-  const next = {
-    ...prev,
-    sc_plan: data.plan_id || prev.sc_plan || "free",
-    sc_subscription_status: data.status || "active",
-    sc_customer_id: data.stripe_customer_id || prev.sc_customer_id || null,
-  };
-  if (data.stripe_subscription_id !== undefined) {
-    next.sc_subscription_id = data.stripe_subscription_id;
-  }
-  if (data.sc_metered != null) next.sc_metered = data.sc_metered;
-  if (data.sc_credit_balance_usd != null) next.sc_credit_balance_usd = data.sc_credit_balance_usd;
-  if (data.sc_credit_limit_usd != null) next.sc_credit_limit_usd = data.sc_credit_limit_usd;
-  if (data.sc_auto_recharge != null) next.sc_auto_recharge = data.sc_auto_recharge;
-  if (data.sc_default_payment_method) {
-    next.sc_default_payment_method = data.sc_default_payment_method;
-  }
-  if (data.sc_credited_sessions) next.sc_credited_sessions = data.sc_credited_sessions;
-  if (data.sc_first_pay_bonus_at) next.sc_first_pay_bonus_at = data.sc_first_pay_bonus_at;
-  if (data.sc_first_pay_bonus_usd != null) next.sc_first_pay_bonus_usd = data.sc_first_pay_bonus_usd;
-  await admin.auth().setCustomUserClaims(userId, next);
-  return next;
+  const { patchUserClaims } = require("./billing-ledger");
+  return patchUserClaims(userId, (prev) => {
+    const next = {
+      ...prev,
+      sc_plan: data.plan_id || prev.sc_plan || "free",
+      sc_subscription_status: data.status || "active",
+      sc_customer_id: data.stripe_customer_id || prev.sc_customer_id || null,
+    };
+    if (data.stripe_subscription_id !== undefined) {
+      next.sc_subscription_id = data.stripe_subscription_id;
+    }
+    if (data.sc_metered != null) next.sc_metered = data.sc_metered;
+    if (data.sc_credit_balance_usd != null) next.sc_credit_balance_usd = data.sc_credit_balance_usd;
+    if (data.sc_credit_limit_usd != null) next.sc_credit_limit_usd = data.sc_credit_limit_usd;
+    if (data.sc_auto_recharge != null) next.sc_auto_recharge = data.sc_auto_recharge;
+    if (data.sc_default_payment_method) {
+      next.sc_default_payment_method = data.sc_default_payment_method;
+    }
+    if (data.sc_credited_sessions) next.sc_credited_sessions = data.sc_credited_sessions;
+    if (data.sc_first_pay_bonus_at) next.sc_first_pay_bonus_at = data.sc_first_pay_bonus_at;
+    if (data.sc_first_pay_bonus_usd != null) next.sc_first_pay_bonus_usd = data.sc_first_pay_bonus_usd;
+    return next;
+  });
 }
 
 async function persistSubscription(userId, data) {

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -298,7 +298,7 @@ async function createKey(ownerUid, name, maxKeys) {
     }
   }
   const { createAuthPluginKey } = require("./auth-connect");
-  return createAuthPluginKey(ownerUid, name || "Production");
+  return createAuthPluginKey(ownerUid, name || "Production", { maxKeys });
 }
 
 async function getOwnedKey(ownerUid, keyUid) {

--- a/api/_lib/power-user.js
+++ b/api/_lib/power-user.js
@@ -103,18 +103,9 @@ async function markPowerUser(uid, patch) {
 async function stampPowerMailSent(uid) {
   if (!uid) return false;
   const { initFirebaseAdmin } = require("./auth");
-  const admin = require("firebase-admin");
   if (!initFirebaseAdmin()) return false;
-  const { setBillingClaims } = require("./billing-ledger");
-  for (let i = 0; i < 3; i++) {
-    const user = await admin.auth().getUser(uid);
-    const prev = user.customClaims || {};
-    if (prev[POWER_MAIL_CLAIM] === "sent") return true;
-    await setBillingClaims(uid, { ...prev, [POWER_MAIL_CLAIM]: "sent" });
-    const after = await admin.auth().getUser(uid);
-    if ((after.customClaims || {})[POWER_MAIL_CLAIM] === "sent") return true;
-  }
-  return false;
+  const { stampOwnerClaim } = require("./billing-ledger");
+  return stampOwnerClaim(uid, POWER_MAIL_CLAIM, "sent");
 }
 
 function isDrainablePowerUser(rec) {

--- a/api/_lib/weekly.js
+++ b/api/_lib/weekly.js
@@ -487,10 +487,8 @@ async function weeklyTick(opts = {}) {
 
     if (result.ok) {
       try {
-        const admin = require("firebase-admin");
-        const { setBillingClaims } = require("./billing-ledger");
-        const fresh = await admin.auth().getUser(r.uid);
-        await setBillingClaims(r.uid, { ...(fresh.customClaims || {}), sc_wk: String(campaignId).slice(0, 24) });
+        const { stampOwnerClaim } = require("./billing-ledger");
+        await stampOwnerClaim(r.uid, "sc_wk", String(campaignId).slice(0, 24));
       } catch (stampErr) {
         errors.push({ email: r.email, error: `sent_but_stamp_failed: ${stampErr.message}` });
       }
@@ -578,13 +576,13 @@ async function unsubscribeEmail(email, token, { confirmOnly = false } = {}) {
     throw err;
   }
   try {
-    const admin = require("firebase-admin");
     const { initFirebaseAdmin } = require("./auth");
-    const { setBillingClaims } = require("./billing-ledger");
+    const { stampOwnerClaim } = require("./billing-ledger");
     if (initFirebaseAdmin()) {
+      const admin = require("firebase-admin");
       const user = await admin.auth().getUserByEmail(clean).catch(() => null);
       if (user) {
-        await setBillingClaims(user.uid, { ...(user.customClaims || {}), sc_unsub: "1" });
+        await stampOwnerClaim(user.uid, "sc_unsub", "1");
       }
     }
   } catch (err) {

--- a/api/_lib/welcome.js
+++ b/api/_lib/welcome.js
@@ -156,9 +156,8 @@ async function handleSignupWelcome(req, body, user) {
   });
   if (result.ok) {
     try {
-      const { setBillingClaims } = require("./billing-ledger");
-      const fresh = await admin.auth().getUser(user.uid);
-      await setBillingClaims(user.uid, { ...(fresh.customClaims || liveClaims), sc_welcome: "sent" });
+      const { stampOwnerClaim } = require("./billing-ledger");
+      await stampOwnerClaim(user.uid, "sc_welcome", "sent");
     } catch (err) {
       console.warn("welcome: claim stamp skipped:", err.message);
     }
@@ -235,10 +234,8 @@ async function drainPendingWelcomes() {
         error: null,
       }).catch(() => {});
       try {
-        const admin = require("firebase-admin");
-        const { setBillingClaims } = require("./billing-ledger");
-        const fresh = await admin.auth().getUser(rec.uid);
-        await setBillingClaims(rec.uid, { ...(fresh.customClaims || {}), sc_welcome: "sent" });
+        const { stampOwnerClaim } = require("./billing-ledger");
+        await stampOwnerClaim(rec.uid, "sc_welcome", "sent");
       } catch (_) {}
       sent += 1;
     } else {
@@ -269,8 +266,8 @@ async function drainPendingWelcomes() {
           });
           if (result.ok) {
             try {
-              const { setBillingClaims } = require("./billing-ledger");
-              await setBillingClaims(user.uid, { ...(user.customClaims || {}), sc_welcome: "sent" });
+              const { stampOwnerClaim } = require("./billing-ledger");
+              await stampOwnerClaim(user.uid, "sc_welcome", "sent");
             } catch (_) {}
             authMailed += 1;
           }

--- a/api/account.js
+++ b/api/account.js
@@ -172,7 +172,7 @@ async function mintConnectKey(ownerUid, maxKeys) {
       }
     }
   }
-  return createAuthPluginKey(ownerUid, PLUGIN_KEY_NAME);
+  return createAuthPluginKey(ownerUid, PLUGIN_KEY_NAME, { maxKeys });
 }
 
 async function handleConnectDevice(req, res) {

--- a/api/billing.js
+++ b/api/billing.js
@@ -114,10 +114,8 @@ async function patchCreditClaims(userId, patch) {
     err.status = 503;
     throw err;
   }
-  const user = await admin.auth().getUser(userId);
-  const next = { ...(user.customClaims || {}), ...patch };
-  await admin.auth().setCustomUserClaims(userId, next);
-  return next;
+  const { patchUserClaims } = require("./_lib/billing-ledger");
+  return patchUserClaims(userId, (live) => ({ ...live, ...patch }));
 }
 
 /* ── GET: free allowance + credit / PAYG status ── */


### PR DESCRIPTION
## Summary
- Route Auth claim writers through `patchUserClaims` (live merge + `sc_write_id` verify) so key mint / mail stamps / settings updates cannot snapshot-revert a wallet write, and credit top-ups retry instead of last-write-wins at $0.
- Enforce plan `max_keys` on Auth-backed key mint (Free 10 / PAYG 25) and stop slicing the owner index to 20.
- Does **not** pretend Auth is a CAS ledger. Single-flight idempotency, durable 600/hr, and CCR still need a real store.

## Test plan
- [x] `node api/_lib/billing-ledger.test.js`
- [x] `node api/_lib/auth-connect.test.js`
- [x] `node api/_lib/power-user.test.js`
- [ ] CI green
- [ ] Creating an 11th Free key returns 429
- [ ] Two distinct Checkout sessions on one account both credit (no $10+$10→$10)


Made with [Cursor](https://cursor.com)