### PR TITLE
fix(web): use root-relative stylesheet URLs on clean routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Version pins
         run: node scripts/check-versions.js
       - name: Static stylesheet path guard
-        run: node scripts/check-stylesheet-paths.js
+        run: npm run check:stylesheet-paths
       - name: API host redirect guard (no catch-all /compress 308)
         run: |
           node scripts/check-api-host-routes.test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
         run: node scripts/check-no-pii.js
       - name: Version pins
         run: node scripts/check-versions.js
+      - name: Static stylesheet path guard
+        run: node scripts/check-stylesheet-paths.js
       - name: API host redirect guard (no catch-all /compress 308)
         run: |
           node scripts/check-api-host-routes.test.js

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prod:smoke": "bash scripts/prod-smoke.sh",
     "prod:domains": "bash scripts/ensure-prod-domains.sh",
     "check:api-host": "node scripts/check-api-host-routes.js",
+    "check:stylesheet-paths": "node scripts/check-stylesheet-paths.js",
     "release:check": "bash scripts/release-check.sh",
     "mcp": "node mcp/server.js",
     "check:version": "node scripts/check-versions.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prod:smoke": "bash scripts/prod-smoke.sh",
     "prod:domains": "bash scripts/ensure-prod-domains.sh",
     "check:api-host": "node scripts/check-api-host-routes.js",
-    "check:stylesheet-paths": "node scripts/check-stylesheet-paths.js",
+    "check:stylesheet-paths": "node scripts/check-stylesheet-paths.test.js && node scripts/check-stylesheet-paths.js",
     "release:check": "bash scripts/release-check.sh",
     "mcp": "node mcp/server.js",
     "check:version": "node scripts/check-versions.js"

--- a/scripts/check-stylesheet-paths.js
+++ b/scripts/check-stylesheet-paths.js
@@ -23,25 +23,34 @@ function htmlFiles(dir) {
 
 function stylesheetHrefs(html) {
   return [...html.matchAll(/<link\b[^>]*>/gi)].flatMap(([tag]) => {
-    const rel = tag.match(/\brel\s*=\s*(["'])(.*?)\1/i)?.[2];
-    const href = tag.match(/\bhref\s*=\s*(["'])(.*?)\1/i)?.[2];
-    return rel?.split(/\s+/).includes("stylesheet") && href ? [href] : [];
+    const attribute = (name) => {
+      const match = tag.match(
+        new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\\x60]+))`, "i")
+      );
+      return match?.slice(1).find((value) => value !== undefined);
+    };
+    const rel = attribute("rel");
+    const href = attribute("href");
+    return rel?.toLowerCase().split(/\s+/).includes("stylesheet") && href ? [href] : [];
   });
 }
 
-const invalidPaths = htmlFiles(WEB).flatMap((file) =>
-  stylesheetHrefs(fs.readFileSync(file, "utf8"))
-    .filter((href) => !href.startsWith("/") && !/^https?:\/\//i.test(href))
-    .map((href) => `${path.relative(ROOT, file)}: ${href}`)
-);
+module.exports = { stylesheetHrefs };
 
-if (invalidPaths.length) {
-  throw new Error(
-    `Stylesheet URLs must be root-relative or external:\n${invalidPaths.join("\n")}`
+function main() {
+  const invalidPaths = htmlFiles(WEB).flatMap((file) =>
+    stylesheetHrefs(fs.readFileSync(file, "utf8"))
+      .filter((href) => !href.startsWith("/") && !/^https?:\/\//i.test(href))
+      .map((href) => `${path.relative(ROOT, file)}: ${href}`)
   );
-}
 
-const normalizerCheck = String.raw`
+  if (invalidPaths.length) {
+    throw new Error(
+      `Stylesheet URLs must be root-relative or external:\n${invalidPaths.join("\n")}`
+    );
+  }
+
+  const normalizerCheck = String.raw`
 import importlib.util
 from pathlib import Path
 
@@ -56,11 +65,14 @@ result = module.ensure_css_links(html)
 assert 'href="/assets/css/supercompress.css?v=105"' in result
 assert 'href="assets/css/supercompress.css' not in result
 `;
-execFileSync("python3", ["-c", normalizerCheck], {
-  cwd: ROOT,
-  stdio: "inherit",
-});
+  execFileSync("python3", ["-c", normalizerCheck], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
 
-console.log(
-  `stylesheet path check: ${htmlFiles(WEB).length} HTML files and article normalizer passed`
-);
+  console.log(
+    `stylesheet path check: ${htmlFiles(WEB).length} HTML files and article normalizer passed`
+  );
+}
+
+if (require.main === module) main();

--- a/scripts/check-stylesheet-paths.js
+++ b/scripts/check-stylesheet-paths.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Guard against route-relative stylesheet URLs in static pages.
+ *
+ * Run: node scripts/check-stylesheet-paths.js
+ */
+"use strict";
+
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const WEB = path.join(ROOT, "web");
+
+function htmlFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return htmlFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith(".html") ? [entryPath] : [];
+  });
+}
+
+function stylesheetHrefs(html) {
+  return [...html.matchAll(/<link\b[^>]*>/gi)].flatMap(([tag]) => {
+    const rel = tag.match(/\brel\s*=\s*(["'])(.*?)\1/i)?.[2];
+    const href = tag.match(/\bhref\s*=\s*(["'])(.*?)\1/i)?.[2];
+    return rel?.split(/\s+/).includes("stylesheet") && href ? [href] : [];
+  });
+}
+
+const invalidPaths = htmlFiles(WEB).flatMap((file) =>
+  stylesheetHrefs(fs.readFileSync(file, "utf8"))
+    .filter((href) => !href.startsWith("/") && !/^https?:\/\//i.test(href))
+    .map((href) => `${path.relative(ROOT, file)}: ${href}`)
+);
+
+if (invalidPaths.length) {
+  throw new Error(
+    `Stylesheet URLs must be root-relative or external:\n${invalidPaths.join("\n")}`
+  );
+}
+
+const normalizerCheck = String.raw`
+import importlib.util
+from pathlib import Path
+
+root = Path.cwd()
+spec = importlib.util.spec_from_file_location(
+    "normalize_article_pages", root / "scripts" / "normalize_article_pages.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+html = '<head><link rel="stylesheet" href="assets/css/supercompress.css?v=105" /></head>'
+result = module.ensure_css_links(html)
+assert 'href="/assets/css/supercompress.css?v=105"' in result
+assert 'href="assets/css/supercompress.css' not in result
+`;
+execFileSync("python3", ["-c", normalizerCheck], {
+  cwd: ROOT,
+  stdio: "inherit",
+});
+
+console.log(
+  `stylesheet path check: ${htmlFiles(WEB).length} HTML files and article normalizer passed`
+);

--- a/scripts/check-stylesheet-paths.test.js
+++ b/scripts/check-stylesheet-paths.test.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert");
+const { stylesheetHrefs } = require("./check-stylesheet-paths");
+
+assert.deepEqual(
+  stylesheetHrefs('<link rel="stylesheet preload" href="/assets/css/site.css">'),
+  ["/assets/css/site.css"]
+);
+assert.deepEqual(
+  stylesheetHrefs("<link rel=StyleSheet href=assets/css/site.css>"),
+  ["assets/css/site.css"]
+);
+assert.deepEqual(
+  stylesheetHrefs("<link rel='preload StyleSheet' href='/assets/css/site.css'>"),
+  ["/assets/css/site.css"]
+);
+
+console.log("check-stylesheet-paths.test.js: ok");

--- a/scripts/fix_article_styles.py
+++ b/scripts/fix_article_styles.py
@@ -18,7 +18,7 @@ SEO_CLUSTER = """
 </nav>
 """
 
-NEW_CSS_LINKS = """<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+NEW_CSS_LINKS = """<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=7" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=1" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=1" />"""
@@ -30,12 +30,12 @@ def strip_inline_style(html: str) -> str:
 
 def replace_css_links(html: str) -> str:
     html = re.sub(
-        r'\s*<link rel="stylesheet" href="assets/css/content-shell\.css\?v=\d+" />\s*',
+        r'\s*<link rel="stylesheet" href="/?assets/css/content-shell\.css\?v=\d+" />\s*',
         "\n",
         html,
     )
     pat = re.compile(
-        r'<link rel="stylesheet" href="assets/css/supercompress\.css\?v=\d+" />\s*'
+        r'<link rel="stylesheet" href="/?assets/css/supercompress\.css\?v=\d+" />\s*'
         r'(?:<link rel="stylesheet" href="/assets/css/landing-chrome\.css\?v=\d+" />\s*)?',
         re.M,
     )

--- a/scripts/normalize_article_pages.py
+++ b/scripts/normalize_article_pages.py
@@ -29,7 +29,7 @@ SKIP = {
     "unsubscribe.html",
 }
 
-CSS_BLOCK = """<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+CSS_BLOCK = """<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />"""

--- a/web/affiliates.html
+++ b/web/affiliates.html
@@ -22,7 +22,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <meta name="theme-color" content="rgb(251,251,248)" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=110" />
+  <link rel="stylesheet" href="/assets/css/supercompress.css?v=110" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     /* ── Affiliate self-serve page ── */

--- a/web/agent-memory-compression.html
+++ b/web/agent-memory-compression.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/ai-search.html
+++ b/web/ai-search.html
@@ -22,7 +22,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/benchmarks.html
+++ b/web/benchmarks.html
@@ -26,7 +26,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     .bench-head { text-align: center; padding: 60px 20px 20px; max-width: 860px; margin: 0 auto; }

--- a/web/better-than-headroom.html
+++ b/web/better-than-headroom.html
@@ -25,7 +25,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/blog.html
+++ b/web/blog.html
@@ -23,7 +23,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=112" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=112" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     /* ── Blog-specific overrides ── */

--- a/web/cache-aligner-prefix-stabilization.html
+++ b/web/cache-aligner-prefix-stabilization.html
@@ -23,7 +23,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/coding-agent-proxy.html
+++ b/web/coding-agent-proxy.html
@@ -20,11 +20,11 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
-<link rel="stylesheet" href="assets/css/style.css?v=110" />
+<link rel="stylesheet" href="/assets/css/style.css?v=110" />
 <style>
     /* ── Blog article styles ── */
     .article-page {

--- a/web/context-compression.html
+++ b/web/context-compression.html
@@ -25,7 +25,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/cut-api-costs.html
+++ b/web/cut-api-costs.html
@@ -25,7 +25,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -26,7 +26,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <meta name="theme-color" content="rgb(251,251,248)" />
-  <link rel="stylesheet" href="assets/css/supercompress.css?v=112" />
+  <link rel="stylesheet" href="/assets/css/supercompress.css?v=112" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/dashboard-analytics.css?v=3" />
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet" />

--- a/web/domain-preprocessors.html
+++ b/web/domain-preprocessors.html
@@ -22,7 +22,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/firecrawl-context-compression.html
+++ b/web/firecrawl-context-compression.html
@@ -19,7 +19,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/headroom-api.html
+++ b/web/headroom-api.html
@@ -25,7 +25,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/how-prompt-compression-works.html
+++ b/web/how-prompt-compression-works.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/live-demo.html
+++ b/web/live-demo.html
@@ -25,8 +25,8 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="assets/css/live-demo.css?v=1" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
+  <link rel="stylesheet" href="/assets/css/live-demo.css?v=1" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <!-- Preconnect hints for faster external resource loading -->
   <link rel="preconnect" href="https://github.com" />

--- a/web/llm-cost-optimization.html
+++ b/web/llm-cost-optimization.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/llm-token-compression.html
+++ b/web/llm-token-compression.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/mcp-integration.html
+++ b/web/mcp-integration.html
@@ -23,7 +23,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/open-source-token-compression.html
+++ b/web/open-source-token-compression.html
@@ -27,7 +27,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/precision-mode-compression.html
+++ b/web/precision-mode-compression.html
@@ -22,7 +22,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/prompt-compression-guide.html
+++ b/web/prompt-compression-guide.html
@@ -5,7 +5,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/prompt-compression.html
+++ b/web/prompt-compression.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/reduce-llm-costs.html
+++ b/web/reduce-llm-costs.html
@@ -25,7 +25,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/reduce-openai-costs.html
+++ b/web/reduce-openai-costs.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/research.html
+++ b/web/research.html
@@ -26,7 +26,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <!-- Preconnect hints for faster external resource loading -->
   <link rel="preconnect" href="https://github.com" />

--- a/web/reversible-compression-ccr.html
+++ b/web/reversible-compression-ccr.html
@@ -22,7 +22,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/supercompress-architecture.html
+++ b/web/supercompress-architecture.html
@@ -5,7 +5,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/supercompress-vs-alternatives.html
+++ b/web/supercompress-vs-alternatives.html
@@ -5,7 +5,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/supercompress-vs-headroom.html
+++ b/web/supercompress-vs-headroom.html
@@ -25,7 +25,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/supercompress-vs-llmlingua.html
+++ b/web/supercompress-vs-llmlingua.html
@@ -54,7 +54,7 @@
     ]
   }
   </script>
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/supercompress-vs-summarization.html
+++ b/web/supercompress-vs-summarization.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/supercompress-vs-truncation.html
+++ b/web/supercompress-vs-truncation.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/token-compression.html
+++ b/web/token-compression.html
@@ -35,7 +35,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/what-is-prompt-compression.html
+++ b/web/what-is-prompt-compression.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />

--- a/web/when-to-use-compression.html
+++ b/web/when-to-use-compression.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
-<link rel="stylesheet" href="assets/css/supercompress.css?v=105" />
+<link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
   <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />


### PR DESCRIPTION
## Summary

Clean URL docs and SEO pages could render unstyled because local stylesheet URLs such as `assets/css/supercompress.css` were resolved relative to the current route and returned 404s.

This updates shipped HTML pages to use root-relative stylesheet URLs, updates article-generation helpers to preserve that behavior, and adds a CI guard against regressions.

Fixes #105

## Changes

- Convert local stylesheet references in affected `web/**/*.html` pages to `/assets/css/...`.
- Update `normalize_article_pages.py` and `fix_article_styles.py` to emit root-relative SuperCompress stylesheet URLs.
- Add `scripts/check-stylesheet-paths.js`, which verifies every local HTML stylesheet URL is root-relative and exercises normalizer output.
- Run the new guard in CI and expose it as `npm run check:stylesheet-paths`.

## Test plan

- [x] `git diff --check`
- [x] `node --check scripts/check-stylesheet-paths.js`
- [x] `python3 -m py_compile scripts/normalize_article_pages.py scripts/fix_article_styles.py`
- [x] `npm run check:stylesheet-paths`
- [x] `node scripts/check-api-host-routes.test.js`
- [x] `node scripts/check-api-host-routes.js`
- [!] `npm run release:check` reached the proxy suite but could not complete in the sandbox because tests requiring localhost binding failed with `EPERM`. Run the full release check in CI.

## Risk and rollback

Risk is low: this changes only asset URL resolution, with no redirects or routing configuration changes. If needed, rollback is a single revert; the regression guard will prevent relative local stylesheet URLs from being reintroduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated website pages to load stylesheets consistently from root-relative paths, improving styling across nested URLs.

* **Chores**
  * Added automated validation to detect invalid stylesheet paths.
  * Added checks to confirm stylesheet URL normalization during continuous integration.
  * Improved handling of legacy stylesheet links during page generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes static pages and article-generation helpers to emit root-relative stylesheet URLs so clean routes resolve CSS from the site root.
- Updates stylesheet references across shipped HTML pages.
- Preserves root-relative paths in article normalization and repair scripts.
- Adds parser tests, a repository-wide stylesheet-path guard, and CI/package-script integration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-stylesheet-paths.js | Adds recursive validation of local stylesheet references and verifies article-normalizer output. |
| scripts/check-stylesheet-paths.test.js | Exercises stylesheet-link parsing across quoted, unquoted, and multi-token rel attributes. |
| scripts/normalize_article_pages.py | Changes generated SuperCompress stylesheet references to root-relative URLs. |
| scripts/fix_article_styles.py | Emits root-relative stylesheet URLs while accepting both old relative and updated root-relative inputs. |
| .github/workflows/ci.yml | Runs the stylesheet-path regression guard in CI. |
| package.json | Exposes the parser tests and repository-wide guard through an npm script. |
| web/coding-agent-proxy.html | Converts both local stylesheet references on this page to root-relative URLs. |
| web/live-demo.html | Converts the page’s primary and page-specific stylesheet references to root-relative URLs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(web): cover stylesheet attribute va..."](https://github.com/supercompress/supercompress/commit/d5bc999abe1a4ed825afcb5619c1007460e6c1a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53291004)</sub>

<!-- /greptile_comment -->