### PR TITLE
feat: live meter section + centered CTA

### DIFF
--- a/api/stats.js
+++ b/api/stats.js
@@ -21,7 +21,7 @@ const admin = require("firebase-admin");
 
 const PACKAGES = ["supercompress-proxy", "@agents-npm-packages/supercompress"];
 /** Fast path for live homepage meter (global stub read). */
-const LIVE_CACHE_MS = 2 * 1000;
+const LIVE_CACHE_MS = 1000;
 /** Full npm + Auth-user scan. */
 const FULL_CACHE_MS = 60 * 1000;
 /** How often to re-scan Auth into the stub even when live cache is warm. */

--- a/web/assets/css/landing-motion.css
+++ b/web/assets/css/landing-motion.css
@@ -354,70 +354,119 @@ html.gsap-ready .logo-marquee-track { animation: none !important; }
   margin-bottom: 24px;
 }
 
-.cta-live-tokens {
-  max-width: 40rem;
-  margin: 0 0 32px;
+.live-meter-section {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  margin: 56px 0 0;
+  padding: clamp(56px, 8vw, 96px) 0;
+  background: #0f1115;
+  color: #f4f2ec;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
-.cta-live-kicker {
+.live-meter-dither {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: 0;
+  image-rendering: pixelated;
+}
+.live-meter-fade {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 70% 60% at 50% 45%, rgba(15, 17, 21, 0.15), rgba(15, 17, 21, 0.88) 72%),
+    linear-gradient(180deg, rgba(15, 17, 21, 0.55), transparent 28%, transparent 72%, rgba(15, 17, 21, 0.7));
+}
+.live-meter-inner {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  max-width: 52rem;
+}
+.live-meter-kicker {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  margin: 0 0 10px;
-  color: #16a34a;
+  justify-content: center;
+  gap: 10px;
+  margin: 0 0 18px;
+  color: #7ddea0;
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
-.cta-live-dot {
-  width: 7px;
-  height: 7px;
+.live-meter-dot {
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  background: #16a34a;
-  box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.55);
-  animation: cta-live-pulse 1.6s ease-out infinite;
+  background: #22c55e;
+  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55);
+  animation: live-meter-pulse 1.4s ease-out infinite;
 }
-@keyframes cta-live-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.5); }
-  70% { box-shadow: 0 0 0 10px rgba(22, 163, 74, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(22, 163, 74, 0); }
+.live-meter-age {
+  color: rgba(244, 242, 236, 0.45);
+  letter-spacing: 0.08em;
+  font-weight: 500;
+  text-transform: none;
+  font-size: 11px;
 }
-.cta-live-value {
+@keyframes live-meter-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55); }
+  70% { box-shadow: 0 0 0 12px rgba(34, 197, 94, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}
+.live-meter-value {
   margin: 0;
   font-family: var(--serif);
   font-weight: 300;
-  font-size: clamp(42px, 7vw, 72px);
-  letter-spacing: -0.045em;
-  line-height: 0.95;
-  color: var(--blue);
+  font-size: clamp(52px, 9vw, 96px);
+  letter-spacing: -0.05em;
+  line-height: 0.92;
+  color: #f7f5f1;
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum" 1;
-  white-space: nowrap;
+  transition: transform 180ms ease, color 180ms ease, text-shadow 180ms ease;
 }
-.cta-live-label {
-  margin: 10px 0 0;
+.live-meter-section.is-ticking .live-meter-value {
+  color: #9ec1ff;
+  text-shadow: 0 0 28px rgba(37, 99, 235, 0.35);
+  transform: translateY(-1px);
+}
+.live-meter-section.is-bump .live-meter-value {
+  color: #fff;
+  text-shadow: 0 0 36px rgba(125, 222, 160, 0.45);
+}
+.live-meter-label {
+  margin: 16px 0 0;
   font-family: var(--serif);
-  font-size: clamp(17px, 2.2vw, 22px);
+  font-size: clamp(18px, 2.4vw, 26px);
   font-weight: 400;
   letter-spacing: -0.02em;
-  color: #3a3a38;
+  color: rgba(244, 242, 236, 0.78);
 }
-.cta-live-sub {
-  margin: 8px 0 0;
-  color: #80807c;
-  font-size: 13px;
-  line-height: 1.45;
+.live-meter-sub {
+  margin: 12px 0 0;
+  color: rgba(244, 242, 236, 0.48);
+  font-size: 14px;
+  line-height: 1.5;
   font-variant-numeric: tabular-nums;
 }
 @media (max-width: 520px) {
-  .cta-live-value {
-    white-space: normal;
+  .live-meter-value {
+    font-size: clamp(40px, 12vw, 56px);
     overflow-wrap: anywhere;
-    font-size: clamp(34px, 11vw, 48px);
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .cta-live-dot { animation: none; }
+  .live-meter-dot { animation: none; }
+  .live-meter-value { transition: none; }
 }
 .micro-dither-strip {
   position: absolute;
@@ -903,33 +952,32 @@ html.gsap-ready .bar > i { transform: scaleX(0); }
   padding: 0;
   position: relative;
   scroll-margin-top: 96px;
-  margin-top: 48px;
+  margin-top: 0;
 }
 .cta-band {
   position: relative;
   overflow: hidden;
   border: 0;
   border-radius: 0;
-  background: #f7f5f1;
+  background: var(--paper, #fbfbf8);
   margin: 0;
   width: 100%;
-  min-height: clamp(480px, 62vh, 680px);
+  min-height: clamp(420px, 58vh, 620px);
   display: grid;
-  align-items: center;
+  place-items: center;
 }
-.cta-hands {
+.cta-dither {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: contain;
-  object-position: center center;
-  transform: scale(0.88);
-  transform-origin: center center;
-  opacity: 0.42;
+  opacity: 0.34;
   pointer-events: none;
-  user-select: none;
   z-index: 0;
+  image-rendering: pixelated;
+}
+.cta-hands {
+  display: none !important;
 }
 .cta-fade {
   position: absolute;
@@ -937,35 +985,38 @@ html.gsap-ready .bar > i { transform: scaleX(0); }
   z-index: 1;
   pointer-events: none;
   background:
-    linear-gradient(90deg, rgba(247,245,241,.92) 0%, rgba(247,245,241,.55) 42%, rgba(247,245,241,.18) 72%, rgba(247,245,241,.35) 100%),
-    linear-gradient(180deg, rgba(247,245,241,.4) 0%, transparent 35%, rgba(247,245,241,.55) 100%);
+    radial-gradient(ellipse 55% 50% at 50% 42%, rgba(251, 251, 248, 0.2), rgba(251, 251, 248, 0.88) 70%),
+    linear-gradient(180deg, rgba(251, 251, 248, 0.65), transparent 30%, transparent 70%, rgba(251, 251, 248, 0.8));
 }
 .cta-copy {
   position: relative;
   z-index: 2;
-  padding: 80px 0;
-  /* keep .container width + horizontal centering — don't override with max-width/margin:0 */
+  padding: clamp(64px, 10vw, 112px) 0;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-.cta-copy .cta-live-tokens,
 .cta-copy .cta-brand,
 .cta-copy h2,
 .cta-copy .cta-lead,
 .cta-copy .cta-actions {
-  max-width: 34rem;
+  max-width: 40rem;
 }
 .cta-brand {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 18px;
+  justify-content: center;
+  gap: 12px;
+  margin: 0 0 22px;
   font-family: var(--serif);
-  font-size: 18px;
+  font-size: clamp(22px, 3vw, 30px);
   letter-spacing: -.02em;
   color: #171717;
 }
 .cta-brand img {
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   object-fit: contain;
 }
 .cta-brand em {
@@ -977,24 +1028,26 @@ html.gsap-ready .bar > i { transform: scaleX(0); }
   margin: 0;
   font-family: var(--serif);
   font-weight: 300;
-  font-size: clamp(34px, 4vw, 48px);
-  line-height: 1.06;
-  letter-spacing: -.03em;
+  font-size: clamp(34px, 5vw, 56px);
+  line-height: 1.05;
+  letter-spacing: -.035em;
   color: #171717;
+  text-wrap: balance;
 }
 .cta-lead {
-  margin: 16px 0 0;
-  max-width: 34rem;
+  margin: 18px 0 0;
+  max-width: 28rem;
   color: #525250;
-  font-size: 15.5px;
-  line-height: 1.6;
+  font-size: 16px;
+  line-height: 1.55;
 }
 .cta-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 26px;
+  margin-top: 30px;
   align-items: center;
+  justify-content: center;
 }
 .cta-section .button-secondary {
   background: rgba(255,255,255,.72);
@@ -1008,19 +1061,8 @@ html.gsap-ready .bar > i { transform: scaleX(0); }
 .cta-grid-simple,
 .cta-inner { display: none !important; }
 @media (max-width: 820px) {
-  .cta-band { min-height: 520px; align-items: end; }
-  .cta-copy { padding: 48px 0 56px; }
-  .cta-fade {
-    background:
-      linear-gradient(180deg, rgba(247,245,241,.2) 0%, rgba(247,245,241,.72) 48%, rgba(247,245,241,.96) 100%),
-      linear-gradient(90deg, rgba(247,245,241,.55), transparent 75%);
-  }
-  .cta-hands {
-    object-fit: contain;
-    object-position: center 28%;
-    transform: scale(0.92);
-    opacity: 0.38;
-  }
+  .cta-band { min-height: 440px; }
+  .cta-copy { padding: 64px 0 72px; }
 }
 .footer-links { display: grid; grid-template-columns: repeat(3,1fr); gap: 28px; }
 .footer-links h4 { margin: 0 0 14px; font-size: 11px; letter-spacing: .08em; font-weight: 600; color: #8a8a86; }
@@ -1050,7 +1092,7 @@ html.gsap-ready .bar > i { transform: scaleX(0); }
 
 /* Metrics dither layer — removed (too busy on this panel) */
 
-#product, #benchmarks, #agents, #docs, #use-cases, #cta, #setup, #pipeline, #vision {
+#product, #benchmarks, #agents, #docs, #use-cases, #cta, #setup, #pipeline, #vision, #live-meter {
   scroll-margin-top: 96px;
 }
 

--- a/web/assets/js/landing-app.js
+++ b/web/assets/js/landing-app.js
@@ -7,6 +7,8 @@
   (function bootLiveTokens() {
     const el = document.getElementById("live-tokens-n");
     const sub = document.getElementById("live-tokens-sub");
+    const age = document.getElementById("live-tokens-age");
+    const section = document.querySelector(".live-meter-section");
     if (!el) return;
 
     let display = 0;
@@ -15,10 +17,34 @@
     let raf = 0;
     let lastPaint = "";
     let lastTickAt = 0;
-    const POLL_MS = 2500;
+    let lastPollOkAt = 0;
+    let pollTimer = 0;
+    let ageTimer = 0;
+    const POLL_MS = 1500;
 
     const fmtFull = (n) =>
       Math.max(0, Math.round(Number(n) || 0)).toLocaleString("en-US");
+
+    const pulse = (bump) => {
+      if (!section || reduced) return;
+      section.classList.add("is-ticking");
+      if (bump) section.classList.add("is-bump");
+      window.clearTimeout(pulse._t);
+      pulse._t = window.setTimeout(() => {
+        section.classList.remove("is-ticking");
+        section.classList.remove("is-bump");
+      }, bump ? 700 : 280);
+    };
+
+    const paintAge = () => {
+      if (!age) return;
+      if (!lastPollOkAt) {
+        age.textContent = "polling…";
+        return;
+      }
+      const sec = Math.max(0, Math.round((Date.now() - lastPollOkAt) / 1000));
+      age.textContent = sec <= 1 ? "just now" : `${sec}s ago`;
+    };
 
     const paint = () => {
       const text = fmtFull(display);
@@ -30,14 +56,18 @@
         const next = `${fmtFull(savedTarget)} tokens saved · across SuperCompress`;
         if (sub.textContent !== next) sub.textContent = next;
       }
+      paintAge();
     };
 
     const onServer = (processed, saved) => {
       const next = Math.max(0, Number(processed) || 0);
+      const bumped = next > target && target > 0;
       // Never invent tokens — only move toward real server totals.
       target = next;
       if (display === 0 || display > next) display = next;
       if (saved != null) savedTarget = Math.max(0, Number(saved) || 0);
+      lastPollOkAt = Date.now();
+      pulse(bumped);
       paint();
     };
 
@@ -54,14 +84,14 @@
 
       if (display < target) {
         const gap = target - display;
-        // Ease toward the real total; never overshoot past server truth.
-        const step = Math.max(gap * 4 * dt, Math.min(gap, 1));
+        const step = Math.max(gap * 5 * dt, Math.min(gap, 1));
         display = Math.min(target, display + step);
       }
       paint();
     };
 
     const pull = () => {
+      if (document.visibilityState === "hidden") return Promise.resolve();
       const q = `/api/stats?fresh=1&_=${Date.now()}`;
       return fetch(q, { credentials: "omit", cache: "no-store" })
         .then((r) => (r.ok ? r.json() : null))
@@ -72,10 +102,24 @@
         .catch(() => {});
     };
 
+    const schedule = () => {
+      window.clearInterval(pollTimer);
+      window.clearInterval(ageTimer);
+      pollTimer = window.setInterval(pull, POLL_MS);
+      ageTimer = window.setInterval(paintAge, 1000);
+    };
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") {
+        pull();
+        schedule();
+      }
+    });
+
     paint();
     raf = requestAnimationFrame(tick);
     pull();
-    setInterval(pull, POLL_MS);
+    schedule();
   })();
 
   // Scroll progress
@@ -205,6 +249,14 @@
     flow: (x, y, t, w, h) => {
       const u = x / w, v = y / h;
       return .24 + Math.sin((u - .5) * 7 + t * 1.1) * Math.cos((v - .5) * 6 - t * .85) * .36 + (1 - v) * .18;
+    },
+    meter: (x, y, t, w, h) => {
+      const u = x / Math.max(w, 1);
+      const v = y / Math.max(h, 1);
+      const sweep = .5 + .5 * Math.sin(u * 10 - t * 2.4);
+      const ring = 1 - Math.min(1, Math.abs(Math.hypot(u - .5, v - .48) - (.18 + .04 * Math.sin(t * 1.6))) / .22);
+      const band = .5 + .5 * Math.sin((v * 14) + t * 1.8);
+      return .12 + sweep * .28 * (1 - v) + ring * .55 + band * .12 * (1 - Math.abs(u - .5) * 1.4);
     }
   };
 
@@ -223,6 +275,7 @@
         || canvas.classList.contains('install-dither')
         || canvas.classList.contains('cta-dither')
         || canvas.classList.contains('cta-band-dither')
+        || canvas.classList.contains('live-meter-dither')
           ? 3.2
           : (canvas.classList.contains('micro-dither')
             || canvas.classList.contains('micro-dither-strip')

--- a/web/index.html
+++ b/web/index.html
@@ -36,7 +36,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
   <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=5" as="image" fetchpriority="high" />
-  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=11" />
+  <link rel="stylesheet" href="/assets/css/landing-motion.css?v=12" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 
 
@@ -653,23 +653,32 @@
       </div>
     </section>
 
+    <section class="live-meter-section" id="live-meter" aria-label="Live tokens processed">
+      <canvas class="dither-canvas live-meter-dither dither-dark" data-dither="meter" aria-hidden="true"></canvas>
+      <div class="live-meter-fade" aria-hidden="true"></div>
+      <div class="container live-meter-inner">
+        <p class="live-meter-kicker">
+          <span class="live-meter-dot" aria-hidden="true"></span>
+          Live
+          <span class="live-meter-age" id="live-tokens-age">polling…</span>
+        </p>
+        <p class="live-meter-value" id="live-tokens-n">—</p>
+        <p class="live-meter-label">tokens processed</p>
+        <p class="live-meter-sub" id="live-tokens-sub">across SuperCompress · updates as people compress</p>
+      </div>
+    </section>
+
     <section class="cta-section" id="cta">
       <div class="cta-band">
-        <img class="cta-hands" src="/assets/img/cta-hands.jpg" alt="" width="1800" height="1200" loading="lazy" decoding="async" />
+        <canvas class="dither-canvas cta-dither" data-dither="flow" aria-hidden="true"></canvas>
         <div class="cta-fade" aria-hidden="true"></div>
         <div class="container cta-copy reveal">
-          <div class="cta-live-tokens" aria-live="polite">
-            <p class="cta-live-kicker"><span class="cta-live-dot" aria-hidden="true"></span> Live</p>
-            <p class="cta-live-value" id="live-tokens-n">—</p>
-            <p class="cta-live-label">tokens processed</p>
-            <p class="cta-live-sub" id="live-tokens-sub">across SuperCompress · updates as people compress</p>
-          </div>
           <div class="cta-brand">
-            <img src="/assets/img/logo-chevrons.png" alt="" width="28" height="28" />
+            <img src="/assets/img/logo-chevrons.png" alt="" width="36" height="36" />
             <span>Super<em>Compress</em></span>
           </div>
-          <h2>Ship AI features with<br>lower per-request cost.</h2>
-          <p class="cta-lead">1M free tokens/mo · then $0.30/1M · no credit card. Prompt compression for chat, RAG, support, and coding agents.</p>
+          <h2>Ship AI features with lower per-request cost.</h2>
+          <p class="cta-lead">1M free tokens/mo · then $0.30/1M · no credit card.</p>
           <div class="cta-actions">
             <a class="button button-primary magnetic" href="/dashboard?signup=1&amp;utm_source=homepage&amp;utm_medium=cta&amp;utm_campaign=activation">Get free API key <span>→</span></a>
             <a class="button button-secondary magnetic" href="https://docs.supercompress.dev/coding-agents?utm_source=homepage&amp;utm_medium=cta&amp;utm_campaign=activation">Coding agents</a>
@@ -757,7 +766,7 @@
 
   <script src="/assets/js/vendor/gsap/gsap.min.js"></script>
   <script src="/assets/js/vendor/gsap/ScrollTrigger.min.js"></script>
-<script src="/assets/js/landing-app.js?v=10"></script>
+<script src="/assets/js/landing-app.js?v=11"></script>
 
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- Live tokens counter is its own section above the CTA (not jammed into CTA copy)
- Animated Bayer dither on the meter + CTA; meter pulses on every real poll and bumps harder when the total increases
- CTA rebuilt as a centered brand composition (no left-aligned hands overlay)
- Faster `/api/stats` live cache (1s) so real compress burns show up quicker

## Test plan
- [ ] Homepage shows dark live meter above CTA with moving dither
- [ ] Number renders `xx,xxx,xxx` and age flips `just now` / `Ns ago`
- [ ] Compress something → meter bumps within a couple seconds
- [ ] CTA is centered with brand + one headline + actions


Made with [Cursor](https://cursor.com)