### PR TITLE
feat: live token odometer with full commas

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -902,7 +902,23 @@ async function lookupUsageReplay(uid, requestId) {
   }
 }
 
-async function applyUsageAndBurn({
+async function applyUsageAndBurn(opts) {
+  const result = await applyUsageAndBurnInner(opts);
+  if (result && !result.already) {
+    try {
+      const { bumpGlobalTokenStats } = require("./global-token-stats");
+      void bumpGlobalTokenStats({
+        tokensIn: opts.tokensIn,
+        tokensSaved: opts.tokensSaved,
+      });
+    } catch {
+      /* public counter is best-effort */
+    }
+  }
+  return result;
+}
+
+async function applyUsageAndBurnInner({
   uid,
   tokensIn,
   tokensOut,

--- a/api/_lib/global-token-stats.js
+++ b/api/_lib/global-token-stats.js
@@ -1,0 +1,138 @@
+/**
+ * Global processed-token counter (Auth stub) for the public live homepage meter.
+ * O(1) read — avoids listUsers on every landing poll.
+ *
+ * Stub uid: sc_stats_total
+ * Claims: { sc_g: { tin, ts, n, seeded } }
+ */
+const admin = require("firebase-admin");
+const { initFirebaseAdmin } = require("./auth");
+
+const STATS_UID = "sc_stats_total";
+
+function auth() {
+  if (!initFirebaseAdmin()) {
+    const err = new Error("Firebase Admin is not configured");
+    err.status = 503;
+    throw err;
+  }
+  return admin.auth();
+}
+
+async function ensureStub() {
+  try {
+    return await auth().getUser(STATS_UID);
+  } catch (err) {
+    if (err?.code !== "auth/user-not-found") throw err;
+    await auth().createUser({
+      uid: STATS_UID,
+      disabled: true,
+      displayName: "SuperCompress public stats",
+    });
+    return auth().getUser(STATS_UID);
+  }
+}
+
+function readFromClaims(claims = {}) {
+  const g = claims.sc_g || {};
+  return {
+    tokens_processed: Math.max(0, Number(g.tin) || 0),
+    tokens_saved: Math.max(0, Number(g.ts) || 0),
+    requests: Math.max(0, Number(g.n) || 0),
+    seeded: Boolean(g.seeded),
+    updated_at: g.at || null,
+  };
+}
+
+async function readGlobalTokenStats() {
+  try {
+    const user = await auth().getUser(STATS_UID).catch(() => null);
+    if (!user) return null;
+    return readFromClaims(user.customClaims || {});
+  } catch (err) {
+    console.warn("global-token-stats read failed:", err.message || err);
+    return null;
+  }
+}
+
+async function writeGlobal(patch) {
+  const user = await ensureStub();
+  const prev = user.customClaims || {};
+  const g = { ...(prev.sc_g || {}), ...patch, at: new Date().toISOString() };
+  await auth().setCustomUserClaims(STATS_UID, { ...prev, sc_g: g });
+  return readFromClaims({ sc_g: g });
+}
+
+/**
+ * Fire-and-forget bump after a successful compress burn.
+ */
+async function bumpGlobalTokenStats({ tokensIn = 0, tokensSaved = 0, requests = 1 } = {}) {
+  const addIn = Math.max(0, Number(tokensIn) || 0);
+  const addSaved = Math.max(0, Number(tokensSaved) || 0);
+  const addReq = Math.max(0, Number(requests) || 0);
+  if (addIn <= 0 && addSaved <= 0 && addReq <= 0) return null;
+
+  for (let i = 0; i < 4; i++) {
+    try {
+      const user = await ensureStub();
+      const prev = user.customClaims || {};
+      const g = prev.sc_g || {};
+      const next = {
+        tin: (Number(g.tin) || 0) + addIn,
+        ts: (Number(g.ts) || 0) + addSaved,
+        n: (Number(g.n) || 0) + addReq,
+        seeded: Boolean(g.seeded),
+        at: new Date().toISOString(),
+      };
+      await auth().setCustomUserClaims(STATS_UID, { ...prev, sc_g: next });
+      return readFromClaims({ sc_g: next });
+    } catch (err) {
+      if (i === 3) {
+        console.warn("global-token-stats bump failed:", err.message || err);
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * If the stub is empty/unseeded, set it to the scanned Auth totals (once).
+ * Never decreases an already-higher live total.
+ */
+async function seedGlobalTokenStats({ tokens_processed = 0, tokens_saved = 0, requests = 0 } = {}) {
+  const tin = Math.max(0, Number(tokens_processed) || 0);
+  const ts = Math.max(0, Number(tokens_saved) || 0);
+  const n = Math.max(0, Number(requests) || 0);
+  try {
+    const user = await ensureStub();
+    const prev = user.customClaims || {};
+    const g = prev.sc_g || {};
+    const curTin = Number(g.tin) || 0;
+    const curTs = Number(g.ts) || 0;
+    const curN = Number(g.n) || 0;
+    if (g.seeded && curTin >= tin) {
+      return readFromClaims(prev);
+    }
+    const next = {
+      tin: Math.max(curTin, tin),
+      ts: Math.max(curTs, ts),
+      n: Math.max(curN, n),
+      seeded: true,
+      at: new Date().toISOString(),
+    };
+    await auth().setCustomUserClaims(STATS_UID, { ...prev, sc_g: next });
+    return readFromClaims({ sc_g: next });
+  } catch (err) {
+    console.warn("global-token-stats seed failed:", err.message || err);
+    return null;
+  }
+}
+
+module.exports = {
+  STATS_UID,
+  readGlobalTokenStats,
+  bumpGlobalTokenStats,
+  seedGlobalTokenStats,
+  readFromClaims,
+};

--- a/api/stats.js
+++ b/api/stats.js
@@ -5,17 +5,31 @@
  * reinstalls inflate that number. Signed-up users = Firebase Auth accounts
  * with an email (real humans who finished dashboard / setup connect).
  *
- * tokens_processed = sum of lifetime (or current-month) tokens_in across
- * human accounts — same Auth meter that bills compress.
+ * tokens_processed prefers the O(1) global Auth stub (sc_stats_total),
+ * bumped on every successful compress burn. Auth listUsers is only used
+ * to seed / periodically resync that stub.
  */
 const { json } = require("./_lib/http");
 const { initFirebaseAdmin } = require("./_lib/auth");
 const { isHumanUser } = require("./_lib/founder-usage");
+const {
+  STATS_UID,
+  readGlobalTokenStats,
+  seedGlobalTokenStats,
+} = require("./_lib/global-token-stats");
 const admin = require("firebase-admin");
 
 const PACKAGES = ["supercompress-proxy", "@agents-npm-packages/supercompress"];
-const CACHE_MS = 60 * 1000; // 60s — landing polls with ?fresh=1
-let cache = { at: 0, payload: null };
+/** Fast path for live homepage meter (global stub read). */
+const LIVE_CACHE_MS = 2 * 1000;
+/** Full npm + Auth-user scan. */
+const FULL_CACHE_MS = 60 * 1000;
+/** How often to re-scan Auth into the stub even when live cache is warm. */
+const RESYNC_MS = 15 * 60 * 1000;
+
+let liveCache = { at: 0, payload: null };
+let fullCache = { at: 0, payload: null };
+let lastResyncAt = 0;
 
 async function npmWeek(pkg) {
   const url = `https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(pkg)}`;
@@ -53,6 +67,7 @@ async function scanAuthGrowth() {
   do {
     const page = await auth.listUsers(1000, pageToken);
     for (const user of page.users) {
+      if (user.uid === STATS_UID) continue;
       total += 1;
       if (!isHumanUser(user)) continue;
       if (user.email || user.providerData?.some((p) => p.email)) withEmail += 1;
@@ -75,6 +90,7 @@ function fmtDownloads(n) {
   return String(n);
 }
 
+/** Compact label for API consumers — UI always uses full comma numbers. */
 function fmtTokens(n) {
   const v = Math.max(0, Number(n) || 0);
   if (v >= 1e9) return `${(v / 1e9).toFixed(v >= 1e10 ? 0 : 1).replace(/\.0$/, "")}B`;
@@ -83,17 +99,105 @@ function fmtTokens(n) {
   return String(Math.round(v));
 }
 
+function fmtFull(n) {
+  return Math.max(0, Math.round(Number(n) || 0)).toLocaleString("en-US");
+}
+
+async function resolveTokenTotals({ forceResync = false } = {}) {
+  const stub = await readGlobalTokenStats().catch(() => null);
+  const stubReady = Boolean(stub && stub.seeded && stub.tokens_processed > 0);
+  const due = forceResync || !stubReady || Date.now() - lastResyncAt > RESYNC_MS;
+
+  if (stubReady && !due) {
+    return {
+      tokens_processed: stub.tokens_processed,
+      tokens_saved: stub.tokens_saved,
+      source: "global_stub",
+      signed_up_users: null,
+      auth_records: null,
+    };
+  }
+
+  let growth = null;
+  try {
+    growth = await scanAuthGrowth();
+    lastResyncAt = Date.now();
+  } catch (err) {
+    console.warn("stats: auth scan failed", err.message || err);
+  }
+
+  if (growth) {
+    try {
+      await seedGlobalTokenStats({
+        tokens_processed: growth.tokens_processed,
+        tokens_saved: growth.tokens_saved,
+      });
+    } catch (err) {
+      console.warn("stats: seed failed", err.message || err);
+    }
+  }
+
+  const after = await readGlobalTokenStats().catch(() => null);
+  const tin =
+    after?.tokens_processed ??
+    growth?.tokens_processed ??
+    stub?.tokens_processed ??
+    null;
+  const ts =
+    after?.tokens_saved ?? growth?.tokens_saved ?? stub?.tokens_saved ?? null;
+
+  return {
+    tokens_processed: tin,
+    tokens_saved: ts,
+    source: growth ? "auth_scan" : stubReady ? "global_stub" : "none",
+    signed_up_users: growth?.signed_up_users ?? null,
+    auth_records: growth?.total_auth_records ?? null,
+  };
+}
+
 module.exports = async (req, res) => {
   if (req.method === "OPTIONS") return json(res, 204, {});
   if (req.method !== "GET") return json(res, 405, { detail: "Method not allowed", allow: "GET" });
 
   try {
+    const fresh = String(req.query?.fresh || "") === "1";
+    const resync = String(req.query?.resync || "") === "1";
+
+    // Homepage live meter: short cache, stub-only token refresh (skip npm).
     if (
-      cache.payload &&
-      Date.now() - cache.at < CACHE_MS &&
-      String(req.query?.fresh || "") !== "1"
+      fresh &&
+      !resync &&
+      liveCache.payload &&
+      Date.now() - liveCache.at < LIVE_CACHE_MS
     ) {
-      return json(res, 200, { ...cache.payload, cached: true });
+      return json(res, 200, { ...liveCache.payload, cached: true });
+    }
+
+    if (fresh && !resync && liveCache.payload) {
+      const tokens = await resolveTokenTotals({ forceResync: false });
+      const tokensProcessed = tokens.tokens_processed;
+      const tokensSaved = tokens.tokens_saved;
+      const payload = {
+        ...liveCache.payload,
+        tokens_processed: tokensProcessed,
+        tokens_processed_label:
+          tokensProcessed == null ? null : fmtTokens(tokensProcessed),
+        tokens_processed_full:
+          tokensProcessed == null ? null : fmtFull(tokensProcessed),
+        tokens_saved: tokensSaved,
+        tokens_saved_label: tokensSaved == null ? null : fmtTokens(tokensSaved),
+        tokens_saved_full: tokensSaved == null ? null : fmtFull(tokensSaved),
+        tokens_source: tokens.source,
+        updated_at: new Date().toISOString(),
+      };
+      if (tokens.signed_up_users != null) payload.signed_up_users = tokens.signed_up_users;
+      if (tokens.auth_records != null) payload.auth_records = tokens.auth_records;
+      liveCache = { at: Date.now(), payload };
+      return json(res, 200, { ...payload, cached: false });
+    }
+
+    if (!fresh && !resync && fullCache.payload && Date.now() - fullCache.at < FULL_CACHE_MS) {
+      return json(res, 200, { ...fullCache.payload, cached: true });
     }
 
     const npmRows = await Promise.all(PACKAGES.map((p) => npmWeek(p).catch(() => null)));
@@ -101,15 +205,21 @@ module.exports = async (req, res) => {
     const npmDownloadsWeek = npm.reduce((s, r) => s + r.downloads, 0);
     const primary = npm.find((r) => r.package === "supercompress-proxy") || npm[0];
 
-    let growth = null;
-    try {
-      growth = await scanAuthGrowth();
-    } catch (err) {
-      console.warn("stats: auth scan failed", err.message || err);
-    }
+    const tokens = await resolveTokenTotals({ forceResync: resync });
 
-    const tokensProcessed = growth?.tokens_processed ?? null;
-    const tokensSaved = growth?.tokens_saved ?? null;
+    const signed =
+      tokens.signed_up_users ??
+      fullCache.payload?.signed_up_users ??
+      liveCache.payload?.signed_up_users ??
+      null;
+    const authRecords =
+      tokens.auth_records ??
+      fullCache.payload?.auth_records ??
+      liveCache.payload?.auth_records ??
+      null;
+
+    const tokensProcessed = tokens.tokens_processed;
+    const tokensSaved = tokens.tokens_saved;
 
     const payload = {
       ok: true,
@@ -125,18 +235,23 @@ module.exports = async (req, res) => {
           }
         : null,
       npm_packages: npm,
-      signed_up_users: growth?.signed_up_users ?? null,
-      auth_records: growth?.total_auth_records ?? null,
+      signed_up_users: signed,
+      auth_records: authRecords,
       tokens_processed: tokensProcessed,
       tokens_processed_label: tokensProcessed == null ? null : fmtTokens(tokensProcessed),
+      tokens_processed_full:
+        tokensProcessed == null ? null : fmtFull(tokensProcessed),
       tokens_saved: tokensSaved,
       tokens_saved_label: tokensSaved == null ? null : fmtTokens(tokensSaved),
+      tokens_saved_full: tokensSaved == null ? null : fmtFull(tokensSaved),
+      tokens_source: tokens.source,
       note:
-        "tokens_processed sums account meters (lifetime when present, else current month). npm weekly downloads count install events — not unique people. signed_up_users = Firebase Auth accounts with email.",
+        "tokens_processed is the live global meter (Auth stub sc_stats_total), seeded from account meters and bumped on compress. npm weekly downloads count install events — not unique people. signed_up_users = Firebase Auth accounts with email.",
       updated_at: new Date().toISOString(),
     };
 
-    cache = { at: Date.now(), payload };
+    liveCache = { at: Date.now(), payload };
+    fullCache = { at: Date.now(), payload };
     return json(res, 200, { ...payload, cached: false });
   } catch (err) {
     console.error("stats error", err);
@@ -144,4 +259,4 @@ module.exports = async (req, res) => {
   }
 };
 
-module.exports._test = { accountProcessed, fmtTokens };
+module.exports._test = { accountProcessed, fmtTokens, fmtFull };

--- a/api/stats.test.js
+++ b/api/stats.test.js
@@ -2,11 +2,13 @@
  * Run: node api/stats.test.js
  */
 const assert = require("assert");
-const { accountProcessed, fmtTokens } = require("./stats.js")._test;
+const { accountProcessed, fmtTokens, fmtFull } = require("./stats.js")._test;
 
 assert.strictEqual(fmtTokens(0), "0");
 assert.strictEqual(fmtTokens(1500), "1.5k");
 assert.strictEqual(fmtTokens(2_100_000), "2.1M");
+assert.strictEqual(fmtFull(48612345), "48,612,345");
+assert.strictEqual(fmtFull(19_000_000), "19,000,000");
 
 assert.deepStrictEqual(accountProcessed({ sc_usage: { tokens_in: 100, tokens_saved: 40 } }), {
   tokens_in: 100,

--- a/web/assets/css/landing-motion.css
+++ b/web/assets/css/landing-motion.css
@@ -355,18 +355,18 @@ html.gsap-ready .logo-marquee-track { animation: none !important; }
 }
 
 .cta-live-tokens {
-  max-width: 34rem;
-  margin: 0 0 28px;
+  max-width: 40rem;
+  margin: 0 0 32px;
 }
 .cta-live-kicker {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin: 0 0 8px;
-  color: var(--blue);
+  margin: 0 0 10px;
+  color: #16a34a;
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 .cta-live-dot {
@@ -382,25 +382,22 @@ html.gsap-ready .logo-marquee-track { animation: none !important; }
   70% { box-shadow: 0 0 0 10px rgba(22, 163, 74, 0); }
   100% { box-shadow: 0 0 0 0 rgba(22, 163, 74, 0); }
 }
-.cta-live-line {
+.cta-live-value {
   margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 12px;
-  align-items: baseline;
   font-family: var(--serif);
-  color: #171717;
-}
-.cta-live-line strong {
   font-weight: 300;
-  font-size: clamp(36px, 5.5vw, 56px);
-  letter-spacing: -0.04em;
-  line-height: 1;
+  font-size: clamp(42px, 7vw, 72px);
+  letter-spacing: -0.045em;
+  line-height: 0.95;
   color: var(--blue);
   font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+  white-space: nowrap;
 }
-.cta-live-line span {
-  font-size: clamp(18px, 2.4vw, 24px);
+.cta-live-label {
+  margin: 10px 0 0;
+  font-family: var(--serif);
+  font-size: clamp(17px, 2.2vw, 22px);
   font-weight: 400;
   letter-spacing: -0.02em;
   color: #3a3a38;
@@ -410,6 +407,14 @@ html.gsap-ready .logo-marquee-track { animation: none !important; }
   color: #80807c;
   font-size: 13px;
   line-height: 1.45;
+  font-variant-numeric: tabular-nums;
+}
+@media (max-width: 520px) {
+  .cta-live-value {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    font-size: clamp(34px, 11vw, 48px);
+  }
 }
 @media (prefers-reduced-motion: reduce) {
   .cta-live-dot { animation: none; }

--- a/web/assets/js/landing-app.js
+++ b/web/assets/js/landing-app.js
@@ -3,7 +3,7 @@
   const hasGsap = Boolean(window.gsap && window.ScrollTrigger);
   if (hasGsap && !reduced) document.documentElement.classList.add('gsap-ready');
 
-  // —— Live tokens processed (public /api/stats) — continuous odometer, always xxx,xxx,xxx
+  // —— Live tokens processed (public /api/stats) — real totals only, always xxx,xxx,xxx
   (function bootLiveTokens() {
     const el = document.getElementById("live-tokens-n");
     const sub = document.getElementById("live-tokens-sub");
@@ -12,13 +12,10 @@
     let display = 0;
     let target = 0;
     let savedTarget = null;
-    let ratePerSec = 0; // estimated from poll deltas
-    let lastPollAt = 0;
-    let lastServer = null;
     let raf = 0;
     let lastPaint = "";
-    const POLL_MS = 3000;
-    const MAX_RATE = 250000; // tokens/sec cap so a big resync doesn't runaway
+    let lastTickAt = 0;
+    const POLL_MS = 2500;
 
     const fmtFull = (n) =>
       Math.max(0, Math.round(Number(n) || 0)).toLocaleString("en-US");
@@ -30,36 +27,16 @@
         el.textContent = text;
       }
       if (sub && savedTarget != null) {
-        const s = fmtFull(savedTarget);
-        const next = `${s} tokens saved · across SuperCompress`;
+        const next = `${fmtFull(savedTarget)} tokens saved · across SuperCompress`;
         if (sub.textContent !== next) sub.textContent = next;
       }
     };
 
     const onServer = (processed, saved) => {
       const next = Math.max(0, Number(processed) || 0);
-      const now = performance.now();
-      if (lastServer != null && lastPollAt > 0) {
-        const dt = Math.max(0.25, (now - lastPollAt) / 1000);
-        const d = next - lastServer;
-        if (d >= 0) {
-          const measured = d / dt;
-          ratePerSec =
-            ratePerSec > 0
-              ? ratePerSec * 0.65 + measured * 0.35
-              : measured;
-          ratePerSec = Math.min(MAX_RATE, Math.max(0, ratePerSec));
-        }
-      }
-      lastServer = next;
-      lastPollAt = now;
-      target = Math.max(target, next);
-      // Snap forward if we're behind the server; never go backwards.
-      if (display < next) {
-        // Catch up over ~0.8s without jumping the whole delta at once.
-        target = next;
-      }
-      if (display === 0 && next > 0) display = next;
+      // Never invent tokens — only move toward real server totals.
+      target = next;
+      if (display === 0 || display > next) display = next;
       if (saved != null) savedTarget = Math.max(0, Number(saved) || 0);
       paint();
     };
@@ -75,21 +52,14 @@
       const dt = Math.min(0.1, Math.max(0, (now - lastTickAt) / 1000));
       lastTickAt = now;
 
-      // Creep toward server target using measured rate; if rate is tiny, still
-      // ease 1–2 units/sec so the counter never looks frozen between polls.
-      const creep = Math.max(ratePerSec, target > display ? 2 : 0);
       if (display < target) {
-        display = Math.min(target, display + creep * dt);
-      } else if (ratePerSec > 0.5) {
-        // Keep ticking past last poll using residual rate (clamped so we don't
-        // invent more than ~1 poll-interval of speculation).
-        const aheadCap = target + ratePerSec * (POLL_MS / 1000) * 1.25;
-        display = Math.min(aheadCap, display + ratePerSec * dt);
-        target = Math.max(target, display);
+        const gap = target - display;
+        // Ease toward the real total; never overshoot past server truth.
+        const step = Math.max(gap * 4 * dt, Math.min(gap, 1));
+        display = Math.min(target, display + step);
       }
       paint();
     };
-    let lastTickAt = 0;
 
     const pull = () => {
       const q = `/api/stats?fresh=1&_=${Date.now()}`;

--- a/web/assets/js/landing-app.js
+++ b/web/assets/js/landing-app.js
@@ -3,75 +3,109 @@
   const hasGsap = Boolean(window.gsap && window.ScrollTrigger);
   if (hasGsap && !reduced) document.documentElement.classList.add('gsap-ready');
 
-  // —— Live tokens processed (public /api/stats) — boot early so CTA isn't stuck on "—"
+  // —— Live tokens processed (public /api/stats) — continuous odometer, always xxx,xxx,xxx
   (function bootLiveTokens() {
     const el = document.getElementById("live-tokens-n");
     const sub = document.getElementById("live-tokens-sub");
     if (!el) return;
 
-    let current = 0;
+    let display = 0;
+    let target = 0;
+    let savedTarget = null;
+    let ratePerSec = 0; // estimated from poll deltas
+    let lastPollAt = 0;
+    let lastServer = null;
     let raf = 0;
-    const POLL_MS = 15000;
+    let lastPaint = "";
+    const POLL_MS = 3000;
+    const MAX_RATE = 250000; // tokens/sec cap so a big resync doesn't runaway
 
-    const fmtFull = (n) => Math.max(0, Math.round(Number(n) || 0)).toLocaleString("en-US");
-    const fmtCompact = (n) => {
-      const v = Math.max(0, Number(n) || 0);
-      if (v >= 1e9) return `${(v / 1e9).toFixed(v >= 1e10 ? 0 : 1).replace(/\.0$/, "")}B`;
-      if (v >= 1e6) return `${(v / 1e6).toFixed(v >= 1e7 ? 0 : 1).replace(/\.0$/, "")}M`;
-      if (v >= 1e3) return `${(v / 1e3).toFixed(v >= 1e4 ? 0 : 1).replace(/\.0$/, "")}k`;
-      return String(Math.round(v));
+    const fmtFull = (n) =>
+      Math.max(0, Math.round(Number(n) || 0)).toLocaleString("en-US");
+
+    const paint = () => {
+      const text = fmtFull(display);
+      if (text !== lastPaint) {
+        lastPaint = text;
+        el.textContent = text;
+      }
+      if (sub && savedTarget != null) {
+        const s = fmtFull(savedTarget);
+        const next = `${s} tokens saved · across SuperCompress`;
+        if (sub.textContent !== next) sub.textContent = next;
+      }
     };
 
-    const setSub = (saved) => {
-      if (!sub || saved == null) return;
-      sub.textContent = `${fmtCompact(saved)} tokens saved · across SuperCompress accounts`;
-    };
-
-    const animateTo = (next) => {
-      const end = Math.max(0, Number(next) || 0);
-      if (raf) cancelAnimationFrame(raf);
-      if (reduced || !Number.isFinite(end)) {
-        current = end;
-        el.textContent = fmtFull(end);
-        return;
-      }
-      const start = current;
-      const delta = end - start;
-      if (Math.abs(delta) < 1) {
-        current = end;
-        el.textContent = fmtFull(end);
-        return;
-      }
-      const t0 = performance.now();
-      const dur = Math.min(1400, 400 + Math.abs(delta) / 8000);
-      const ease = (t) => 1 - Math.pow(1 - t, 3);
-      const frame = (now) => {
-        const p = Math.min(1, (now - t0) / dur);
-        current = start + delta * ease(p);
-        el.textContent = fmtFull(current);
-        if (p < 1) raf = requestAnimationFrame(frame);
-        else {
-          current = end;
-          el.textContent = fmtFull(end);
+    const onServer = (processed, saved) => {
+      const next = Math.max(0, Number(processed) || 0);
+      const now = performance.now();
+      if (lastServer != null && lastPollAt > 0) {
+        const dt = Math.max(0.25, (now - lastPollAt) / 1000);
+        const d = next - lastServer;
+        if (d >= 0) {
+          const measured = d / dt;
+          ratePerSec =
+            ratePerSec > 0
+              ? ratePerSec * 0.65 + measured * 0.35
+              : measured;
+          ratePerSec = Math.min(MAX_RATE, Math.max(0, ratePerSec));
         }
-      };
-      raf = requestAnimationFrame(frame);
+      }
+      lastServer = next;
+      lastPollAt = now;
+      target = Math.max(target, next);
+      // Snap forward if we're behind the server; never go backwards.
+      if (display < next) {
+        // Catch up over ~0.8s without jumping the whole delta at once.
+        target = next;
+      }
+      if (display === 0 && next > 0) display = next;
+      if (saved != null) savedTarget = Math.max(0, Number(saved) || 0);
+      paint();
     };
 
-    const pull = (fresh) => {
-      const q = fresh ? `/api/stats?fresh=1&_=${Date.now()}` : `/api/stats?_=${Date.now()}`;
+    const tick = (now) => {
+      raf = requestAnimationFrame(tick);
+      if (reduced) {
+        display = target;
+        paint();
+        return;
+      }
+      if (!lastTickAt) lastTickAt = now;
+      const dt = Math.min(0.1, Math.max(0, (now - lastTickAt) / 1000));
+      lastTickAt = now;
+
+      // Creep toward server target using measured rate; if rate is tiny, still
+      // ease 1–2 units/sec so the counter never looks frozen between polls.
+      const creep = Math.max(ratePerSec, target > display ? 2 : 0);
+      if (display < target) {
+        display = Math.min(target, display + creep * dt);
+      } else if (ratePerSec > 0.5) {
+        // Keep ticking past last poll using residual rate (clamped so we don't
+        // invent more than ~1 poll-interval of speculation).
+        const aheadCap = target + ratePerSec * (POLL_MS / 1000) * 1.25;
+        display = Math.min(aheadCap, display + ratePerSec * dt);
+        target = Math.max(target, display);
+      }
+      paint();
+    };
+    let lastTickAt = 0;
+
+    const pull = () => {
+      const q = `/api/stats?fresh=1&_=${Date.now()}`;
       return fetch(q, { credentials: "omit", cache: "no-store" })
         .then((r) => (r.ok ? r.json() : null))
         .then((d) => {
           if (!d || d.tokens_processed == null) return;
-          animateTo(d.tokens_processed);
-          setSub(d.tokens_saved);
+          onServer(d.tokens_processed, d.tokens_saved);
         })
         .catch(() => {});
     };
 
-    pull(true);
-    setInterval(() => pull(true), POLL_MS);
+    paint();
+    raf = requestAnimationFrame(tick);
+    pull();
+    setInterval(pull, POLL_MS);
   })();
 
   // Scroll progress

--- a/web/index.html
+++ b/web/index.html
@@ -757,7 +757,7 @@
 
   <script src="/assets/js/vendor/gsap/gsap.min.js"></script>
   <script src="/assets/js/vendor/gsap/ScrollTrigger.min.js"></script>
-<script src="/assets/js/landing-app.js?v=9"></script>
+<script src="/assets/js/landing-app.js?v=10"></script>
 
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -36,7 +36,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
   <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=5" as="image" fetchpriority="high" />
-  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=10" />
+  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=11" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 
 
@@ -660,11 +660,9 @@
         <div class="container cta-copy reveal">
           <div class="cta-live-tokens" aria-live="polite">
             <p class="cta-live-kicker"><span class="cta-live-dot" aria-hidden="true"></span> Live</p>
-            <p class="cta-live-line">
-              <strong id="live-tokens-n">—</strong>
-              <span>tokens processed</span>
-            </p>
-            <p class="cta-live-sub" id="live-tokens-sub">across SuperCompress · refreshes as people compress</p>
+            <p class="cta-live-value" id="live-tokens-n">—</p>
+            <p class="cta-live-label">tokens processed</p>
+            <p class="cta-live-sub" id="live-tokens-sub">across SuperCompress · updates as people compress</p>
           </div>
           <div class="cta-brand">
             <img src="/assets/img/logo-chevrons.png" alt="" width="28" height="28" />
@@ -759,7 +757,7 @@
 
   <script src="/assets/js/vendor/gsap/gsap.min.js"></script>
   <script src="/assets/js/vendor/gsap/ScrollTrigger.min.js"></script>
-<script src="/assets/js/landing-app.js?v=8"></script>
+<script src="/assets/js/landing-app.js?v=9"></script>
 
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- CTA live meter is a continuous odometer (ticks between polls) instead of a static compact `49M` label
- Always renders full `xx,xxx,xxx` for processed **and** saved
- Adds O(1) `sc_stats_total` Auth stub bumped on every successful compress burn; `/api/stats?fresh=1` reads that stub on a 2s cache so the homepage can poll every 3s without `listUsers`

## Test plan
- [ ] `node api/stats.test.js`
- [ ] Hit `/api/stats?fresh=1` — `tokens_processed_full` looks like `48,xxx,xxx`, `tokens_source` is `global_stub` or `auth_scan`
- [ ] Landing CTA above bottom CTA shows comma-formatted number that keeps updating
- [ ] Compress a request → stub / counter increases after next poll
- [ ] Prod smoke still green after deploy


Made with [Cursor](https://cursor.com)