### PR TITLE
feat: automated payment thank-you email from Arjun

### DIFF
--- a/api/_lib/credit-topup.js
+++ b/api/_lib/credit-topup.js
@@ -293,6 +293,24 @@ async function applyCreditTopUp(session) {
   console.log(
     `Credited $${creditUsd}${bonusUsd ? ` + $${bonusUsd} first-pay bonus` : ""} to ${userId}; balance=$${newBalance}`
   );
+
+  try {
+    const { schedulePaymentThankYou, firstNameFromUser } = require("./payment-thank-you");
+    schedulePaymentThankYou({
+      uid: userId,
+      email: user.email || "",
+      firstName: firstNameFromUser(user),
+      creditUsd,
+      autoRecharge,
+      paymentKey: session.id,
+      kind,
+      paymentCreatedSec: session.created,
+      alreadyCredited: false,
+    });
+  } catch (err) {
+    console.warn("payment thank-you schedule skipped:", err.message || err);
+  }
+
   return {
     applied: true,
     already: false,

--- a/api/_lib/mail.js
+++ b/api/_lib/mail.js
@@ -546,6 +546,89 @@ async function sendWelcomeEmail({ email, firstName, idempotencyKey }) {
 }
 
 /**
+ * Heartfelt founder thank-you after a successful prepaid credit purchase.
+ * Auto-recharge charges should not use this — only intentional Checkout pays.
+ */
+function paymentThankYouCopy({ firstName, email, creditUsd, autoRecharge }) {
+  const hi = firstName ? `Hey ${firstName}` : "Hey";
+  const amount = Number(creditUsd);
+  const amountLabel =
+    Number.isFinite(amount) && amount > 0 ? `$${amount.toFixed(amount % 1 ? 2 : 0)}` : null;
+  const subject = firstName
+    ? `${firstName}, thank you — means more than you know`
+    : "Thank you — means more than you know";
+
+  const text = `${hi},
+
+It's Arjun, founder of SuperCompress.
+
+I just saw your payment come through${amountLabel ? ` (${amountLabel})` : ""} — thank you. Seriously. Building this is lonely sometimes, and every person who puts real money behind SuperCompress is a huge deal to me.
+
+We're going to make the product 100× better for you and everyone else using it. If anything feels off, confusing, missing, or just "I wish it did X" — hit reply. I read every note myself.
+
+Dashboard: ${SITE}/dashboard
+Coding agents: ${SITE}/docs/coding-agents
+
+${autoRecharge ? "Auto-recharge is on so you shouldn't hit a wall mid-session — you can change that anytime in Billing.\n\n" : ""}Thanks again for trusting us with this.
+Arjun
+Founder, SuperCompress
+${REPLY_TO}`;
+
+  const bodyHtml = `
+<p style="margin:0 0 16px;font-size:16px;">${escapeHtml(hi)},</p>
+${eyebrow("Thank you")}
+${displayHeadline("Means more than you know")}
+<p style="margin:0 0 16px;">It's <strong>Arjun</strong>, founder of SuperCompress.</p>
+<p style="margin:0 0 16px;">I just saw your payment come through${
+    amountLabel ? ` (<strong>${escapeHtml(amountLabel)}</strong>)` : ""
+  } — thank you. Seriously. Building this is lonely sometimes, and every person who puts real money behind SuperCompress is a huge deal to me.</p>
+<p style="margin:0 0 16px;">We're going to make the product <strong>100× better</strong> for you and everyone else using it. If anything feels off, confusing, missing, or just “I wish it did X” — <strong>hit reply</strong>. I read every note myself.</p>
+${
+    autoRecharge
+      ? proofCallout("Auto-recharge is on so you shouldn’t hit a wall mid-session. Change it anytime in Billing.")
+      : ""
+  }
+${ctaButton("Open your dashboard →", `${SITE}/dashboard`)}
+<p style="margin:12px 0 0;font-size:14px;">
+  <a href="${SITE}/docs/coding-agents" style="color:${BRAND};text-decoration:none;font-weight:600;">Coding agents setup</a>
+  · <a href="${SITE}/dashboard#billing" style="color:${BRAND};text-decoration:none;font-weight:600;">Billing</a>
+</p>
+${signatureBlock()}`;
+
+  const html = brandedEmailHtml({
+    preheader: "Thank you for paying for SuperCompress — reply anytime with feedback.",
+    title: subject,
+    bodyHtml,
+    kind: "payment_thanks",
+  });
+
+  return { subject, text, html, to: email };
+}
+
+async function sendPaymentThankYouEmail({
+  email,
+  firstName,
+  creditUsd,
+  autoRecharge,
+  idempotencyKey,
+}) {
+  if (!email || !String(email).includes("@")) {
+    return { ok: false, error: "missing email" };
+  }
+  const copy = paymentThankYouCopy({
+    firstName,
+    email: String(email).trim(),
+    creditUsd,
+    autoRecharge: Boolean(autoRecharge),
+  });
+  const result = await sendViaResend({
+    ...copy,
+    idempotencyKey: idempotencyKey || null,
+  });
+  return { ...result, subject: copy.subject, text: copy.text, html: copy.html };
+}
+
+/**
  * Power-user email when someone newly crosses 1M tokens.
  * Rank/leaderboard lines are optional (omit for the automatic trigger).
  * @param {{ firstName?: string, email: string, rank?: number, tokensIn?: number, tokensSaved?: number, requests?: number, morePct?: number, cutPct?: number }} opts
@@ -911,6 +994,7 @@ async function sendWeeklyEmail({ email, firstName, campaignId, unsubUrl, listUns
 module.exports = {
   welcomeCopy,
   powerUserCopy,
+  paymentThankYouCopy,
   weeklyCopy,
   shipCopy,
   weeklyEmailCopy,
@@ -923,6 +1007,7 @@ module.exports = {
   sendViaResend,
   sendWelcomeEmail,
   sendPowerUserEmail,
+  sendPaymentThankYouEmail,
   sendWeeklyEmail,
   DEFAULT_FROM,
 };

--- a/api/_lib/payment-thank-you.js
+++ b/api/_lib/payment-thank-you.js
@@ -1,0 +1,181 @@
+/**
+ * Founder thank-you email after a successful prepaid credit Checkout.
+ *
+ * Only intentional Checkout pays (credit_enable / credit_topup) — never
+ * silent auto-recharge PIs. Deduped per Stripe session via Resend
+ * Idempotency-Key + optional config-store record.
+ *
+ * Cutoff: payments whose Stripe created timestamp is before
+ * PAYMENT_THANK_YOU_AFTER (default 2026-08-14T23:00:00Z) are skipped so the
+ * first three live sales are not backfilled.
+ */
+
+const DEFAULT_AFTER_ISO = "2026-08-14T23:00:00.000Z";
+
+function paymentThankYouAfterMs() {
+  const raw = String(process.env.PAYMENT_THANK_YOU_AFTER || DEFAULT_AFTER_ISO).trim();
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : Date.parse(DEFAULT_AFTER_ISO);
+}
+
+function firstNameFromUser(user = {}) {
+  const raw = user.displayName || user.name || "";
+  if (raw && String(raw).trim()) return String(raw).trim().split(/\s+/)[0];
+  const email = user.email || "";
+  if (email.includes("@")) {
+    const local = email.split("@")[0];
+    if (local && !/^\d+$/.test(local)) return local.split(/[._+-]/)[0];
+  }
+  return "";
+}
+
+function thankYouIdempotencyKey(paymentKey) {
+  return `payment-thanks-${String(paymentKey || "").trim()}`.slice(0, 256);
+}
+
+function shouldSendPaymentThankYou({ kind, paymentCreatedSec, alreadyCredited }) {
+  if (alreadyCredited) return false;
+  const k = String(kind || "");
+  // Checkout credit packs only — not off-session auto-recharge.
+  if (k === "credit_auto_recharge") return false;
+  if (!k.startsWith("credit_")) return false;
+  if (paymentCreatedSec != null) {
+    const createdMs = Number(paymentCreatedSec) * 1000;
+    if (Number.isFinite(createdMs) && createdMs < paymentThankYouAfterMs()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function markPaymentThankYou(paymentKey, patch) {
+  if (!paymentKey) return null;
+  try {
+    const { mutateStore } = require("./store");
+    return await mutateStore((store) => {
+      if (!store.payment_thank_you_emails) store.payment_thank_you_emails = {};
+      const prev = store.payment_thank_you_emails[paymentKey] || {};
+      const next = { ...prev, ...patch, payment_key: paymentKey };
+      store.payment_thank_you_emails[paymentKey] = next;
+      return next;
+    });
+  } catch (err) {
+    console.warn("payment thank-you store skip:", err.message || err);
+    return { payment_key: paymentKey, ...patch };
+  }
+}
+
+/**
+ * Fire-and-forget after a successful credit top-up.
+ * Safe to call on webhook retries — Resend + store dedupe by session id.
+ */
+function schedulePaymentThankYou({
+  uid,
+  email,
+  firstName,
+  creditUsd,
+  autoRecharge,
+  paymentKey,
+  kind,
+  paymentCreatedSec,
+  alreadyCredited,
+}) {
+  if (
+    !shouldSendPaymentThankYou({
+      kind,
+      paymentCreatedSec,
+      alreadyCredited,
+    })
+  ) {
+    return;
+  }
+  const key = String(paymentKey || "").trim();
+  const to = String(email || "").trim();
+  if (!key || !to.includes("@")) return;
+
+  setImmediate(() => {
+    void deliverPaymentThankYou({
+      uid,
+      email: to,
+      firstName,
+      creditUsd,
+      autoRecharge,
+      paymentKey: key,
+      kind,
+    }).catch((err) => {
+      console.warn("payment thank-you failed:", err?.message || err);
+    });
+  });
+}
+
+async function deliverPaymentThankYou({
+  uid,
+  email,
+  firstName,
+  creditUsd,
+  autoRecharge,
+  paymentKey,
+  kind,
+}) {
+  const { sendPaymentThankYouEmail } = require("./mail");
+  const idempotencyKey = thankYouIdempotencyKey(paymentKey);
+
+  try {
+    const { loadStore } = require("./store");
+    const store = await loadStore().catch(() => null);
+    const existing = store?.payment_thank_you_emails?.[paymentKey];
+    if (existing?.status === "sent") {
+      return { ok: true, already: true };
+    }
+  } catch (_) {
+    /* store optional */
+  }
+
+  await markPaymentThankYou(paymentKey, {
+    uid: uid || null,
+    email,
+    first_name: firstName || "",
+    kind: kind || null,
+    credit_usd: Number(creditUsd) || 0,
+    auto_recharge: Boolean(autoRecharge),
+    status: "sending",
+    idempotency_key: idempotencyKey,
+    send_attempt_at: new Date().toISOString(),
+  });
+
+  const result = await sendPaymentThankYouEmail({
+    email,
+    firstName: firstName || "",
+    creditUsd,
+    autoRecharge,
+    idempotencyKey,
+  });
+
+  if (!result.ok) {
+    await markPaymentThankYou(paymentKey, {
+      status: "failed",
+      error: result.error || "send_failed",
+      failed_at: new Date().toISOString(),
+    });
+    return result;
+  }
+
+  await markPaymentThankYou(paymentKey, {
+    status: "sent",
+    provider: result.provider || "resend",
+    provider_id: result.id || null,
+    sent_at: new Date().toISOString(),
+    error: null,
+  });
+  return result;
+}
+
+module.exports = {
+  DEFAULT_AFTER_ISO,
+  paymentThankYouAfterMs,
+  shouldSendPaymentThankYou,
+  schedulePaymentThankYou,
+  deliverPaymentThankYou,
+  thankYouIdempotencyKey,
+  firstNameFromUser,
+};

--- a/api/_lib/payment-thank-you.test.js
+++ b/api/_lib/payment-thank-you.test.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for payment thank-you gating (no Resend / Firebase).
+ * Run: node api/_lib/payment-thank-you.test.js
+ */
+const assert = require("assert");
+const {
+  shouldSendPaymentThankYou,
+  paymentThankYouAfterMs,
+  DEFAULT_AFTER_ISO,
+  thankYouIdempotencyKey,
+} = require("./payment-thank-you");
+const { paymentThankYouCopy } = require("./mail");
+
+assert.ok(Date.parse(DEFAULT_AFTER_ISO));
+assert.strictEqual(paymentThankYouAfterMs(), Date.parse(DEFAULT_AFTER_ISO));
+
+assert.strictEqual(
+  shouldSendPaymentThankYou({
+    kind: "credit_enable",
+    paymentCreatedSec: Math.floor(Date.parse("2026-08-15T00:00:00Z") / 1000),
+    alreadyCredited: false,
+  }),
+  true
+);
+
+assert.strictEqual(
+  shouldSendPaymentThankYou({
+    kind: "credit_topup",
+    paymentCreatedSec: Math.floor(Date.parse("2026-08-15T12:00:00Z") / 1000),
+    alreadyCredited: false,
+  }),
+  true
+);
+
+// First three sales (before cutoff) must not get a backfilled thank-you
+assert.strictEqual(
+  shouldSendPaymentThankYou({
+    kind: "credit_enable",
+    paymentCreatedSec: Math.floor(Date.parse("2026-08-14T03:56:56Z") / 1000),
+    alreadyCredited: false,
+  }),
+  false
+);
+
+assert.strictEqual(
+  shouldSendPaymentThankYou({
+    kind: "credit_auto_recharge",
+    paymentCreatedSec: Math.floor(Date.parse("2026-08-20T00:00:00Z") / 1000),
+    alreadyCredited: false,
+  }),
+  false
+);
+
+assert.strictEqual(
+  shouldSendPaymentThankYou({
+    kind: "credit_enable",
+    paymentCreatedSec: Math.floor(Date.parse("2026-08-20T00:00:00Z") / 1000),
+    alreadyCredited: true,
+  }),
+  false
+);
+
+assert.ok(thankYouIdempotencyKey("cs_test").startsWith("payment-thanks-"));
+
+{
+  const copy = paymentThankYouCopy({
+    firstName: "Leo",
+    email: "leo@example.com",
+    creditUsd: 10,
+    autoRecharge: true,
+  });
+  assert.match(copy.subject, /Leo/);
+  assert.match(copy.text, /Arjun/);
+  assert.match(copy.text, /\$10/);
+  assert.match(copy.text, /Auto-recharge/);
+  assert.match(copy.html, /100× better/);
+  assert.match(copy.html, /hit reply/i);
+}
+
+console.log("payment-thank-you.test.js: ok");


### PR DESCRIPTION
## Summary
- After a successful prepaid credit Checkout (`credit_enable` / `credit_topup`), send a personal founder thank-you (Resend, reply-to Arjun).
- **Not** sent for auto-recharge off-session charges.
- Cutoff `PAYMENT_THANK_YOU_AFTER` (default `2026-08-14T23:00:00Z`) so the first three sales are not backfilled.
- Deduped per Stripe session id.

## Test plan
- [x] `node api/_lib/payment-thank-you.test.js`
- [ ] After deploy: next real Checkout credit gets the email; reconciling an old session does not
- [ ] Auto-recharge PI does not trigger thank-you

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a personalized founder thank-you email after eligible prepaid credit Checkouts, with timestamp gating and session-based deduplication.

- Adds payment-type and cutoff eligibility checks.
- Adds Resend email copy and delivery support.
- Hooks delivery into successful credit top-ups and adds focused gating/copy tests.
- The current fire-and-forget scheduling does not reliably preserve delivery work across the serverless response boundary.

<h3>Confidence Score: 4/5</h3>

The payment thank-you delivery should be made durable or awaited before merging because eligible customers can otherwise receive no email.

The webhook returns after scheduling delivery through setImmediate, leaving the store and Resend operations outside the awaited request lifecycle with no durable retry path.

**Files Needing Attention:** api/_lib/payment-thank-you.js, api/_lib/credit-topup.js

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/_lib/credit-topup.js | Hooks thank-you scheduling into newly applied credits, but does not await or durably enqueue the side effect. |
| api/_lib/payment-thank-you.js | Implements eligibility, deduplication metadata, and delivery state, but defers the required send as untracked serverless background work. |
| api/_lib/mail.js | Adds escaped payment thank-you copy and routes delivery through the existing Resend helper. |
| api/_lib/payment-thank-you.test.js | Covers gating and copy generation but does not exercise the request-lifecycle delivery behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Webhook
    participant TopUp as applyCreditTopUp
    participant Scheduler as schedulePaymentThankYou
    participant Resend
    Stripe->>Webhook: Successful Checkout event
    Webhook->>TopUp: await applyCreditTopUp(session)
    TopUp->>Scheduler: schedulePaymentThankYou(...)
    Scheduler-->>TopUp: return before delivery
    TopUp-->>Webhook: credited result
    Webhook-->>Stripe: HTTP 200
    Note over Scheduler,Resend: Invocation may end before deferred work completes
    Scheduler-->>Resend: setImmediate delivery (not guaranteed)
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: send founder thank-you email after..."](https://github.com/supercompress/supercompress/commit/32f4cd265455493723fde8700fee97dc000afc97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53514510)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->