### PR TITLE
Live tokens-processed counter on landing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
         run: node api/_lib/founder-usage.test.js
       - name: Usage day reconstruction
         run: node api/_lib/usage-days.test.js
+      - name: Public stats helpers
+        run: node api/stats.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
       - name: Proxy package tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Public page: https://www.supercompress.dev/changelog
 ## [Unreleased]
 
 ### Site / docs
+- Landing live counter: tokens processed across SuperCompress (from `/api/stats`)
 - GitHub Sponsors on the Supercompress repo (`FUNDING.yml` + Sponsor badge) → [@arjunkshah12345-hash](https://github.com/sponsors/arjunkshah12345-hash)
 - Product mail campaign copy lives in private GitHub `Supercompress/email-campaigns` (not OSS); loaders read Vercel env / local mirror
 - Product mail (welcome + Sunday tip + Wednesday ship) sends from Resend on `hello@supercompress.dev`; Ideatrusa/gog drains paused offline

--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -584,6 +584,17 @@ async function applyUsageAndBurnClaimsFallback({
             tokens_saved: planned.ledger.tokens_saved,
             tokens_reported: planned.ledger.tokens_reported || 0,
             d: packed.d,
+            ...(() => {
+              const prev = liveClaims.sc_usage || {};
+              const lifeIn = Number(prev.life_in || 0) || 0;
+              const lifeSaved = Number(prev.life_saved || 0) || 0;
+              const seededIn = lifeIn > 0 ? lifeIn : Number(prev.tokens_in || 0) || 0;
+              const seededSaved = lifeSaved > 0 ? lifeSaved : Number(prev.tokens_saved || 0) || 0;
+              return {
+                life_in: seededIn + Math.max(0, Number(tokensIn) || 0),
+                life_saved: seededSaved + Math.max(0, Number(tokensSaved) || 0),
+              };
+            })(),
           },
           sc_credit_balance_usd: roundUsd(microsToUsd(planned.ledger.credit_balance_micros)),
           sc_recent_billing: [
@@ -792,6 +803,10 @@ async function mirrorClaims(uid, ledger) {
         tokens_reported: ledger.tokens_reported,
         ...(prev.sc_usage?.month === ledger.month && prev.sc_usage?.d
           ? { d: prev.sc_usage.d }
+          : {}),
+        ...(Number(prev.sc_usage?.life_in) > 0 ? { life_in: Number(prev.sc_usage.life_in) } : {}),
+        ...(Number(prev.sc_usage?.life_saved) > 0
+          ? { life_saved: Number(prev.sc_usage.life_saved) }
           : {}),
       },
       sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
@@ -1149,6 +1164,15 @@ async function creditBalanceClaimsFallback({
             tokens_out: ledger.tokens_out,
             tokens_saved: ledger.tokens_saved,
             tokens_reported: ledger.tokens_reported || 0,
+            ...(Number(liveClaims.sc_usage?.life_in) > 0
+              ? { life_in: Number(liveClaims.sc_usage.life_in) }
+              : {}),
+            ...(Number(liveClaims.sc_usage?.life_saved) > 0
+              ? { life_saved: Number(liveClaims.sc_usage.life_saved) }
+              : {}),
+            ...(liveClaims.sc_usage?.month === ledger.month && liveClaims.sc_usage?.d
+              ? { d: liveClaims.sc_usage.d }
+              : {}),
           },
           sc_credit_balance_usd: roundUsd(microsToUsd(ledger.credit_balance_micros)),
           sc_credit_limit_usd: ledger.credit_limit_usd,
@@ -1333,6 +1357,13 @@ async function creditBalance({
           tokens_out: result.ledger.tokens_out,
           tokens_saved: result.ledger.tokens_saved,
           tokens_reported: result.ledger.tokens_reported,
+          ...(Number(prev.sc_usage?.life_in) > 0 ? { life_in: Number(prev.sc_usage.life_in) } : {}),
+          ...(Number(prev.sc_usage?.life_saved) > 0
+            ? { life_saved: Number(prev.sc_usage.life_saved) }
+            : {}),
+          ...(prev.sc_usage?.month === result.ledger.month && prev.sc_usage?.d
+            ? { d: prev.sc_usage.d }
+            : {}),
         },
         sc_credit_balance_usd: roundUsd(microsToUsd(result.ledger.credit_balance_micros)),
         sc_credit_limit_usd: result.ledger.credit_limit_usd,

--- a/api/stats.js
+++ b/api/stats.js
@@ -4,13 +4,17 @@
  * npm "weekly downloads" ≠ unique humans. Publish days, mirrors, CI, and
  * reinstalls inflate that number. Signed-up users = Firebase Auth accounts
  * with an email (real humans who finished dashboard / setup connect).
+ *
+ * tokens_processed = sum of lifetime (or current-month) tokens_in across
+ * human accounts — same Auth meter that bills compress.
  */
 const { json } = require("./_lib/http");
 const { initFirebaseAdmin } = require("./_lib/auth");
+const { isHumanUser } = require("./_lib/founder-usage");
 const admin = require("firebase-admin");
 
 const PACKAGES = ["supercompress-proxy", "@agents-npm-packages/supercompress"];
-const CACHE_MS = 30 * 60 * 1000;
+const CACHE_MS = 5 * 60 * 1000; // 5 min — live enough for landing counter
 let cache = { at: 0, payload: null };
 
 async function npmWeek(pkg) {
@@ -26,26 +30,57 @@ async function npmWeek(pkg) {
   };
 }
 
-async function countSignedUpUsers() {
+function accountProcessed(claims = {}) {
+  const u = claims.sc_usage || {};
+  const life = Number(u.life_in || 0) || 0;
+  const month = Number(u.tokens_in || 0) || 0;
+  const lifeSaved = Number(u.life_saved || 0) || 0;
+  const monthSaved = Number(u.tokens_saved || 0) || 0;
+  return {
+    tokens_in: Math.max(life, month),
+    tokens_saved: Math.max(lifeSaved, monthSaved),
+  };
+}
+
+async function scanAuthGrowth() {
   if (!initFirebaseAdmin()) return null;
   const auth = admin.auth();
   let pageToken;
   let withEmail = 0;
   let total = 0;
+  let tokens_processed = 0;
+  let tokens_saved = 0;
   do {
     const page = await auth.listUsers(1000, pageToken);
     for (const user of page.users) {
       total += 1;
+      if (!isHumanUser(user)) continue;
       if (user.email || user.providerData?.some((p) => p.email)) withEmail += 1;
+      const rec = accountProcessed(user.customClaims || {});
+      tokens_processed += rec.tokens_in;
+      tokens_saved += rec.tokens_saved;
     }
     pageToken = page.pageToken;
   } while (pageToken);
-  return { total_auth_records: total, signed_up_users: withEmail };
+  return {
+    total_auth_records: total,
+    signed_up_users: withEmail,
+    tokens_processed,
+    tokens_saved,
+  };
 }
 
 function fmtDownloads(n) {
   if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1).replace(/\.0$/, "")}k+`;
   return String(n);
+}
+
+function fmtTokens(n) {
+  const v = Math.max(0, Number(n) || 0);
+  if (v >= 1e9) return `${(v / 1e9).toFixed(v >= 1e10 ? 0 : 1).replace(/\.0$/, "")}B`;
+  if (v >= 1e6) return `${(v / 1e6).toFixed(v >= 1e7 ? 0 : 1).replace(/\.0$/, "")}M`;
+  if (v >= 1e3) return `${(v / 1e3).toFixed(v >= 1e4 ? 0 : 1).replace(/\.0$/, "")}k`;
+  return String(Math.round(v));
 }
 
 module.exports = async (req, res) => {
@@ -62,12 +97,15 @@ module.exports = async (req, res) => {
     const npmDownloadsWeek = npm.reduce((s, r) => s + r.downloads, 0);
     const primary = npm.find((r) => r.package === "supercompress-proxy") || npm[0];
 
-    let users = null;
+    let growth = null;
     try {
-      users = await countSignedUpUsers();
+      growth = await scanAuthGrowth();
     } catch (err) {
-      console.warn("stats: auth count failed", err.message || err);
+      console.warn("stats: auth scan failed", err.message || err);
     }
+
+    const tokensProcessed = growth?.tokens_processed ?? null;
+    const tokensSaved = growth?.tokens_saved ?? null;
 
     const payload = {
       ok: true,
@@ -83,10 +121,14 @@ module.exports = async (req, res) => {
           }
         : null,
       npm_packages: npm,
-      signed_up_users: users?.signed_up_users ?? null,
-      auth_records: users?.total_auth_records ?? null,
+      signed_up_users: growth?.signed_up_users ?? null,
+      auth_records: growth?.total_auth_records ?? null,
+      tokens_processed: tokensProcessed,
+      tokens_processed_label: tokensProcessed == null ? null : fmtTokens(tokensProcessed),
+      tokens_saved: tokensSaved,
+      tokens_saved_label: tokensSaved == null ? null : fmtTokens(tokensSaved),
       note:
-        "npm weekly downloads count install events (mirrors, CI, reinstalls, version bumps) — not unique people. signed_up_users = Firebase Auth accounts with email who finished signup/connect.",
+        "tokens_processed sums account meters (lifetime when present, else current month). npm weekly downloads count install events — not unique people. signed_up_users = Firebase Auth accounts with email.",
       updated_at: new Date().toISOString(),
     };
 
@@ -97,3 +139,5 @@ module.exports = async (req, res) => {
     return json(res, 500, { ok: false, detail: err.message || String(err) });
   }
 };
+
+module.exports._test = { accountProcessed, fmtTokens };

--- a/api/stats.test.js
+++ b/api/stats.test.js
@@ -1,0 +1,20 @@
+/**
+ * Run: node api/stats.test.js
+ */
+const assert = require("assert");
+const { accountProcessed, fmtTokens } = require("./stats.js")._test;
+
+assert.strictEqual(fmtTokens(0), "0");
+assert.strictEqual(fmtTokens(1500), "1.5k");
+assert.strictEqual(fmtTokens(2_100_000), "2.1M");
+
+assert.deepStrictEqual(accountProcessed({ sc_usage: { tokens_in: 100, tokens_saved: 40 } }), {
+  tokens_in: 100,
+  tokens_saved: 40,
+});
+assert.deepStrictEqual(
+  accountProcessed({ sc_usage: { tokens_in: 100, life_in: 9_000_000, life_saved: 4_000_000, tokens_saved: 40 } }),
+  { tokens_in: 9_000_000, tokens_saved: 4_000_000 }
+);
+
+console.log("stats.test.js: ok");

--- a/web/assets/css/landing-motion.css
+++ b/web/assets/css/landing-motion.css
@@ -350,8 +350,56 @@ html.gsap-ready .logo-marquee-track { animation: none !important; }
   border-radius: 8px;
   overflow: hidden;
   background: #fff;
-  margin-top: 72px;
+  margin-top: 28px;
   margin-bottom: 24px;
+}
+
+.live-tokens-band {
+  margin-top: 56px;
+  padding: 28px 0 0;
+}
+.live-tokens-inner {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto;
+}
+.live-tokens-kicker {
+  margin: 0 0 8px;
+  color: var(--blue);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.live-tokens-line {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  align-items: baseline;
+  justify-content: center;
+  font-family: var(--serif);
+  color: var(--ink, #171717);
+}
+.live-tokens-line strong {
+  font-weight: 300;
+  font-size: clamp(42px, 7vw, 72px);
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--blue);
+  font-variant-numeric: tabular-nums;
+}
+.live-tokens-line span {
+  font-size: clamp(22px, 3.2vw, 32px);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  color: #3a3a38;
+}
+.live-tokens-sub {
+  margin: 10px 0 0;
+  color: #80807c;
+  font-size: 13px;
+  line-height: 1.45;
 }
 .micro-dither-strip {
   position: absolute;

--- a/web/assets/js/landing-app.js
+++ b/web/assets/js/landing-app.js
@@ -842,4 +842,47 @@
     };
     requestAnimationFrame(draw);
   }
+
+  // —— Live tokens processed (public /api/stats) ——
+  (function bootLiveTokens() {
+    const el = document.getElementById("live-tokens-n");
+    const sub = document.getElementById("live-tokens-sub");
+    if (!el) return;
+
+    const fmt = (n) => {
+      const v = Math.max(0, Number(n) || 0);
+      if (v >= 1e9) return `${(v / 1e9).toFixed(v >= 1e10 ? 0 : 1).replace(/\.0$/, "")}B`;
+      if (v >= 1e6) return `${(v / 1e6).toFixed(v >= 1e7 ? 0 : 1).replace(/\.0$/, "")}M`;
+      if (v >= 1e3) return `${(v / 1e3).toFixed(v >= 1e4 ? 0 : 1).replace(/\.0$/, "")}k`;
+      return String(Math.round(v));
+    };
+
+    const paint = (n, saved) => {
+      const end = Math.max(0, Number(n) || 0);
+      if (!window.gsap) {
+        el.textContent = fmt(end);
+      } else {
+        const state = { value: 0 };
+        gsap.to(state, {
+          value: end,
+          duration: 1.35,
+          ease: "power2.out",
+          onUpdate: () => {
+            el.textContent = fmt(state.value);
+          },
+        });
+      }
+      if (sub && saved != null) {
+        sub.textContent = `${fmt(saved)} tokens saved · across SuperCompress accounts`;
+      }
+    };
+
+    fetch("/api/stats", { credentials: "omit", cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!d || d.tokens_processed == null) return;
+        paint(d.tokens_processed, d.tokens_saved);
+      })
+      .catch(() => {});
+  })();
 })();

--- a/web/index.html
+++ b/web/index.html
@@ -36,7 +36,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
   <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=5" as="image" fetchpriority="high" />
-  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=8" />
+  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=9" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 
 
@@ -321,6 +321,17 @@
             </span>
           </h2>
         </div>
+      </div>
+    </section>
+
+    <section class="live-tokens-band" aria-label="Tokens processed live">
+      <div class="container live-tokens-inner">
+        <p class="live-tokens-kicker">Live</p>
+        <p class="live-tokens-line">
+          <strong id="live-tokens-n" data-live-tokens>—</strong>
+          <span>tokens processed</span>
+        </p>
+        <p class="live-tokens-sub" id="live-tokens-sub">across SuperCompress · updates as people compress</p>
       </div>
     </section>
 
@@ -751,7 +762,7 @@
 
   <script src="/assets/js/vendor/gsap/gsap.min.js"></script>
   <script src="/assets/js/vendor/gsap/ScrollTrigger.min.js"></script>
-<script src="/assets/js/landing-app.js?v=6"></script>
+<script src="/assets/js/landing-app.js?v=7"></script>
 
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- `/api/stats` returns `tokens_processed` / `tokens_saved` from Auth account meters (5‑min cache).
- Compress burns now bump `sc_usage.life_in` / `life_saved` so the public total keeps growing across months.
- Landing page shows a live count-up band above the metrics card.

## Test plan
- [x] `node api/stats.test.js`
- [x] `node api/_lib/billing-ledger.test.js`
- [ ] Open www homepage — live tokens band paints a real number
- [ ] `GET /api/stats` includes `tokens_processed` and labels
- [ ] Prod smoke still 32/32


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live landing-page counter showing tokens processed and saved across SuperCompress.
  * Added formatted token totals with responsive presentation and animated updates.

* **Bug Fixes**
  * Preserved lifetime usage and saved-token totals when updating account metrics.

* **Tests**
  * Added automated coverage for token formatting and usage aggregation.

* **Chores**
  * Improved statistics freshness by reducing the cache duration to five minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->