### PR TITLE
fix: client audit — idempotent compress retries + password UX

### DIFF
--- a/api/_lib/billing-ledger.js
+++ b/api/_lib/billing-ledger.js
@@ -100,12 +100,23 @@ function computeCompressFingerprint(body = {}) {
  * Decide whether an existing billing_usage row is a safe replay.
  * Throws idempotency_conflict (409) when the key is reused with a different payload.
  */
+function fingerprintsMatch(prevFp, fp) {
+  const a = String(prevFp || "").trim();
+  const b = String(fp || "").trim();
+  if (!a || !b) return false;
+  if (a === b) return true;
+  // Legacy Auth claims rows stored only the first 16 hex chars.
+  if (a.length <= 16 && b.startsWith(a)) return true;
+  if (b.length <= 16 && a.startsWith(b)) return true;
+  return false;
+}
+
 function assertUsageIdempotencyMatch(prev, { fingerprint, tokensIn, tokensOut, tokensSaved }) {
   if (!prev || typeof prev !== "object") return;
   const prevFp = String(prev.fingerprint || "").trim();
   const fp = String(fingerprint || "").trim();
   if (fp) {
-    if (prevFp && prevFp !== fp) {
+    if (prevFp && !fingerprintsMatch(prevFp, fp)) {
       throw billingError(
         "idempotency_conflict",
         "Idempotency-Key reused with a different request payload",
@@ -399,6 +410,7 @@ function fitCustomClaims(claims) {
       if (Array.isArray(next.sc_recent_billing)) {
         next.sc_recent_billing = next.sc_recent_billing.slice(0, 8).map((r) => ({
           i: String(r?.i || "").slice(0, 40),
+          // Claims budget is tight (~1KB). Keep a stable prefix; matchers accept prefix==full.
           f: r?.f ? String(r.f).slice(0, 16) : null,
           tin: Number(r?.tin) || 0,
           tout: Number(r?.tout) || 0,
@@ -600,7 +612,7 @@ async function applyUsageAndBurnClaimsFallback({
           sc_recent_billing: [
             {
               i: rid.slice(0, 40),
-              f: fp ? String(fp).slice(0, 16) : null,
+              f: fp || null,
               tin: Number(tokensIn) || 0,
               tout: Number(tokensOut) || 0,
               ts: Number(tokensSaved) || 0,
@@ -723,7 +735,7 @@ async function reserveIdempotencyLease(uid, requestId, fingerprint) {
         if (prev.status === "pending") {
           const until = Number(prev.lease_until || 0);
           if (until > now) {
-            if (prev.fingerprint && fp && prev.fingerprint !== fp) {
+            if (prev.fingerprint && fp && !fingerprintsMatch(prev.fingerprint, fp)) {
               throw billingError(
                 "idempotency_conflict",
                 "Idempotency-Key reused with a different request payload"
@@ -732,7 +744,7 @@ async function reserveIdempotencyLease(uid, requestId, fingerprint) {
             return { status: "pending", data: prev };
           }
           // Expired lease — take over.
-        } else if (prev.fingerprint && fp && prev.fingerprint !== fp) {
+        } else if (prev.fingerprint && fp && !fingerprintsMatch(prev.fingerprint, fp)) {
           throw billingError(
             "idempotency_conflict",
             "Idempotency-Key reused with a different request payload"

--- a/api/_lib/billing-ledger.test.js
+++ b/api/_lib/billing-ledger.test.js
@@ -183,6 +183,27 @@ assertUsageIdempotencyMatch(
   { fingerprint: "abc", tokensIn: 99, tokensOut: 1, tokensSaved: 98 }
 );
 
+// Auth claims store a 16-char fingerprint prefix — must still replay against full hash
+{
+  const full = "a".repeat(64);
+  assertUsageIdempotencyMatch(
+    { fingerprint: full.slice(0, 16), tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
+    { fingerprint: full, tokensIn: 10, tokensOut: 5, tokensSaved: 5 }
+  );
+  assertUsageIdempotencyMatch(
+    { fingerprint: full, tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
+    { fingerprint: full.slice(0, 16), tokensIn: 10, tokensOut: 5, tokensSaved: 5 }
+  );
+  mustThrow(
+    () =>
+      assertUsageIdempotencyMatch(
+        { fingerprint: "bbbbbbbbbbbbbbbb", tokens_in: 10, tokens_out: 5, tokens_saved: 5 },
+        { fingerprint: full, tokensIn: 10, tokensOut: 5, tokensSaved: 5 }
+      ),
+    "idempotency_conflict"
+  );
+}
+
 // Idempotency: different fingerprint → conflict
 mustThrow(
   () =>

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -629,7 +629,7 @@
             <input class="dash-field-input" id="auth-email" type="email" required autocomplete="email" placeholder="you@company.com" />
             <label class="dash-field-label" for="auth-password">Password</label>
             <input class="dash-field-input" id="auth-password" type="password" required minlength="6" autocomplete="new-password" placeholder="At least 6 characters" />
-            <button type="button" class="btn-link-muted dash-forgot-password" id="btn-forgot-password">Forgot password?</button>
+            <button type="button" class="btn-link-muted dash-forgot-password hidden" id="btn-forgot-password">Forgot password?</button>
             <button type="submit" class="btn-brand dash-auth-submit" id="auth-submit">Create free account</button>
           </form>
         </div>

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -1052,14 +1052,14 @@ npm exec supercompress setup</pre>
         <input class="dash-field-input" id="password-new" type="password" autocomplete="new-password" minlength="6" placeholder="At least 6 characters" />
         <label class="dash-field-label" for="password-confirm">Confirm new password</label>
         <input class="dash-field-input" id="password-confirm" type="password" autocomplete="new-password" minlength="6" />
-        <p class="dash-auth-error hidden" id="password-error" style="margin-top:10px"></p>
-        <p class="dash-auth-sub hidden" id="password-ok" style="margin-top:10px;color:#166534"></p>
         <button type="button" class="btn-brand" id="btn-confirm-password">Save password</button>
       </div>
       <div id="password-google-only" class="hidden">
         <p class="dash-auth-sub" style="margin-top:0">This account signs in with Google. Manage your password in your Google Account, or we can email a reset link if email/password is also enabled.</p>
         <button type="button" class="btn-brand" id="btn-send-password-reset">Email password reset link</button>
       </div>
+      <p class="dash-auth-error hidden" id="password-error" style="margin-top:10px"></p>
+      <p class="dash-auth-sub hidden" id="password-ok" style="margin-top:10px;color:#166534"></p>
       <button type="button" class="btn-link-muted" id="btn-cancel-password">Cancel</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Fix false `idempotency_conflict` (409) when Auth claims store a 16-char fingerprint prefix and retries send the full hash — coding-agent retries were failing in prod (reproduced).
- Keep claims packing on a 16-char prefix (1KB budget); matchers accept prefix↔full.
- Password modal: status messages visible for Google-only reset path; Forgot password hidden on signup tab by default.

## Test plan
- [x] `node api/_lib/billing-ledger.test.js`
- [x] Prefixed fingerprint assertUsageIdempotencyMatch smoke
- [ ] After merge+deploy: same Idempotency-Key + body → 200/replay, not 409
- [ ] Prod smoke + article CSS root-relative (`/assets/css/...`)
- [ ] Dashboard: Forgot password only on Log in; Google password modal shows reset OK/error

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes compression retries compatible with the shortened fingerprints retained in Firebase Auth claims and adjusts dashboard password UX.
- Accepts comparisons between full SHA-256 request fingerprints and their stored 16-character prefixes across claims and Firestore idempotency paths.
- Stores full fingerprints initially while preserving claims-size truncation during packing.
- Adds prefix/full matching coverage to the billing-ledger tests.
- Shows Forgot password only on the login tab and makes password reset status visible to Google-only accounts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified in the changed paths.

The idempotency matcher remains bound to server-generated SHA-256 fingerprints while accommodating the intentional 16-character claims representation, and the dashboard scripts correctly reconcile and reset the modified UI elements.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/_lib/billing-ledger.js | Adds centralized full-to-prefix fingerprint matching and retains full fingerprints until claims-size packing requires truncation. |
| api/_lib/billing-ledger.test.js | Covers matching in both full-to-prefix directions and verifies that a different prefix still conflicts. |
| web/dashboard.html | Corrects initial forgot-password visibility and relocates password status nodes so both account-provider branches can display them. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Compress request] --> B[Compute full SHA-256 fingerprint]
  B --> C{Existing idempotency record?}
  C -- No --> D[Acquire lease and process request]
  C -- Yes --> E{Stored full or 16-character prefix matches?}
  E -- Yes --> F[Return completed or pending state]
  E -- No --> G[Return idempotency conflict]
  D --> H[Persist billing result]
  H --> I[Pack Auth claims, truncating fingerprint if needed]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): show password modal stat..."](https://github.com/supercompress/supercompress/commit/3776ccd9920792a3de2f9c33ef2587266935b26b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53352988)</sub>

<!-- /greptile_comment -->