### PR TITLE
Fix live tokens counter above CTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Public page: https://www.supercompress.dev/changelog
 ## [Unreleased]
 
 ### Site / docs
-- Landing live counter: tokens processed across SuperCompress (from `/api/stats`)
+- Landing live counter: tokens processed across SuperCompress (from `/api/stats`), above the bottom CTA, polling every 15s
 - GitHub Sponsors on the Supercompress repo (`FUNDING.yml` + Sponsor badge) → [@arjunkshah12345-hash](https://github.com/sponsors/arjunkshah12345-hash)
 - Product mail campaign copy lives in private GitHub `Supercompress/email-campaigns` (not OSS); loaders read Vercel env / local mirror
 - Product mail (welcome + Sunday tip + Wednesday ship) sends from Resend on `hello@supercompress.dev`; Ideatrusa/gog drains paused offline

--- a/api/stats.js
+++ b/api/stats.js
@@ -14,7 +14,7 @@ const { isHumanUser } = require("./_lib/founder-usage");
 const admin = require("firebase-admin");
 
 const PACKAGES = ["supercompress-proxy", "@agents-npm-packages/supercompress"];
-const CACHE_MS = 5 * 60 * 1000; // 5 min — live enough for landing counter
+const CACHE_MS = 60 * 1000; // 60s — landing polls with ?fresh=1
 let cache = { at: 0, payload: null };
 
 async function npmWeek(pkg) {
@@ -88,7 +88,11 @@ module.exports = async (req, res) => {
   if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed", allow: "GET" });
 
   try {
-    if (cache.payload && Date.now() - cache.at < CACHE_MS) {
+    if (
+      cache.payload &&
+      Date.now() - cache.at < CACHE_MS &&
+      String(req.query?.fresh || "") !== "1"
+    ) {
       return json(res, 200, { ...cache.payload, cached: true });
     }
 

--- a/web/assets/css/landing-motion.css
+++ b/web/assets/css/landing-motion.css
@@ -350,20 +350,18 @@ html.gsap-ready .logo-marquee-track { animation: none !important; }
   border-radius: 8px;
   overflow: hidden;
   background: #fff;
-  margin-top: 28px;
+  margin-top: 72px;
   margin-bottom: 24px;
 }
 
-.live-tokens-band {
-  margin-top: 56px;
-  padding: 28px 0 0;
+.cta-live-tokens {
+  max-width: 34rem;
+  margin: 0 0 28px;
 }
-.live-tokens-inner {
-  text-align: center;
-  max-width: 720px;
-  margin: 0 auto;
-}
-.live-tokens-kicker {
+.cta-live-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   margin: 0 0 8px;
   color: var(--blue);
   font-size: 11px;
@@ -371,35 +369,50 @@ html.gsap-ready .logo-marquee-track { animation: none !important; }
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
-.live-tokens-line {
+.cta-live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #16a34a;
+  box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.55);
+  animation: cta-live-pulse 1.6s ease-out infinite;
+}
+@keyframes cta-live-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.5); }
+  70% { box-shadow: 0 0 0 10px rgba(22, 163, 74, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(22, 163, 74, 0); }
+}
+.cta-live-line {
   margin: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px 14px;
+  gap: 8px 12px;
   align-items: baseline;
-  justify-content: center;
   font-family: var(--serif);
-  color: var(--ink, #171717);
+  color: #171717;
 }
-.live-tokens-line strong {
+.cta-live-line strong {
   font-weight: 300;
-  font-size: clamp(42px, 7vw, 72px);
+  font-size: clamp(36px, 5.5vw, 56px);
   letter-spacing: -0.04em;
   line-height: 1;
   color: var(--blue);
   font-variant-numeric: tabular-nums;
 }
-.live-tokens-line span {
-  font-size: clamp(22px, 3.2vw, 32px);
+.cta-live-line span {
+  font-size: clamp(18px, 2.4vw, 24px);
   font-weight: 400;
   letter-spacing: -0.02em;
   color: #3a3a38;
 }
-.live-tokens-sub {
-  margin: 10px 0 0;
+.cta-live-sub {
+  margin: 8px 0 0;
   color: #80807c;
   font-size: 13px;
   line-height: 1.45;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cta-live-dot { animation: none; }
 }
 .micro-dither-strip {
   position: absolute;
@@ -928,6 +941,7 @@ html.gsap-ready .bar > i { transform: scaleX(0); }
   padding: 80px 0;
   /* keep .container width + horizontal centering — don't override with max-width/margin:0 */
 }
+.cta-copy .cta-live-tokens,
 .cta-copy .cta-brand,
 .cta-copy h2,
 .cta-copy .cta-lead,

--- a/web/assets/js/landing-app.js
+++ b/web/assets/js/landing-app.js
@@ -3,6 +3,77 @@
   const hasGsap = Boolean(window.gsap && window.ScrollTrigger);
   if (hasGsap && !reduced) document.documentElement.classList.add('gsap-ready');
 
+  // —— Live tokens processed (public /api/stats) — boot early so CTA isn't stuck on "—"
+  (function bootLiveTokens() {
+    const el = document.getElementById("live-tokens-n");
+    const sub = document.getElementById("live-tokens-sub");
+    if (!el) return;
+
+    let current = 0;
+    let raf = 0;
+    const POLL_MS = 15000;
+
+    const fmtFull = (n) => Math.max(0, Math.round(Number(n) || 0)).toLocaleString("en-US");
+    const fmtCompact = (n) => {
+      const v = Math.max(0, Number(n) || 0);
+      if (v >= 1e9) return `${(v / 1e9).toFixed(v >= 1e10 ? 0 : 1).replace(/\.0$/, "")}B`;
+      if (v >= 1e6) return `${(v / 1e6).toFixed(v >= 1e7 ? 0 : 1).replace(/\.0$/, "")}M`;
+      if (v >= 1e3) return `${(v / 1e3).toFixed(v >= 1e4 ? 0 : 1).replace(/\.0$/, "")}k`;
+      return String(Math.round(v));
+    };
+
+    const setSub = (saved) => {
+      if (!sub || saved == null) return;
+      sub.textContent = `${fmtCompact(saved)} tokens saved · across SuperCompress accounts`;
+    };
+
+    const animateTo = (next) => {
+      const end = Math.max(0, Number(next) || 0);
+      if (raf) cancelAnimationFrame(raf);
+      if (reduced || !Number.isFinite(end)) {
+        current = end;
+        el.textContent = fmtFull(end);
+        return;
+      }
+      const start = current;
+      const delta = end - start;
+      if (Math.abs(delta) < 1) {
+        current = end;
+        el.textContent = fmtFull(end);
+        return;
+      }
+      const t0 = performance.now();
+      const dur = Math.min(1400, 400 + Math.abs(delta) / 8000);
+      const ease = (t) => 1 - Math.pow(1 - t, 3);
+      const frame = (now) => {
+        const p = Math.min(1, (now - t0) / dur);
+        current = start + delta * ease(p);
+        el.textContent = fmtFull(current);
+        if (p < 1) raf = requestAnimationFrame(frame);
+        else {
+          current = end;
+          el.textContent = fmtFull(end);
+        }
+      };
+      raf = requestAnimationFrame(frame);
+    };
+
+    const pull = (fresh) => {
+      const q = fresh ? `/api/stats?fresh=1&_=${Date.now()}` : `/api/stats?_=${Date.now()}`;
+      return fetch(q, { credentials: "omit", cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (!d || d.tokens_processed == null) return;
+          animateTo(d.tokens_processed);
+          setSub(d.tokens_saved);
+        })
+        .catch(() => {});
+    };
+
+    pull(true);
+    setInterval(() => pull(true), POLL_MS);
+  })();
+
   // Scroll progress
   window.addEventListener('scroll', () => {
     const prog = document.querySelector('.scroll-progress');
@@ -842,47 +913,4 @@
     };
     requestAnimationFrame(draw);
   }
-
-  // —— Live tokens processed (public /api/stats) ——
-  (function bootLiveTokens() {
-    const el = document.getElementById("live-tokens-n");
-    const sub = document.getElementById("live-tokens-sub");
-    if (!el) return;
-
-    const fmt = (n) => {
-      const v = Math.max(0, Number(n) || 0);
-      if (v >= 1e9) return `${(v / 1e9).toFixed(v >= 1e10 ? 0 : 1).replace(/\.0$/, "")}B`;
-      if (v >= 1e6) return `${(v / 1e6).toFixed(v >= 1e7 ? 0 : 1).replace(/\.0$/, "")}M`;
-      if (v >= 1e3) return `${(v / 1e3).toFixed(v >= 1e4 ? 0 : 1).replace(/\.0$/, "")}k`;
-      return String(Math.round(v));
-    };
-
-    const paint = (n, saved) => {
-      const end = Math.max(0, Number(n) || 0);
-      if (!window.gsap) {
-        el.textContent = fmt(end);
-      } else {
-        const state = { value: 0 };
-        gsap.to(state, {
-          value: end,
-          duration: 1.35,
-          ease: "power2.out",
-          onUpdate: () => {
-            el.textContent = fmt(state.value);
-          },
-        });
-      }
-      if (sub && saved != null) {
-        sub.textContent = `${fmt(saved)} tokens saved · across SuperCompress accounts`;
-      }
-    };
-
-    fetch("/api/stats", { credentials: "omit", cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        if (!d || d.tokens_processed == null) return;
-        paint(d.tokens_processed, d.tokens_saved);
-      })
-      .catch(() => {});
-  })();
 })();

--- a/web/index.html
+++ b/web/index.html
@@ -36,7 +36,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
   <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=5" as="image" fetchpriority="high" />
-  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=9" />
+  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=10" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 
 
@@ -321,17 +321,6 @@
             </span>
           </h2>
         </div>
-      </div>
-    </section>
-
-    <section class="live-tokens-band" aria-label="Tokens processed live">
-      <div class="container live-tokens-inner">
-        <p class="live-tokens-kicker">Live</p>
-        <p class="live-tokens-line">
-          <strong id="live-tokens-n" data-live-tokens>—</strong>
-          <span>tokens processed</span>
-        </p>
-        <p class="live-tokens-sub" id="live-tokens-sub">across SuperCompress · updates as people compress</p>
       </div>
     </section>
 
@@ -669,6 +658,14 @@
         <img class="cta-hands" src="/assets/img/cta-hands.jpg" alt="" width="1800" height="1200" loading="lazy" decoding="async" />
         <div class="cta-fade" aria-hidden="true"></div>
         <div class="container cta-copy reveal">
+          <div class="cta-live-tokens" aria-live="polite">
+            <p class="cta-live-kicker"><span class="cta-live-dot" aria-hidden="true"></span> Live</p>
+            <p class="cta-live-line">
+              <strong id="live-tokens-n">—</strong>
+              <span>tokens processed</span>
+            </p>
+            <p class="cta-live-sub" id="live-tokens-sub">across SuperCompress · refreshes as people compress</p>
+          </div>
           <div class="cta-brand">
             <img src="/assets/img/logo-chevrons.png" alt="" width="28" height="28" />
             <span>Super<em>Compress</em></span>
@@ -762,7 +759,7 @@
 
   <script src="/assets/js/vendor/gsap/gsap.min.js"></script>
   <script src="/assets/js/vendor/gsap/ScrollTrigger.min.js"></script>
-<script src="/assets/js/landing-app.js?v=7"></script>
+<script src="/assets/js/landing-app.js?v=8"></script>
 
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- Moves the live tokens counter above the bottom CTA (“Ship AI features…”)
- Shows full locale numbers (not stuck on — / compact-only)
- Polls `/api/stats?fresh=1` every 15s with count-up

## Test plan
- [ ] Scroll to bottom CTA — live number sits above SuperCompress brand
- [ ] Number is full (e.g. 48,643,428) and green pulse reads live
- [ ] Hard refresh; value loads within ~1s


Made with [Cursor](https://cursor.com)