### PR TITLE
fix: real live token stub across cold starts

### DIFF
--- a/api/stats.js
+++ b/api/stats.js
@@ -106,7 +106,26 @@ function fmtFull(n) {
 async function resolveTokenTotals({ forceResync = false } = {}) {
   const stub = await readGlobalTokenStats().catch(() => null);
   const stubReady = Boolean(stub && stub.seeded && stub.tokens_processed > 0);
-  const due = forceResync || !stubReady || Date.now() - lastResyncAt > RESYNC_MS;
+  const stubAgeMs = stub?.updated_at
+    ? Math.max(0, Date.now() - Date.parse(stub.updated_at))
+    : Number.POSITIVE_INFINITY;
+  // Prefer Auth stub claims age over lambda memory — cold starts must not
+  // re-listUsers every request when the stub is already seeded.
+  const due =
+    forceResync ||
+    !stubReady ||
+    stubAgeMs > RESYNC_MS ||
+    (lastResyncAt > 0 && Date.now() - lastResyncAt > RESYNC_MS);
+
+  if (stubReady && !forceResync && stubAgeMs <= RESYNC_MS) {
+    return {
+      tokens_processed: stub.tokens_processed,
+      tokens_saved: stub.tokens_saved,
+      source: "global_stub",
+      signed_up_users: null,
+      auth_records: null,
+    };
+  }
 
   if (stubReady && !due) {
     return {


### PR DESCRIPTION
## Summary
- Live `/api/stats` prefers the seeded `sc_stats_total` stub after the first Auth scan
- Resync freshness uses the stub claim timestamp so cold starts do not invent a fake meter or re-listUsers every poll
- Landing counter already never ticks past server truth

## Test plan
- [ ] `curl 'https://api.supercompress.dev/api/stats?fresh=1'` → real `tokens_processed_full` with commas
- [ ] Second poll within 15m → `tokens_source: global_stub`
- [ ] CTA shows the same full number, no `49M`


Made with [Cursor](https://cursor.com)