### PR TITLE
Fix billing dither bar and full-month analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
         run: node api/_lib/auth-connect.test.js
       - name: Founder usage aggregation
         run: node api/_lib/founder-usage.test.js
+      - name: Usage day reconstruction
+        run: node api/_lib/usage-days.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
       - name: Proxy package tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Public page: https://www.supercompress.dev/changelog
 - AMCP scale-training stack (`scripts/amcp`) — JS-compatible wider keep-policy, coding-agent + QA oracles, Kaggle GPU entry (`kaggle/amcp-scale`)
 
 ### API / dashboard
+- Billing usage bar uses the same animated dither + bloom as Analytics (grow-in + shimmer), not a static dotted strip
+- Analytics charts the full billing month per signed-in account; missing daily rows spread across the month instead of dumping onto today
 - Founder admin on `internal.supercompress.dev` shows all-account usage (processed / in / out / saved / cut %, leaderboard) with the same dither charts as dashboard Analytics
 
 - Soft-200 scanner/probe noise (`softProbe`) so Vercel Observability error rate stays ~0; real clients with credentials still get proper 4xx

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -14,6 +14,7 @@
  */
 const crypto = require("crypto");
 const { initFirebaseAdmin } = require("./auth");
+const { bumpPackedDays, dayKey } = require("./usage-days");
 const {
   FREE_TOKENS_PER_MONTH,
   USD_PER_MILLION,
@@ -368,6 +369,16 @@ function fitCustomClaims(claims) {
   const next = { ...(claims || {}) };
   const steps = [
     () => {
+      if (next.sc_usage?.d && typeof next.sc_usage.d === "object") {
+        const keys = Object.keys(next.sc_usage.d).sort();
+        if (keys.length > 14) {
+          const d = {};
+          for (const k of keys.slice(-14)) d[k] = next.sc_usage.d[k];
+          next.sc_usage = { ...next.sc_usage, d };
+        }
+      }
+    },
+    () => {
       delete next.sc_agent_plugin;
     },
     () => {
@@ -550,6 +561,18 @@ async function applyUsageAndBurnClaimsFallback({
           claims: liveClaims,
         });
         already = false;
+        const packed = bumpPackedDays(
+          liveClaims.sc_usage?.month === planned.ledger.month
+            ? { m: planned.ledger.month, d: liveClaims.sc_usage.d || {} }
+            : { m: planned.ledger.month, d: {} },
+          {
+            month: planned.ledger.month,
+            day: dayKey(),
+            tokens_in: tokensIn,
+            tokens_saved: tokensSaved,
+            requests: 1,
+          }
+        );
         return {
           ...liveClaims,
           sc_billing_rev: prevRev + 1,
@@ -560,6 +583,7 @@ async function applyUsageAndBurnClaimsFallback({
             tokens_out: planned.ledger.tokens_out,
             tokens_saved: planned.ledger.tokens_saved,
             tokens_reported: planned.ledger.tokens_reported || 0,
+            d: packed.d,
           },
           sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
           sc_recent_billing: [
@@ -766,6 +790,9 @@ async function mirrorClaims(uid, ledger) {
         tokens_out: ledger.tokens_out,
         tokens_saved: ledger.tokens_saved,
         tokens_reported: ledger.tokens_reported,
+        ...(prev.sc_usage?.month === ledger.month && prev.sc_usage?.d
+          ? { d: prev.sc_usage.d }
+          : {}),
       },
       sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
       ...(ledger.credit_limit_usd != null

--- a/api/_lib/firebase-key-store.js
+++ b/api/_lib/firebase-key-store.js
@@ -198,9 +198,11 @@ async function listKeys(ownerUid) {
   }
 
   let account_usage = null;
+  let ownerClaims = {};
   try {
     const owner = await ownerRecord(ownerUid);
     const claims = owner.customClaims || {};
+    ownerClaims = claims;
     const month = new Date().toISOString().slice(0, 7);
     // Prefer durable billing ledger (same source as compress paywall) over mirrored claims.
     try {
@@ -243,6 +245,28 @@ async function listKeys(ownerUid) {
       }
     }
   } catch (_) {}
+
+  if (account_usage) {
+    try {
+      const { expandPackedDays, daysFromRecentBilling, mergeDays, fillMonthGap } = require("./usage-days");
+      const month = account_usage.month;
+      const recorded = expandPackedDays(
+        ownerClaims.sc_usage?.month === month
+          ? { m: month, d: ownerClaims.sc_usage.d || {} }
+          : null,
+        month
+      );
+      const fromRecent = Object.keys(recorded).length
+        ? {}
+        : daysFromRecentBilling(ownerClaims.sc_recent_billing, month);
+      const filled = fillMonthGap(mergeDays(recorded, fromRecent), account_usage, month);
+      account_usage = {
+        ...account_usage,
+        by_day: filled.by_day,
+        by_day_source: filled.source,
+      };
+    } catch (_) {}
+  }
 
   // Attribute billing-meter gap onto a real key so the table never shows
   // "per-key store empty" when default + coding-agent keys exist.

--- a/api/_lib/founder-usage.js
+++ b/api/_lib/founder-usage.js
@@ -3,6 +3,8 @@
  * Used by the founder dashboard on internal.supercompress.dev.
  */
 
+const { expandPackedDays, fillMonthGap, mergeDays } = require("./usage-days");
+
 const STUB_RE = /^(sck_|sc_lnk_|sc_at_|sc_ac_|sc_aff_)/;
 
 function monthKey(d = new Date()) {
@@ -51,6 +53,13 @@ function rowFromUser(user, month = monthKey()) {
     recorded_requests: requests,
     cut_pct: cutPct(current ? tokens_saved : tokens_saved, current ? tokens_in : tokens_in),
     created_at: user.metadata?.creationTime || null,
+    by_day: current
+      ? fillMonthGap(
+          expandPackedDays({ m: month, d: usage.d || {} }, month),
+          { tokens_in, tokens_out, tokens_saved, requests },
+          month
+        ).by_day
+      : {},
   };
 }
 
@@ -124,6 +133,14 @@ function mergeStoreDays(store) {
   return byDay;
 }
 
+function mergeRowDays(rows) {
+  let byDay = {};
+  for (const r of rows || []) {
+    byDay = mergeDays(byDay, r.by_day || {});
+  }
+  return byDay;
+}
+
 function analyticsBundle({ totals, leaderboard, plans, byDay }) {
   return {
     live: true,
@@ -157,6 +174,7 @@ module.exports = {
   rowFromUser,
   summarizeRows,
   mergeStoreDays,
+  mergeRowDays,
   analyticsBundle,
   STUB_RE,
 };

--- a/api/_lib/usage-days.js
+++ b/api/_lib/usage-days.js
@@ -1,0 +1,225 @@
+/**
+ * Compact per-day usage on Auth claims (`sc_usage.d`) and read-time reconstruction.
+ * Firestore is off by default, so monthly meters had no daily series — charts
+ * looked like "only the last few days" after the client dumped the gap on today.
+ */
+
+const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+function monthKey(d = new Date()) {
+  return d.toISOString().slice(0, 7);
+}
+
+function dayKey(d = new Date()) {
+  return d.toISOString().slice(0, 10);
+}
+
+function isIsoDay(day) {
+  return ISO_DAY.test(String(day || ""));
+}
+
+function emptyDay() {
+  return { tokens_in: 0, tokens_out: 0, tokens_saved: 0, requests: 0 };
+}
+
+function daysInMonth(month) {
+  const [y, m] = String(month || "").split("-").map(Number);
+  if (!y || !m) return 31;
+  return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+function monthDayKeys(month = monthKey(), throughIso = dayKey()) {
+  const m = String(month || monthKey());
+  const end =
+    String(throughIso || "").slice(0, 7) === m
+      ? Math.max(1, Number(String(throughIso).slice(8, 10)) || 1)
+      : daysInMonth(m);
+  const out = [];
+  for (let i = 1; i <= end; i++) {
+    out.push(`${m}-${String(i).padStart(2, "0")}`);
+  }
+  return out;
+}
+
+function trimPackedDays(packed, keep = 16) {
+  const d = { ...(packed?.d || {}) };
+  const keys = Object.keys(d).sort();
+  if (keys.length <= keep) return { m: packed?.m, d };
+  const next = {};
+  for (const k of keys.slice(-keep)) next[k] = d[k];
+  return { m: packed?.m, d: next };
+}
+
+function bumpPackedDays(prev, stats = {}, now = new Date()) {
+  const day = isIsoDay(stats.day) ? stats.day : dayKey(now);
+  const month = String(stats.month || day.slice(0, 7));
+  const src = prev && prev.m === month ? { ...(prev.d || {}) } : {};
+  const dd = day.slice(8, 10);
+  const cur = Array.isArray(src[dd]) ? src[dd] : [0, 0, 0];
+  src[dd] = [
+    (Number(cur[0]) || 0) + Math.max(0, Number(stats.tokens_in) || 0),
+    (Number(cur[1]) || 0) + Math.max(0, Number(stats.tokens_saved) || 0),
+    (Number(cur[2]) || 0) + Math.max(0, Number(stats.requests) || 1),
+  ];
+  return trimPackedDays({ m: month, d: src }, 16);
+}
+
+function expandPackedDays(packed, month = monthKey()) {
+  const m = String(packed?.m || month);
+  const out = {};
+  if (!packed || packed.m !== m || !packed.d || typeof packed.d !== "object") return out;
+  for (const [dd, rec] of Object.entries(packed.d)) {
+    const iso = `${m}-${String(dd).padStart(2, "0")}`;
+    if (!isIsoDay(iso)) continue;
+    const tin = Number(Array.isArray(rec) ? rec[0] : rec.tokens_in) || 0;
+    const saved = Number(Array.isArray(rec) ? rec[1] : rec.tokens_saved) || 0;
+    const req = Number(Array.isArray(rec) ? rec[2] : rec.requests) || 0;
+    out[iso] = {
+      tokens_in: tin,
+      tokens_saved: saved,
+      tokens_out: Math.max(0, tin - saved),
+      requests: req,
+    };
+  }
+  return out;
+}
+
+function daysFromRecentBilling(recent, month = monthKey()) {
+  const out = {};
+  for (const row of Array.isArray(recent) ? recent : []) {
+    const t = Number(row?.t || 0);
+    if (!t) continue;
+    const iso = new Date(t).toISOString().slice(0, 10);
+    if (iso.slice(0, 7) !== month) continue;
+    if (!out[iso]) out[iso] = emptyDay();
+    out[iso].tokens_in += Number(row.tin || 0);
+    out[iso].tokens_out += Number(row.tout || 0);
+    out[iso].tokens_saved += Number(row.ts || 0);
+    out[iso].requests += 1;
+  }
+  return out;
+}
+
+function mergeDays(...maps) {
+  const out = {};
+  for (const map of maps) {
+    for (const [day, rec] of Object.entries(map || {})) {
+      if (!isIsoDay(day)) continue;
+      if (!out[day]) out[day] = emptyDay();
+      out[day].tokens_in += Number(rec.tokens_in || 0);
+      out[day].tokens_out += Number(rec.tokens_out || 0);
+      out[day].tokens_saved += Number(rec.tokens_saved || 0);
+      out[day].requests += Number(rec.requests || 0);
+    }
+  }
+  return out;
+}
+
+function addDays(a, b) {
+  const out = { ...(a || {}) };
+  for (const [day, rec] of Object.entries(b || {})) {
+    if (!isIsoDay(day)) continue;
+    const cur = out[day] || emptyDay();
+    out[day] = {
+      tokens_in: (cur.tokens_in || 0) + (Number(rec.tokens_in) || 0),
+      tokens_out: (cur.tokens_out || 0) + (Number(rec.tokens_out) || 0),
+      tokens_saved: (cur.tokens_saved || 0) + (Number(rec.tokens_saved) || 0),
+      requests: (cur.requests || 0) + (Number(rec.requests) || 0),
+    };
+  }
+  return out;
+}
+
+/**
+ * When monthly totals exist but daily rows don't cover them, spread the gap
+ * across the calendar month (weighted by known-day activity) instead of
+ * dumping everything onto today.
+ */
+function fillMonthGap(byDay, totals = {}, month = monthKey(), throughIso = dayKey()) {
+  const keys = monthDayKeys(month, throughIso);
+  const recorded = { ...(byDay || {}) };
+  let dayIn = 0;
+  let daySaved = 0;
+  let dayReq = 0;
+  for (const iso of keys) {
+    const d = recorded[iso] || emptyDay();
+    dayIn += d.tokens_in;
+    daySaved += d.tokens_saved;
+    dayReq += d.requests;
+  }
+  const gapIn = Math.max(0, Number(totals.tokens_in || 0) - dayIn);
+  const gapSaved = Math.max(0, Number(totals.tokens_saved || 0) - daySaved);
+  const gapReq = Math.max(0, Number(totals.requests || 0) - dayReq);
+  if (gapIn < 500 && gapSaved < 500 && gapReq <= 0) {
+    return { by_day: recorded, source: "recorded" };
+  }
+
+  const weights = keys.map((iso) => {
+    const d = recorded[iso];
+    const w = 1 + (d ? Math.max(d.requests || 0, d.tokens_in > 0 ? 2 : 0) : 0);
+    return w;
+  });
+  const wSum = weights.reduce((s, w) => s + w, 0) || keys.length;
+  const out = { ...recorded };
+  let usedIn = 0;
+  let usedSaved = 0;
+  let usedReq = 0;
+  keys.forEach((iso, i) => {
+    const last = i === keys.length - 1;
+    const share = weights[i] / wSum;
+    const addIn = last ? gapIn - usedIn : Math.round(gapIn * share);
+    const addSaved = last ? gapSaved - usedSaved : Math.round(gapSaved * share);
+    const addReq = last ? gapReq - usedReq : Math.round(gapReq * share);
+    usedIn += addIn;
+    usedSaved += addSaved;
+    usedReq += addReq;
+    const cur = out[iso] || emptyDay();
+    out[iso] = {
+      tokens_in: cur.tokens_in + Math.max(0, addIn),
+      tokens_saved: cur.tokens_saved + Math.max(0, addSaved),
+      tokens_out: cur.tokens_out + Math.max(0, addIn - addSaved),
+      requests: cur.requests + Math.max(0, addReq),
+    };
+  });
+  return {
+    by_day: out,
+    source: Object.keys(recorded).length ? "mixed" : "reconstructed",
+  };
+}
+
+function accountDaysFromClaims(claims = {}, month = monthKey()) {
+  const usage = claims.sc_usage || {};
+  const packedMonth = usage.month === month ? { m: month, d: usage.d || {} } : null;
+  const recorded = expandPackedDays(packedMonth, month);
+  const fromRecent = Object.keys(recorded).length
+    ? {}
+    : daysFromRecentBilling(claims.sc_recent_billing, month);
+  const merged = mergeDays(recorded, fromRecent);
+  const totals =
+    usage.month === month
+      ? {
+          tokens_in: usage.tokens_in,
+          tokens_saved: usage.tokens_saved,
+          tokens_out: usage.tokens_out,
+          requests: usage.requests,
+        }
+      : {};
+  return fillMonthGap(merged, totals, month);
+}
+
+module.exports = {
+  monthKey,
+  dayKey,
+  isIsoDay,
+  emptyDay,
+  daysInMonth,
+  monthDayKeys,
+  trimPackedDays,
+  bumpPackedDays,
+  expandPackedDays,
+  daysFromRecentBilling,
+  mergeDays,
+  addDays,
+  fillMonthGap,
+  accountDaysFromClaims,
+};

--- a/api/_lib/usage-days.test.js
+++ b/api/_lib/usage-days.test.js
@@ -1,0 +1,65 @@
+/**
+ * Run: node api/_lib/usage-days.test.js
+ */
+const assert = require("assert");
+const {
+  bumpPackedDays,
+  expandPackedDays,
+  daysFromRecentBilling,
+  fillMonthGap,
+  monthDayKeys,
+  accountDaysFromClaims,
+} = require("./usage-days");
+
+const packed = bumpPackedDays(null, {
+  day: "2026-08-13",
+  month: "2026-08",
+  tokens_in: 1000,
+  tokens_saved: 400,
+  requests: 2,
+});
+assert.strictEqual(packed.m, "2026-08");
+assert.deepStrictEqual(packed.d["13"], [1000, 400, 2]);
+
+const again = bumpPackedDays(packed, {
+  day: "2026-08-13",
+  month: "2026-08",
+  tokens_in: 50,
+  tokens_saved: 20,
+  requests: 1,
+});
+assert.deepStrictEqual(again.d["13"], [1050, 420, 3]);
+
+const expanded = expandPackedDays(again, "2026-08");
+assert.strictEqual(expanded["2026-08-13"].tokens_in, 1050);
+assert.strictEqual(expanded["2026-08-13"].tokens_saved, 420);
+assert.ok(!expandPackedDays({ m: "2026-07", d: again.d }, "2026-07")["2026-08-13"]);
+
+const fromRecent = daysFromRecentBilling(
+  [{ tin: 80, ts: 30, tout: 50, t: Date.parse("2026-08-02T15:00:00.000Z") }],
+  "2026-08"
+);
+assert.strictEqual(fromRecent["2026-08-02"].tokens_in, 80);
+
+const keys = monthDayKeys("2026-08", "2026-08-10");
+assert.strictEqual(keys.length, 10);
+assert.strictEqual(keys[0], "2026-08-01");
+assert.strictEqual(keys[9], "2026-08-10");
+
+const filled = fillMonthGap({}, { tokens_in: 10000, tokens_saved: 4000, requests: 20 }, "2026-08", "2026-08-10");
+assert.strictEqual(filled.source, "reconstructed");
+const sumIn = Object.values(filled.by_day).reduce((s, d) => s + d.tokens_in, 0);
+assert.strictEqual(sumIn, 10000);
+assert.ok(filled.by_day["2026-08-01"].tokens_in > 0);
+assert.ok(filled.by_day["2026-08-10"].tokens_in > 0);
+
+const claims = accountDaysFromClaims(
+  {
+    sc_usage: { month: "2026-08", tokens_in: 5000, tokens_saved: 2000, requests: 5, d: { "03": [1000, 400, 1] } },
+  },
+  "2026-08"
+);
+assert.ok(claims.by_day["2026-08-03"].tokens_in >= 1000);
+assert.ok(Object.values(claims.by_day).reduce((s, d) => s + d.tokens_in, 0) >= 5000);
+
+console.log("usage-days.test.js: ok");

--- a/api/founder-usage.js
+++ b/api/founder-usage.js
@@ -10,6 +10,7 @@ const {
   rowFromUser,
   summarizeRows,
   mergeStoreDays,
+  mergeRowDays,
   analyticsBundle,
 } = require("./_lib/founder-usage");
 
@@ -54,11 +55,12 @@ module.exports = async (req, res) => {
     const rows = await scanAuthRows(month);
     const summary = summarizeRows(rows, month);
 
-    let byDay = {};
+    let byDay = mergeRowDays(rows);
     try {
       const { loadStore } = require("./_lib/store");
       const store = await loadStore({ forceRemote: false });
-      byDay = mergeStoreDays(store);
+      const { mergeDays } = require("./_lib/usage-days");
+      byDay = mergeDays(byDay, mergeStoreDays(store));
     } catch (_) {}
 
     const payload = {

--- a/api/keys.js
+++ b/api/keys.js
@@ -41,6 +41,7 @@ module.exports = async (req, res) => {
           tokens_in: Math.max(Number(account_usage?.tokens_in || 0), agentTotals.tokens_in),
           tokens_out: Math.max(Number(account_usage?.tokens_out || 0), agentTotals.tokens_out),
           tokens_saved: Math.max(Number(account_usage?.tokens_saved || 0), agentTotals.tokens_saved),
+          ...(account_usage?.by_day ? { by_day: account_usage.by_day, by_day_source: account_usage.by_day_source } : {}),
         };
       }
       return json(res, 200, { ...keys, account_usage, coding_agent_usage, agent_plugin });

--- a/web/assets/js/analytics-data.js
+++ b/web/assets/js/analytics-data.js
@@ -8,15 +8,49 @@
 
   const ISO_DAY = /^\d{4}-\d{2}-\d{2}$/;
 
+  function utcYmd(d = new Date()) {
+    return d.toISOString().slice(0, 10);
+  }
+
   function dayKeys(n = 30) {
     const out = [];
     for (let i = n - 1; i >= 0; i--) {
       const d = new Date();
-      d.setHours(12, 0, 0, 0);
-      d.setDate(d.getDate() - i);
+      d.setUTCHours(12, 0, 0, 0);
+      d.setUTCDate(d.getUTCDate() - i);
       out.push(d.toISOString().slice(0, 10));
     }
     return out;
+  }
+
+  function daysInMonth(month) {
+    const [y, m] = String(month || "").split("-").map(Number);
+    if (!y || !m) return 31;
+    return new Date(Date.UTC(y, m, 0)).getUTCDate();
+  }
+
+  /** Calendar days for the billing month through today (UTC), plus any earlier ISO days in `extra`. */
+  function monthKeys(month, throughIso, extra = []) {
+    const today = utcYmd();
+    const m = String(month || today.slice(0, 7));
+    const through = String(throughIso || today);
+    const end =
+      through.slice(0, 7) === m ? Math.max(1, Number(through.slice(8, 10)) || 1) : daysInMonth(m);
+    const out = [];
+    for (let i = 1; i <= end; i++) out.push(`${m}-${String(i).padStart(2, "0")}`);
+    const earlier = (extra || [])
+      .filter((d) => ISO_DAY.test(d) && d < out[0])
+      .sort();
+    const start = earlier[0];
+    if (!start) return out;
+    const merged = [];
+    let cur = new Date(start + "T12:00:00Z");
+    const last = new Date(out[out.length - 1] + "T12:00:00Z");
+    while (cur <= last && merged.length < 62) {
+      merged.push(cur.toISOString().slice(0, 10));
+      cur.setUTCDate(cur.getUTCDate() + 1);
+    }
+    return merged.length ? merged : out;
   }
 
   function labelDay(iso) {
@@ -71,10 +105,23 @@
   /**
    * Build chart + KPI bundle from /api/keys payload (or demo shape).
    */
+  function addDay(target, day, rec) {
+    if (!isChartDay(day)) return;
+    if (!target[day]) target[day] = emptyDay();
+    target[day].tokens_saved += Number(rec.tokens_saved || 0);
+    target[day].tokens_in += Number(rec.tokens_in || 0);
+    target[day].requests += Number(rec.requests || 0);
+  }
+
   function aggregateUsage(payload) {
-    const keys = dayKeys(30);
-    const byDay = Object.fromEntries(keys.map((k) => [k, emptyDay()]));
     const usage = payload.usage || {};
+    const account = payload.account_usage || {};
+    const month = account.month || utcYmd().slice(0, 7);
+    const accountDays = {};
+    for (const [day, rec] of Object.entries(account.by_day || {})) {
+      addDay(accountDays, day, rec);
+    }
+    const keyDays = {};
     const keyRows = [];
 
     for (const k of payload.keys || []) {
@@ -84,11 +131,21 @@
         value: Number(snap.total_tokens_saved || 0),
       });
       for (const [day, rec] of Object.entries(snap.by_day || {})) {
-        if (!isChartDay(day) || !byDay[day]) continue;
-        byDay[day].tokens_saved += Number(rec.tokens_saved || 0);
-        byDay[day].tokens_in += Number(rec.tokens_in || 0);
-        byDay[day].requests += Number(rec.requests || 0);
+        addDay(keyDays, day, rec);
       }
+    }
+
+    const accountHasDays = Object.values(accountDays).some(
+      (d) => d.tokens_in > 0 || d.tokens_saved > 0 || d.requests > 0
+    );
+    const sourceDays = accountHasDays ? accountDays : keyDays;
+    const keys = monthKeys(month, utcYmd(), Object.keys(sourceDays));
+    const byDay = Object.fromEntries(keys.map((k) => [k, emptyDay()]));
+    for (const [day, rec] of Object.entries(sourceDays)) {
+      if (!byDay[day]) byDay[day] = emptyDay();
+      byDay[day].tokens_saved += rec.tokens_saved;
+      byDay[day].tokens_in += rec.tokens_in;
+      byDay[day].requests += rec.requests;
     }
 
     const agents = Object.entries(payload.coding_agent_usage || {})
@@ -243,8 +300,18 @@
     };
   }
 
+  function chartDayList(bundle) {
+    const extra = Object.keys(bundle.byDay || {}).filter(isChartDay);
+    const month = (bundle.account && bundle.account.month) || utcYmd().slice(0, 7);
+    return monthKeys(month, utcYmd(), extra);
+  }
+
   function meterFromBundle(bundle) {
-    const keys = dayKeys(30);
+    if (!bundle.byDay) bundle.byDay = {};
+    const keys = chartDayList(bundle);
+    for (const iso of keys) {
+      if (!bundle.byDay[iso]) bundle.byDay[iso] = emptyDay();
+    }
     let daySaved = 0;
     let dayIn = 0;
     let dayReq = 0;
@@ -278,30 +345,47 @@
       Number(agentT.requests || 0)
     );
 
-    // Month meter ahead of ISO by_day (common when ledger/agent totals exist but
-    // daily rows lagged). Fold the gap onto today so the area chart matches KPIs.
+    // Month meter ahead of daily rows: spread the gap across the whole month
+    // (weighted toward days that already have activity). Never dump it on today.
     const gapSaved = saved - daySaved;
     const gapIn = tin - dayIn;
     const gapReq = req - dayReq;
     if (gapSaved > 500 || gapIn > 500 || gapReq > 0) {
-      const today = keys[keys.length - 1];
-      const cur = bundle.byDay[today] || emptyDay();
-      bundle.byDay[today] = {
-        tokens_saved: cur.tokens_saved + Math.max(0, gapSaved),
-        tokens_in: cur.tokens_in + Math.max(0, gapIn),
-        requests: cur.requests + Math.max(0, gapReq),
-      };
+      const weights = keys.map((iso) => {
+        const d = bundle.byDay[iso];
+        return 1 + (d && (d.requests || d.tokens_in) ? Math.max(d.requests || 0, 2) : 0);
+      });
+      const wSum = weights.reduce((s, w) => s + w, 0) || keys.length || 1;
+      let usedS = 0;
+      let usedI = 0;
+      let usedR = 0;
+      keys.forEach((iso, i) => {
+        const last = i === keys.length - 1;
+        const share = weights[i] / wSum;
+        const addS = last ? gapSaved - usedS : Math.round(gapSaved * share);
+        const addI = last ? gapIn - usedI : Math.round(gapIn * share);
+        const addR = last ? gapReq - usedR : Math.round(gapReq * share);
+        usedS += addS;
+        usedI += addI;
+        usedR += addR;
+        const cur = bundle.byDay[iso] || emptyDay();
+        bundle.byDay[iso] = {
+          tokens_saved: cur.tokens_saved + Math.max(0, addS),
+          tokens_in: cur.tokens_in + Math.max(0, addI),
+          requests: cur.requests + Math.max(0, addR),
+        };
+      });
       daySaved = saved;
       dayIn = tin;
       dayReq = req;
     }
 
-    return { saved, tin, req, daySaved, dayIn, dayReq };
+    return { saved, tin, req, daySaved, dayIn, dayReq, keys };
   }
 
   function bundleToSeries(bundle) {
-    const keys = dayKeys(30);
     const meter = meterFromBundle(bundle);
+    const keys = meter.keys || chartDayList(bundle);
     const areaData = keys.map((iso) => {
       const L = labelDay(iso);
       return { x: L.full, y: bundle.byDay[iso]?.tokens_saved || 0, iso };
@@ -367,6 +451,7 @@
 
   const api = {
     dayKeys,
+    monthKeys,
     labelDay,
     isChartDay,
     aggregateUsage,

--- a/web/assets/js/analytics-data.test.js
+++ b/web/assets/js/analytics-data.test.js
@@ -58,8 +58,13 @@ assert.strictEqual(series.totalReq, 12);
 assert.ok(series.cut >= 50 && series.cut <= 52, `cut=${series.cut}`);
 assert.ok(
   series.areaData.some((d) => d.y > 0),
-  "synthesizes a chart day when by_day empty / non-ISO only"
+  "synthesizes chart days when by_day empty / non-ISO only"
 );
+assert.ok(
+  series.areaData.filter((d) => d.y > 0).length > 1,
+  "spreads month totals across the calendar, not a single spike"
+);
+assert.ok(series.areaData.length >= 8, "full month-to-date axis");
 assert.ok(
   !series.areaData.some((d) => d.y === 99999),
   "ignores reconcile-* by_day keys"
@@ -94,7 +99,7 @@ assert.strictEqual(s2.totalSaved, 2000);
 assert.strictEqual(s2.totalIn, 5000);
 assert.strictEqual(s2.totalReq, 10);
 
-// Month meter ahead of partial by_day — chart catches up on today.
+// Month meter ahead of partial by_day — chart catches up across the month.
 const partial = aggregateUsage({
   keys: [{ id: "k1", name: "Production" }],
   usage: {
@@ -126,6 +131,10 @@ assert.strictEqual(
   s3.areaData.reduce((s, d) => s + d.y, 0),
   250000,
   "chart area matches month meter after gap fold"
+);
+assert.ok(
+  s3.areaData.filter((d) => d.y > 0).length > 1,
+  "gap is not dumped onto today only"
 );
 
 console.log("analytics-data.test.js: ok");

--- a/web/assets/js/dashboard-analytics.js
+++ b/web/assets/js/dashboard-analytics.js
@@ -147,7 +147,7 @@
           color: "brand",
           variant: "gradient",
           bloom: "aura",
-          maxBars: 30,
+          maxBars: Math.max(8, series.reqs.length),
           progress: done ? 1 : p,
           yMax: reqMax,
           unit: "requests",

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -937,22 +937,51 @@ function watchBillingMeter(track) {
       return;
     }
     if (document.getElementById("panel-billing")?.classList.contains("hidden")) return;
-    window.DitherKitLite?.renderDitherMeter?.(track, billingMeterOpts(track));
+    const kit = window.DitherKitLite;
+    if (!kit?.renderDitherMeter) return;
+    kit.renderDitherMeter(track, { ...billingMeterOpts(track), bloom: "aura" });
   });
   obs.observe(track);
   track._dkMeterObs = obs;
 }
 
-function paintBillingUsageMeter(track) {
+function paintBillingUsageMeter(track, { animate = true } = {}) {
   const kit = window.DitherKitLite;
   if (!track || !kit?.renderDitherMeter) return;
   watchBillingMeter(track);
   if (document.getElementById("panel-billing")?.classList.contains("hidden")) return;
-  const paint = () => {
+  kit.stopMeterDitherLoop?.(track);
+  if (typeof track._dkMeterCancel === "function") {
+    track._dkMeterCancel();
+    track._dkMeterCancel = null;
+  }
+  const opts = { ...billingMeterOpts(track), bloom: "aura" };
+  const target = Number(opts.progress) || 0;
+  const paint = (p) => {
     if (!track.isConnected) return;
-    kit.renderDitherMeter(track, billingMeterOpts(track));
+    kit.renderDitherMeter(track, { ...opts, progress: target * p });
   };
-  requestAnimationFrame(() => requestAnimationFrame(paint));
+  const finish = () => {
+    paint(1);
+    kit.startMeterDitherLoop?.(track, opts);
+  };
+  if (!animate || !kit.animateChart) {
+    requestAnimationFrame(() => requestAnimationFrame(finish));
+    return;
+  }
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      if (!track.isConnected) return;
+      if (track.getBoundingClientRect().width < 16) {
+        finish();
+        return;
+      }
+      track._dkMeterCancel = kit.animateChart((p) => {
+        paint(p);
+        if (p > 0.98) finish();
+      }, 900);
+    });
+  });
 }
 
 function renderSubscription(sub) {

--- a/web/assets/js/dither-kit-lite.js
+++ b/web/assets/js/dither-kit-lite.js
@@ -619,54 +619,113 @@
     };
   }
 
+  function ensureMeterHost(el) {
+    if (!el) return null;
+    el.classList.add("dk-meter-host");
+    let crisp = el.querySelector("canvas.dk-meter");
+    let bloom = el.querySelector("canvas.dk-meter-bloom");
+    if (!crisp) {
+      bloom = document.createElement("canvas");
+      bloom.className = "dk-meter-bloom";
+      bloom.setAttribute("aria-hidden", "true");
+      crisp = document.createElement("canvas");
+      crisp.className = "dk-meter";
+      crisp.setAttribute("aria-hidden", "true");
+      el.appendChild(bloom);
+      el.appendChild(crisp);
+    }
+    return { host: el, crisp, bloom };
+  }
+
   /** Horizontal Bayer usage meter (billing free-allowance bar). */
   function renderDitherMeter(el, options = {}) {
     if (!el) return false;
-    el.querySelectorAll(".dash-billing-usage-fill").forEach((n) => n.remove());
-    let canvas = el.querySelector("canvas.dk-meter");
-    if (!canvas) {
-      canvas = document.createElement("canvas");
-      canvas.className = "dk-meter";
-      canvas.setAttribute("aria-hidden", "true");
-      el.appendChild(canvas);
-    }
-    const rect = el.getBoundingClientRect();
-    const cssW = Math.round(rect.width || el.clientWidth || 0);
-    const cssH = Math.round(rect.height || el.clientHeight || 0);
-    // Hidden panels are display:none → 0×0. Never fall back to a fake width.
+    const pack = ensureMeterHost(el);
+    if (!pack) return false;
+    const { host, crisp, bloom } = pack;
+    const rect = host.getBoundingClientRect();
+    const cssW = Math.round(rect.width || host.clientWidth || 0);
+    const cssH = Math.round(rect.height || host.clientHeight || 0);
+    // Hidden panels are display:none → 0×0. Keep the CSS fill until we can paint.
     if (cssW < 16 || cssH < 4) return false;
+    host.querySelectorAll(".dash-billing-usage-fill").forEach((n) => n.remove());
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
-    canvas.width = Math.round(cssW * dpr);
-    canvas.height = Math.round(cssH * dpr);
-    canvas.style.width = "100%";
-    canvas.style.height = "100%";
-    const ctx = canvas.getContext("2d");
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    for (const c of [crisp, bloom]) {
+      c.width = Math.round(cssW * dpr);
+      c.height = Math.round(cssH * dpr);
+      c.style.width = "100%";
+      c.style.height = "100%";
+      c.getContext("2d").setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    const ctx = crisp.getContext("2d");
     ctx.clearRect(0, 0, cssW, cssH);
 
-    const pct = clamp01((Number(options.progress) || 0) / (options.max || 1));
+    const max = options.max == null ? 1 : Number(options.max) || 1;
+    const pct = clamp01((Number(options.progress) || 0) / max);
     const colorName = options.color || (pct >= 0.9 ? "red" : pct >= 0.7 ? "orange" : "brand");
     const seed = seedOf(colorName);
-    const cell = 4;
-    const cols = Math.min(MAX_COLS, Math.max(8, Math.round(cssW / cell)));
-    const rows = Math.min(MAX_ROWS, Math.max(4, Math.round(cssH / cell)));
-    const off = document.createElement("canvas");
-    off.width = cols;
-    off.height = rows;
-    const octx = off.getContext("2d");
-    const fillCols = Math.round(cols * pct);
-    octx.fillStyle = "rgba(15,23,42,0.08)";
-    octx.fillRect(0, 0, cols, rows);
-    for (let x = 0; x < fillCols; x++) {
-      paintColumn(octx, x, 0, rows, seed, {
-        variant: "dotted",
-        intensity: 0.92,
-        dim: 1,
-      });
+    const phase = Number(options.phase) || 0;
+    const fillW = Math.max(pct > 0 ? 6 : 0, Math.round(cssW * pct));
+    const padY = 2;
+    const fillH = Math.max(8, cssH - padY * 2);
+
+    ctx.fillStyle = "rgba(23,23,23,0.05)";
+    ctx.fillRect(0, 0, cssW, cssH);
+
+    if (fillW > 0) {
+      const { cols, rows } = backingSize(fillW, fillH);
+      const off = document.createElement("canvas");
+      off.width = cols;
+      off.height = rows;
+      const octx = off.getContext("2d");
+      for (let x = 0; x < cols; x++) {
+        paintColumn(octx, x, 0, rows, seed, {
+          variant: "gradient",
+          stacked: true,
+          dim: 1,
+          intensity: 0.22 + 0.1 * Math.sin(phase * 1.6 + x * 0.09),
+          phase,
+        });
+      }
+      ctx.imageSmoothingEnabled = false;
+      ctx.drawImage(off, 0, padY, fillW, fillH);
+      ctx.fillStyle = rgb(seed.line, 1, 0.55);
+      ctx.fillRect(Math.max(0, fillW - 2), padY, 2, fillH);
     }
-    ctx.imageSmoothingEnabled = false;
-    ctx.drawImage(off, 0, 0, cssW, cssH);
+
+    applyBloom(bloom, crisp, options.bloom || "aura", host);
+    host._dkLastMeter = { ...options, progress: pct, max: 1 };
     return true;
+  }
+
+  function startMeterDitherLoop(el, options = {}) {
+    if (!el) return;
+    stopMeterDitherLoop(el);
+    let phase = Number(options.phase) || 0;
+    let last = performance.now();
+    let acc = 0;
+    const tick = (now) => {
+      if (!el.isConnected) {
+        stopMeterDitherLoop(el);
+        return;
+      }
+      const dt = Math.min(48, now - last);
+      last = now;
+      acc += dt;
+      phase += dt * 0.00115;
+      if (acc >= 50 && el.getBoundingClientRect().width >= 16) {
+        acc = 0;
+        renderDitherMeter(el, { ...(el._dkLastMeter || {}), ...options, phase, bloom: options.bloom || "aura" });
+      }
+      el._dkMeterRaf = requestAnimationFrame(tick);
+    };
+    el._dkMeterRaf = requestAnimationFrame(tick);
+  }
+
+  function stopMeterDitherLoop(el) {
+    if (!el || !el._dkMeterRaf) return;
+    cancelAnimationFrame(el._dkMeterRaf);
+    el._dkMeterRaf = 0;
   }
 
   function ensureWashCanvas(el) {
@@ -818,6 +877,8 @@
     stopChartDitherLoop,
     animateChart,
     renderDitherMeter,
+    startMeterDitherLoop,
+    stopMeterDitherLoop,
     formatCompact,
     seedOf,
   };

--- a/web/assets/js/founder-analytics.js
+++ b/web/assets/js/founder-analytics.js
@@ -94,7 +94,7 @@
         color: "brand",
         variant: "gradient",
         bloom: "aura",
-        maxBars: 30,
+        maxBars: Math.max(8, series.reqs.length),
         progress: 1,
         yMax: reqMax,
         unit: "requests",

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -123,17 +123,31 @@
     }
 
     .dash-billing-usage-track {
+      position: relative;
       width: 100%;
-      height: 16px;
-      border-radius: 4px;
-      background: #ecece8;
+      height: 28px;
+      border-radius: 8px;
+      background: #f3f3ef;
+      border: 1px solid rgba(23, 23, 23, 0.08);
       overflow: hidden;
     }
 
-    .dash-billing-usage-track canvas.dk-meter {
+    .dash-billing-usage-track canvas.dk-meter,
+    .dash-billing-usage-track canvas.dk-meter-bloom {
+      position: absolute;
+      inset: 0;
       display: block;
       width: 100% !important;
       height: 100% !important;
+      pointer-events: none;
+    }
+
+    .dash-billing-usage-track canvas.dk-meter-bloom {
+      z-index: 0;
+    }
+
+    .dash-billing-usage-track canvas.dk-meter {
+      z-index: 1;
     }
 
     .dash-billing-usage-fill {
@@ -832,7 +846,7 @@ npm exec supercompress setup</pre>
           <div class="dash-panel-head">
             <div>
               <h1>Analytics</h1>
-              <p>Token savings from your keys and coding agents, last 30 days.</p>
+              <p>Token savings from your keys and coding agents, this billing month.</p>
             </div>
             <div class="dash-panel-actions">
               <span class="an-status" style="margin:0">
@@ -884,7 +898,7 @@ npm exec supercompress setup</pre>
               <header class="panel-head">
                 <div>
                   <h2>Tokens saved</h2>
-                  <p>Daily · last 30 days · hover a day</p>
+                  <p>Daily · this month · hover a day</p>
                 </div>
                 <span class="chip chip--cut" id="an-chip-delta">—</span>
               </header>
@@ -895,9 +909,9 @@ npm exec supercompress setup</pre>
               <header class="panel-head">
                 <div>
                   <h2>Requests</h2>
-                  <p>Compress calls · last 30 days</p>
+                  <p>Compress calls · this month</p>
                 </div>
-                <span class="chip">30 days</span>
+                <span class="chip">This month</span>
               </header>
               <div class="chart-well" id="an-bars"></div>
             </section>
@@ -923,7 +937,7 @@ npm exec supercompress setup</pre>
             </section>
           </div>
 
-          <p class="an-footnote">Signed-in usage from your SuperCompress account · last 30 days</p>
+          <p class="an-footnote">Signed-in usage from your SuperCompress account · this billing month</p>
         </div>
 
         <!-- Billing / PAYG -->
@@ -1124,10 +1138,10 @@ npm exec supercompress setup</pre>
   </footer>
   <script src="assets/js/firebase-config.js?v=3"></script>
   <script src="assets/js/supercompress.js?v=1"></script>
-  <script src="/assets/js/dither-kit-lite.js?v=14"></script>
-  <script src="/assets/js/analytics-data.js?v=3"></script>
+  <script src="/assets/js/dither-kit-lite.js?v=15"></script>
+  <script src="/assets/js/analytics-data.js?v=4"></script>
   <script src="/assets/js/dashboard-analytics.js?v=6"></script>
-  <script type="module" src="/assets/js/dashboard-api.js?v=38"></script>
+  <script type="module" src="/assets/js/dashboard-api.js?v=39"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>

--- a/web/founder.html
+++ b/web/founder.html
@@ -1153,8 +1153,8 @@
 
   </div>
 
-  <script src="/assets/js/dither-kit-lite.js?v=14"></script>
-  <script src="/assets/js/analytics-data.js?v=3"></script>
+  <script src="/assets/js/dither-kit-lite.js?v=15"></script>
+  <script src="/assets/js/analytics-data.js?v=4"></script>
   <script src="/assets/js/founder-analytics.js?v=1"></script>
   <!-- Firebase + internal dashboard logic -->
   <script type="importmap">


### PR DESCRIPTION
## Summary
- Billing usage bar is the same animated dither + bloom as Analytics (grow-in, then a live shimmer). The old static dotted strip is gone.
- Analytics charts the full billing month for the signed-in account. Missing daily rows are spread across the month instead of dumped onto today.
- Each account’s series comes from that user’s meter only. New compresses write compact per-day buckets on Auth claims so days stay real going forward.

## Test plan
- [x] `node api/_lib/usage-days.test.js`
- [x] `node web/assets/js/analytics-data.test.js`
- [x] `node api/_lib/founder-usage.test.js`
- [x] `node api/_lib/billing-ledger.test.js`
- [ ] Open dashboard Billing — bar grows in and keeps shimmering
- [ ] Open Analytics — axis is the 1st through today, not a 1–2 day spike
- [ ] Confirm another account only sees its own usage


Made with [Cursor](https://cursor.com)