### PR TITLE
feat(legal): Terms of Service and Privacy Policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -273,6 +273,21 @@
       "permanent": true
     },
     {
+      "source": "/tos",
+      "destination": "/terms",
+      "permanent": true
+    },
+    {
+      "source": "/terms-of-service",
+      "destination": "/terms",
+      "permanent": true
+    },
+    {
+      "source": "/privacy-policy",
+      "destination": "/privacy",
+      "permanent": true
+    },
+    {
       "source": "/token-compression-tools",
       "destination": "/open-source-token-compression",
       "permanent": true
@@ -1496,6 +1511,14 @@
     {
       "source": "/what-ai-tool-reduce-api-costs",
       "destination": "/what-ai-tool-reduce-api-costs.html"
+    },
+    {
+      "source": "/terms",
+      "destination": "/terms.html"
+    },
+    {
+      "source": "/privacy",
+      "destination": "/privacy.html"
     },
     {
       "source": "/supercompress-vs-truncation",

--- a/web/assets/css/legal-page.css
+++ b/web/assets/css/legal-page.css
@@ -1,0 +1,186 @@
+/**
+ * Legal document pages (Terms, Privacy) — readable long-form on paper brand.
+ */
+.legal-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 72px 24px 120px;
+}
+
+.legal-kicker {
+  margin: 0 0 12px;
+  font-family: var(--sans, "Geist", system-ui, sans-serif);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #0566ff;
+  text-align: center;
+}
+
+.legal-page > h1 {
+  margin: 0 auto 14px;
+  max-width: 16ch;
+  font-family: var(--serif, Platypi, Georgia, serif);
+  font-weight: 300;
+  font-size: clamp(2rem, 4.5vw, 2.85rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+  text-align: center;
+  color: #171717;
+}
+
+.legal-meta {
+  margin: 0 auto 36px;
+  text-align: center;
+  font-family: var(--sans, "Geist", system-ui, sans-serif);
+  font-size: 0.92rem;
+  color: #5c5a55;
+  line-height: 1.55;
+}
+
+.legal-meta a {
+  color: #0566ff;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.legal-toc {
+  margin: 0 0 40px;
+  padding: 20px 22px;
+  border: 1px solid #e6e7eb;
+  background: rgba(255, 255, 255, 0.72);
+  border-radius: 12px;
+}
+
+.legal-toc p {
+  margin: 0 0 10px;
+  font-family: var(--sans, "Geist", system-ui, sans-serif);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9a9892;
+}
+
+.legal-toc ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  font-family: var(--sans, "Geist", system-ui, sans-serif);
+  font-size: 0.92rem;
+  line-height: 1.7;
+  color: #171717;
+}
+
+.legal-toc a {
+  color: #171717;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.legal-toc a:hover {
+  color: #0566ff;
+  border-bottom-color: rgba(5, 102, 255, 0.35);
+}
+
+.legal-section {
+  margin: 0 0 36px;
+  font-family: var(--sans, "Geist", system-ui, sans-serif);
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #2a2a28;
+}
+
+.legal-section h2 {
+  margin: 0 0 12px;
+  padding-top: 8px;
+  font-family: var(--serif, Platypi, Georgia, serif);
+  font-weight: 400;
+  font-size: 1.45rem;
+  letter-spacing: -0.02em;
+  color: #171717;
+  scroll-margin-top: 88px;
+}
+
+.legal-section h3 {
+  margin: 22px 0 8px;
+  font-family: var(--sans, "Geist", system-ui, sans-serif);
+  font-weight: 600;
+  font-size: 1.02rem;
+  color: #171717;
+}
+
+.legal-section p,
+.legal-section li {
+  margin: 0 0 12px;
+}
+
+.legal-section ul,
+.legal-section ol {
+  margin: 0 0 14px;
+  padding-left: 1.25rem;
+}
+
+.legal-section a {
+  color: #0566ff;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.legal-callout {
+  margin: 16px 0 20px;
+  padding: 14px 16px;
+  border-left: 3px solid #0566ff;
+  background: rgba(5, 102, 255, 0.06);
+  border-radius: 0 10px 10px 0;
+  font-size: 0.95rem;
+}
+
+.legal-callout p {
+  margin: 0;
+}
+
+.legal-section table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 12px 0 18px;
+  font-size: 0.9rem;
+}
+
+.legal-section th,
+.legal-section td {
+  border: 1px solid #e6e7eb;
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.legal-section th {
+  background: #f7f8fb;
+  font-weight: 600;
+  color: #171717;
+}
+
+.legal-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  justify-content: center;
+  margin: 8px 0 28px;
+  font-family: var(--sans, "Geist", system-ui, sans-serif);
+  font-size: 0.9rem;
+}
+
+.legal-nav a {
+  color: #5c5a55;
+  text-decoration: none;
+}
+
+.legal-nav a[aria-current="page"] {
+  color: #0566ff;
+  font-weight: 600;
+}
+
+.legal-nav a:hover {
+  color: #0566ff;
+}

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -632,6 +632,7 @@
             <button type="button" class="btn-link-muted dash-forgot-password hidden" id="btn-forgot-password">Forgot password?</button>
             <button type="submit" class="btn-brand dash-auth-submit" id="auth-submit">Create free account</button>
           </form>
+          <p class="dash-auth-sub" style="margin-top:14px;font-size:12px;line-height:1.5">By continuing, you agree to our <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Policy</a>.</p>
         </div>
 
         <div id="dev-auth-area" class="hidden">
@@ -1157,9 +1158,16 @@ npm exec supercompress setup</pre>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
             </ul>
           </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
+            </ul>
+          </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="assets/js/firebase-config.js?v=3"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -751,9 +751,16 @@
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
             </ul>
           </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
+            </ul>
+          </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy | SuperCompress</title>
+  <meta name="description" content="Privacy Policy for SuperCompress: how we collect, use, store, and share personal data for the hosted API, dashboard, and website. Effective August 14, 2026." />
+  <meta property="og:title" content="Privacy Policy | SuperCompress" />
+  <meta property="og:description" content="How SuperCompress handles account, billing, and compression-related data." />
+  <meta property="og:image" content="https://www.supercompress.dev/assets/img/og-share-light.png" />
+  <meta property="og:url" content="https://www.supercompress.dev/privacy" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="SuperCompress" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://www.supercompress.dev/assets/img/og-share-light.png" />
+  <meta name="twitter:title" content="Privacy Policy | SuperCompress" />
+  <meta name="twitter:site" content="@supercompress" />
+  <link rel="canonical" href="https://www.supercompress.dev/privacy" />
+  <meta name="robots" content="index,follow" />
+  <link rel="icon" href="/favicon-chevron.ico?v=3" sizes="any" />
+  <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+  <link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
+  <link rel="stylesheet" href="/assets/css/legal-page.css?v=1" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Privacy Policy",
+    "url": "https://www.supercompress.dev/privacy",
+    "dateModified": "2026-08-14",
+    "isPartOf": {"@type": "WebSite", "name": "SuperCompress", "url": "https://www.supercompress.dev/"},
+    "about": "Privacy practices for SuperCompress hosted services"
+  }
+  </script>
+</head>
+<body>
+<header class="df-header">
+  <div class="df-header-blur" aria-hidden="true"></div>
+  <div class="df-header-inner">
+    <a href="/" class="df-logo-desktop">
+      <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+      <span class="df-logo-word">Super<em>Compress</em></span>
+    </a>
+    <div class="df-header-end">
+      <nav class="df-nav-pill" aria-label="Main">
+        <a href="/benchmarks">Benchmarks</a>
+        <a href="/#agents">Agents</a>
+        <a href="/blog">Blog</a>
+        <a href="/changelog">Changelog</a>
+        <a href="https://docs.supercompress.dev">Docs</a>
+      </nav>
+      <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
+    </div>
+    <div class="df-mobile-bar">
+      <a href="/" class="df-logo-mobile">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+      </a>
+      <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
+      <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+  </div>
+  <div class="df-mobile-nav" id="df-mobile-nav">
+    <a href="/benchmarks">Benchmarks</a>
+    <a href="/blog">Blog</a>
+    <a href="https://docs.supercompress.dev">Docs</a>
+    <a href="/terms">Terms</a>
+    <a href="/privacy" aria-current="page">Privacy</a>
+    <a href="/dashboard?signup=1">Get API key</a>
+  </div>
+</header>
+<div class="df-header-spacer" aria-hidden="true"></div>
+
+<main class="legal-page">
+  <p class="legal-kicker">Legal</p>
+  <h1>Privacy Policy</h1>
+  <p class="legal-meta">
+    Effective: <strong>August 14, 2026</strong><br />
+    Last updated: <strong>August 14, 2026</strong><br />
+    Related: <a href="/terms">Terms of Service</a>
+  </p>
+
+  <nav class="legal-nav" aria-label="Legal documents">
+    <a href="/terms">Terms of Service</a>
+    <a href="/privacy" aria-current="page">Privacy Policy</a>
+  </nav>
+
+  <div class="legal-callout" style="margin-bottom:28px">
+    <p><strong>Short version:</strong> We process account and billing data to run SuperCompress. Compress requests are processed to return results and meter usage. We may briefly retain compressed outputs for idempotent retries (typically up to about 48 hours), and we keep usage/billing metadata longer. We do not sell your personal information. Self-hosted open-source installs do not send your prompts to us unless you configure them to call our hosted API.</p>
+  </div>
+
+  <nav class="legal-toc" aria-label="On this page">
+    <p>Contents</p>
+    <ol>
+      <li><a href="#scope">Scope</a></li>
+      <li><a href="#controller">Who is responsible</a></li>
+      <li><a href="#collect">Information we collect</a></li>
+      <li><a href="#use">How we use information</a></li>
+      <li><a href="#legal-bases">Legal bases (EEA/UK)</a></li>
+      <li><a href="#sharing">How we share information</a></li>
+      <li><a href="#retention">Retention</a></li>
+      <li><a href="#security">Security</a></li>
+      <li><a href="#international">International transfers</a></li>
+      <li><a href="#rights">Your rights</a></li>
+      <li><a href="#children">Children</a></li>
+      <li><a href="#cookies">Cookies and similar technologies</a></li>
+      <li><a href="#self-host">Self-hosting and open source</a></li>
+      <li><a href="#changes">Changes</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ol>
+  </nav>
+
+  <section class="legal-section" id="scope">
+    <h2>1. Scope</h2>
+    <p>This Privacy Policy explains how <strong>Arjun Shah</strong>, doing business as <strong>SuperCompress</strong> (“<strong>SuperCompress</strong>,” “<strong>we</strong>,” “<strong>us</strong>,” or “<strong>our</strong>”), collects, uses, discloses, and otherwise processes personal information in connection with:</p>
+    <ul>
+      <li><a href="https://www.supercompress.dev">supercompress.dev</a> and related subdomains;</li>
+      <li>the hosted compression API, dashboard, billing, playground, and agent/MCP tooling we operate; and</li>
+      <li>support and product emails related to those services.</li>
+    </ul>
+    <p>It does <strong>not</strong> cover third-party sites or model providers you send data to after compression (OpenAI, Anthropic, Google, Cursor, etc.). Their privacy policies apply to those services.</p>
+  </section>
+
+  <section class="legal-section" id="controller">
+    <h2>2. Who is responsible</h2>
+    <p>For personal information processed in connection with the Services, the controller (or equivalent) is:</p>
+    <p>
+      Arjun Shah d/b/a SuperCompress<br />
+      Email: <a href="mailto:arjunkshah21@gmail.com">arjunkshah21@gmail.com</a>
+    </p>
+    <p>If you need a data processing agreement (DPA) for enterprise use of the hosted API, contact us at the same address.</p>
+  </section>
+
+  <section class="legal-section" id="collect">
+    <h2>3. Information we collect</h2>
+
+    <h3>3.1 Account and identity</h3>
+    <ul>
+      <li>Email address, display name, and authentication identifiers (for example Firebase Auth UID);</li>
+      <li>Sign-in method (email/password or Google OAuth profile information Google shares with us);</li>
+      <li>Account preferences and settings.</li>
+    </ul>
+
+    <h3>3.2 Billing and payments</h3>
+    <ul>
+      <li>Stripe customer identifiers, subscription/credit status, invoices, and payment event metadata;</li>
+      <li>Prepaid credit balances, auto-recharge preferences, and usage-derived charges;</li>
+      <li>Limited billing contact details associated with your Stripe customer.</li>
+    </ul>
+    <p>Payment card numbers are handled by <strong>Stripe</strong>; we do not store full card numbers on SuperCompress servers.</p>
+
+    <h3>3.3 API usage and compression processing</h3>
+    <ul>
+      <li><strong>Request content you submit:</strong> context, query, and related parameters needed to compress. We process this content to produce compressed outputs and measure tokens.</li>
+      <li><strong>Technical fingerprints:</strong> cryptographic hashes of billing-relevant request fields used for idempotency and double-billing prevention (not a substitute for encryption of your content).</li>
+      <li><strong>Outputs:</strong> compressed text and savings metadata returned to you. For idempotent retries, we may temporarily store a replayable compressed response (see Retention).</li>
+      <li><strong>Usage metrics:</strong> tokens in/out/saved, request counts, timestamps, rate-limit counters, API key identifiers (hashed or prefixed as implemented), and error/status codes.</li>
+    </ul>
+
+    <h3>3.4 Device and log data</h3>
+    <ul>
+      <li>IP address, user agent, approximate location derived from IP, request timestamps, and diagnostic logs from our hosting provider (currently <strong>Vercel</strong>) and related infrastructure;</li>
+      <li>Security and abuse-prevention signals (for example rate-limit hits).</li>
+    </ul>
+
+    <h3>3.5 Communications</h3>
+    <ul>
+      <li>Emails you send us, and transactional product emails we send you (welcome, billing receipts/thank-you, paywall notices, optional product tips if you remain subscribed);</li>
+      <li>Support correspondence.</li>
+    </ul>
+
+    <h3>3.6 Information we do not intentionally collect</h3>
+    <p>We do not require government ID numbers or sensitive special-category data to use SuperCompress. Please do not submit highly sensitive personal data in compress payloads unless necessary for your use case and lawful for you to process—you control what you send.</p>
+  </section>
+
+  <section class="legal-section" id="use">
+    <h2>4. How we use information</h2>
+    <p>We use personal information to:</p>
+    <ul>
+      <li>provide, operate, secure, and improve the Services;</li>
+      <li>authenticate users, manage API keys, and enforce rate limits and quotas;</li>
+      <li>meter usage, bill credits, prevent double-billing, and detect fraud/abuse;</li>
+      <li>send transactional messages (account, security, billing) and, where permitted, product updates—you can unsubscribe from non-essential marketing emails;</li>
+      <li>respond to support requests and investigate incidents;</li>
+      <li>comply with law, enforce our <a href="/terms">Terms of Service</a>, and protect rights, safety, and property; and</li>
+      <li>produce aggregated, de-identified statistics (for example overall token-savings trends) that do not identify you.</li>
+    </ul>
+    <p>We do <strong>not</strong> sell your personal information. We do not use Customer Content to train third-party foundation models for public release. We do not use your compress payloads to build a public dataset of customer prompts.</p>
+  </section>
+
+  <section class="legal-section" id="legal-bases">
+    <h2>5. Legal bases (EEA/UK)</h2>
+    <p>If GDPR/UK GDPR applies, we process personal data under these bases as appropriate:</p>
+    <ul>
+      <li><strong>Contract</strong> — to provide the Services you request (account, API, billing);</li>
+      <li><strong>Legitimate interests</strong> — security, abuse prevention, product improvement with appropriate safeguards, and limited product communications;</li>
+      <li><strong>Consent</strong> — where required (for example certain cookies or marketing), which you may withdraw;</li>
+      <li><strong>Legal obligation</strong> — when we must retain or disclose information to comply with law.</li>
+    </ul>
+  </section>
+
+  <section class="legal-section" id="sharing">
+    <h2>6. How we share information</h2>
+    <p>We share personal information with:</p>
+    <table>
+      <thead>
+        <tr><th>Category</th><th>Examples</th><th>Purpose</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Infrastructure</td>
+          <td>Vercel (hosting/compute), Google Firebase / Google Cloud (auth, datastore)</td>
+          <td>Run and store the Services</td>
+        </tr>
+        <tr>
+          <td>Payments</td>
+          <td>Stripe</td>
+          <td>Process payments and credits</td>
+        </tr>
+        <tr>
+          <td>Email delivery</td>
+          <td>Transactional email providers (for example Resend or similar)</td>
+          <td>Send account and product email</td>
+        </tr>
+        <tr>
+          <td>Professional advisors</td>
+          <td>Lawyers, accountants</td>
+          <td>As needed for business operations</td>
+        </tr>
+        <tr>
+          <td>Authorities</td>
+          <td>Courts, regulators, law enforcement</td>
+          <td>When legally required or to protect rights/safety</td>
+        </tr>
+        <tr>
+          <td>Business transfers</td>
+          <td>Acquirer or successor</td>
+          <td>If we are involved in a merger, acquisition, or asset sale</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>Processors act on our instructions and are required to protect data appropriately. We may also share information at your direction (for example if you integrate SuperCompress into a workflow that forwards data elsewhere).</p>
+  </section>
+
+  <section class="legal-section" id="retention">
+    <h2>7. Retention</h2>
+    <p>We retain information only as long as needed for the purposes above, including:</p>
+    <ul>
+      <li><strong>Account data</strong> — for the life of the account, then deleted or de-identified within a reasonable period after closure, unless law requires longer retention.</li>
+      <li><strong>Billing and ledger metadata</strong> (token counts, credit burns, idempotency fingerprints, payment references) — retained as needed for accounting, dispute resolution, abuse prevention, and legal compliance (often years for financial records).</li>
+      <li><strong>Replayable compressed responses</strong> — retained briefly to support idempotent retries (on the order of <strong>about 48 hours</strong>), after which response bodies are intended to expire or be scrubbed while billing metadata may remain.</li>
+      <li><strong>Server logs</strong> — retained for a limited operational window consistent with our host’s defaults and our security needs, then deleted or aggregated.</li>
+      <li><strong>Email records</strong> — retained as needed to operate communications and prove delivery of transactional notices.</li>
+    </ul>
+    <p>Exact periods may vary as we improve systems; we will not keep Customer Content longer than reasonably necessary for the Services.</p>
+  </section>
+
+  <section class="legal-section" id="security">
+    <h2>8. Security</h2>
+    <p>We use administrative, technical, and organizational measures designed to protect personal information, including TLS in transit, access controls on production systems, hashed or secret-managed API credentials, and least-privilege practices for operators. No method of transmission or storage is 100% secure; we cannot guarantee absolute security.</p>
+    <p>You are responsible for protecting your API keys and account credentials and for configuring your clients safely.</p>
+  </section>
+
+  <section class="legal-section" id="international">
+    <h2>9. International transfers</h2>
+    <p>We are based in the United States. If you access the Services from another country, your information may be processed in the U.S. and other countries where our providers operate. Where required, we rely on appropriate transfer mechanisms (such as Standard Contractual Clauses) offered by our processors.</p>
+  </section>
+
+  <section class="legal-section" id="rights">
+    <h2>10. Your rights</h2>
+    <p>Depending on where you live, you may have rights to:</p>
+    <ul>
+      <li>access, correct, or delete personal information;</li>
+      <li>portability of certain data;</li>
+      <li>object to or restrict certain processing;</li>
+      <li>withdraw consent where processing is consent-based; and</li>
+      <li>appeal or lodge a complaint with a supervisory authority.</li>
+    </ul>
+    <h3>10.1 California (CCPA/CPRA)</h3>
+    <p>California residents may have rights to know, delete, correct, and opt out of “sale” or “sharing” of personal information as those terms are defined by law. We do <strong>not</strong> sell personal information and do not share it for cross-context behavioral advertising in the way those statutes typically target. To exercise rights, email <a href="mailto:arjunkshah21@gmail.com">arjunkshah21@gmail.com</a>. We will not discriminate against you for exercising privacy rights.</p>
+    <h3>10.2 How to exercise rights</h3>
+    <p>Email us from the address on your account when possible so we can verify your request. We may need additional information to confirm identity. Authorized agents may submit requests as allowed by law.</p>
+  </section>
+
+  <section class="legal-section" id="children">
+    <h2>11. Children</h2>
+    <p>The Services are not directed to children under 16, and we do not knowingly collect personal information from children under 16. If you believe a child provided us personal information, contact us and we will take appropriate steps to delete it.</p>
+  </section>
+
+  <section class="legal-section" id="cookies">
+    <h2>12. Cookies and similar technologies</h2>
+    <p>We use cookies and similar technologies that are necessary to operate the site and dashboard (for example session/auth cookies from Firebase and security preferences). We may use limited analytics or performance tooling from our host; if we introduce advertising cookies or non-essential trackers, we will update this Policy and provide choices where required.</p>
+    <p>You can control cookies through your browser settings. Disabling certain cookies may break login or dashboard features.</p>
+  </section>
+
+  <section class="legal-section" id="self-host">
+    <h2>13. Self-hosting and open source</h2>
+    <p>If you run SuperCompress open-source software entirely on your own machines without calling our hosted API, your prompts stay in your environment and this Policy does not apply to that local processing. If your installation is configured to send requests to <code>api.supercompress.dev</code> (or another SuperCompress hosted endpoint), those requests are processed under this Policy.</p>
+  </section>
+
+  <section class="legal-section" id="changes">
+    <h2>14. Changes</h2>
+    <p>We may update this Privacy Policy from time to time. We will post the revised version on this page and update the “Last updated” date. For material changes, we will provide additional notice when reasonable. Continued use of the Services after the effective date means you acknowledge the updated Policy.</p>
+  </section>
+
+  <section class="legal-section" id="contact">
+    <h2>15. Contact</h2>
+    <p>Privacy questions or requests:</p>
+    <p>
+      SuperCompress / Arjun Shah<br />
+      Email: <a href="mailto:arjunkshah21@gmail.com">arjunkshah21@gmail.com</a><br />
+      Web: <a href="https://www.supercompress.dev">https://www.supercompress.dev</a>
+    </p>
+  </section>
+</main>
+
+<footer class="df-footer">
+  <div class="df-footer-inner">
+    <div class="df-footer-grid">
+      <div class="df-footer-brand">
+        <a href="/" class="df-footer-lockup">
+          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+          <p class="df-footer-heading">Super<em>Compress</em></p>
+        </a>
+        <p>Prompt compression for AI apps.</p>
+      </div>
+      <div class="df-footer-links">
+        <div>
+          <p class="df-footer-heading">Legal</p>
+          <ul>
+            <li><a href="/terms">Terms of Service</a></li>
+            <li><a href="/privacy" aria-current="page">Privacy Policy</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="df-footer-heading">Product</p>
+          <ul>
+            <li><a href="/dashboard?signup=1">Get API key</a></li>
+            <li><a href="https://docs.supercompress.dev">Docs</a></li>
+            <li><a href="/benchmarks">Benchmarks</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <p class="df-footer-copy">© SuperCompress · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
+  </div>
+</footer>
+<script src="/assets/js/site-chrome.js?v=12"></script>
+</body>
+</html>

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -3,6 +3,8 @@
 # Full LLM index: https://supercompress.dev/llms-full.txt
 # Human-readable AI search facts: https://supercompress.dev/ai-search
 # AI search facts: https://supercompress.dev/ai-search.json
+# Terms: https://www.supercompress.dev/terms
+# Privacy: https://www.supercompress.dev/privacy
 
 User-agent: GPTBot
 Allow: /

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -7,6 +7,18 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://www.supercompress.dev/terms</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.supercompress.dev/privacy</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://www.supercompress.dev/better-than-headroom</loc>
     <lastmod>2026-08-08</lastmod>
     <changefreq>daily</changefreq>

--- a/web/terms.html
+++ b/web/terms.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Terms of Service | SuperCompress</title>
+  <meta name="description" content="Terms of Service for the SuperCompress hosted API, dashboard, website, and related services. Effective August 14, 2026." />
+  <meta property="og:title" content="Terms of Service | SuperCompress" />
+  <meta property="og:description" content="The agreement that governs your use of SuperCompress hosted services." />
+  <meta property="og:image" content="https://www.supercompress.dev/assets/img/og-share-light.png" />
+  <meta property="og:url" content="https://www.supercompress.dev/terms" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="SuperCompress" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://www.supercompress.dev/assets/img/og-share-light.png" />
+  <meta name="twitter:title" content="Terms of Service | SuperCompress" />
+  <meta name="twitter:site" content="@supercompress" />
+  <link rel="canonical" href="https://www.supercompress.dev/terms" />
+  <meta name="robots" content="index,follow" />
+  <link rel="icon" href="/favicon-chevron.ico?v=3" sizes="any" />
+  <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
+  <link rel="stylesheet" href="/assets/css/supercompress.css?v=105" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
+  <link rel="stylesheet" href="/assets/css/legal-page.css?v=1" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Terms of Service",
+    "url": "https://www.supercompress.dev/terms",
+    "dateModified": "2026-08-14",
+    "isPartOf": {"@type": "WebSite", "name": "SuperCompress", "url": "https://www.supercompress.dev/"},
+    "about": "Terms governing SuperCompress hosted API, dashboard, and website"
+  }
+  </script>
+</head>
+<body>
+<header class="df-header">
+  <div class="df-header-blur" aria-hidden="true"></div>
+  <div class="df-header-inner">
+    <a href="/" class="df-logo-desktop">
+      <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+      <span class="df-logo-word">Super<em>Compress</em></span>
+    </a>
+    <div class="df-header-end">
+      <nav class="df-nav-pill" aria-label="Main">
+        <a href="/benchmarks">Benchmarks</a>
+        <a href="/#agents">Agents</a>
+        <a href="/blog">Blog</a>
+        <a href="/changelog">Changelog</a>
+        <a href="https://docs.supercompress.dev">Docs</a>
+      </nav>
+      <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
+    </div>
+    <div class="df-mobile-bar">
+      <a href="/" class="df-logo-mobile">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+      </a>
+      <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
+      <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+  </div>
+  <div class="df-mobile-nav" id="df-mobile-nav">
+    <a href="/benchmarks">Benchmarks</a>
+    <a href="/blog">Blog</a>
+    <a href="https://docs.supercompress.dev">Docs</a>
+    <a href="/terms" aria-current="page">Terms</a>
+    <a href="/privacy">Privacy</a>
+    <a href="/dashboard?signup=1">Get API key</a>
+  </div>
+</header>
+<div class="df-header-spacer" aria-hidden="true"></div>
+
+<main class="legal-page">
+  <p class="legal-kicker">Legal</p>
+  <h1>Terms of Service</h1>
+  <p class="legal-meta">
+    Effective: <strong>August 14, 2026</strong><br />
+    Last updated: <strong>August 14, 2026</strong><br />
+    Related: <a href="/privacy">Privacy Policy</a>
+  </p>
+
+  <nav class="legal-nav" aria-label="Legal documents">
+    <a href="/terms" aria-current="page">Terms of Service</a>
+    <a href="/privacy">Privacy Policy</a>
+  </nav>
+
+  <nav class="legal-toc" aria-label="On this page">
+    <p>Contents</p>
+    <ol>
+      <li><a href="#agreement">Agreement to these Terms</a></li>
+      <li><a href="#who">Who we are</a></li>
+      <li><a href="#services">The Services</a></li>
+      <li><a href="#accounts">Accounts and API keys</a></li>
+      <li><a href="#customer-content">Your content</a></li>
+      <li><a href="#acceptable-use">Acceptable use</a></li>
+      <li><a href="#billing">Plans, credits, and billing</a></li>
+      <li><a href="#open-source">Open-source software</a></li>
+      <li><a href="#ip">Intellectual property</a></li>
+      <li><a href="#confidentiality">Confidentiality</a></li>
+      <li><a href="#third-parties">Third-party services</a></li>
+      <li><a href="#disclaimers">Disclaimers</a></li>
+      <li><a href="#liability">Limitation of liability</a></li>
+      <li><a href="#indemnity">Indemnification</a></li>
+      <li><a href="#suspension">Suspension and termination</a></li>
+      <li><a href="#changes">Changes to the Services or Terms</a></li>
+      <li><a href="#law">Governing law and disputes</a></li>
+      <li><a href="#misc">General</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ol>
+  </nav>
+
+  <section class="legal-section" id="agreement">
+    <h2>1. Agreement to these Terms</h2>
+    <p>These Terms of Service (“<strong>Terms</strong>”) are a binding agreement between you and <strong>Arjun Shah</strong>, doing business as <strong>SuperCompress</strong> (“<strong>SuperCompress</strong>,” “<strong>we</strong>,” “<strong>us</strong>,” or “<strong>our</strong>”). They govern your access to and use of:</p>
+    <ul>
+      <li>the websites at <a href="https://www.supercompress.dev">supercompress.dev</a>, related subdomains (including <code>api.</code>, <code>docs.</code>, and <code>www.</code>), and marketing pages;</li>
+      <li>the hosted compression API, dashboard, billing portal, playground, and agent/MCP integrations we operate; and</li>
+      <li>any related support, emails, or documentation we provide for the hosted product</li>
+    </ul>
+    <p>(collectively, the “<strong>Services</strong>”).</p>
+    <div class="legal-callout">
+      <p>By creating an account, generating an API key, calling the hosted API, enabling pay-as-you-go credits, or otherwise using the Services, you agree to these Terms and our <a href="/privacy">Privacy Policy</a>. If you do not agree, do not use the Services.</p>
+    </div>
+    <p>If you use the Services on behalf of a company or other entity, you represent that you have authority to bind that entity, and “you” includes that entity.</p>
+    <p>You must be at least <strong>18 years old</strong> (or the age of majority where you live) to use the Services.</p>
+  </section>
+
+  <section class="legal-section" id="who">
+    <h2>2. Who we are</h2>
+    <p>SuperCompress is operated by Arjun Shah. For notices under these Terms, email <a href="mailto:arjunkshah21@gmail.com">arjunkshah21@gmail.com</a>.</p>
+    <p>These Terms apply to the <strong>hosted</strong> Services. Separately, our open-source libraries and packages are available under the <strong>MIT License</strong> (or other licenses stated in those repositories). Self-hosting open-source code on your own infrastructure is governed by that license—not by these hosted-service Terms—except where you still use our hosted API, dashboard, or billing.</p>
+  </section>
+
+  <section class="legal-section" id="services">
+    <h2>3. The Services</h2>
+    <p>SuperCompress provides query-aware context / prompt compression and related tooling so you can reduce oversized LLM inputs before inference. Features may include:</p>
+    <ul>
+      <li>HTTP APIs that accept context and a query and return compressed text and savings metadata;</li>
+      <li>account dashboard, API keys, usage analytics, and prepaid credit billing;</li>
+      <li>integrations for coding agents (for example MCP / proxy setup helpers); and</li>
+      <li>documentation, demos, and benchmarks.</li>
+    </ul>
+    <p>We may modify, suspend, or discontinue features with reasonable notice when practicable. We do not guarantee uninterrupted availability, specific latency, or particular compression ratios or answer-quality outcomes for your workloads. Public benchmarks describe our held-out evaluations; your results may differ.</p>
+    <p>You are solely responsible for: (a) how you use compressed outputs with third-party model providers; (b) evaluating quality, safety, and compliance for your application; and (c) securing your systems, secrets, and downstream data flows.</p>
+  </section>
+
+  <section class="legal-section" id="accounts">
+    <h2>4. Accounts and API keys</h2>
+    <p>You may need an account (for example via email/password or Google sign-in through Firebase Authentication) to use parts of the Services. You agree to provide accurate information and keep it updated.</p>
+    <p><strong>API keys and credentials</strong> are confidential. You are responsible for all activity under your account and keys, including usage by employees, contractors, agents, and automated systems you authorize. Notify us promptly if you believe a key or account is compromised. We may revoke or rotate keys to protect the Services or other users.</p>
+    <p>You may not share accounts in a way that circumvents plan limits, rate limits, or billing, or sell/transfer accounts without our prior written consent.</p>
+  </section>
+
+  <section class="legal-section" id="customer-content">
+    <h2>5. Your content</h2>
+    <p>“<strong>Customer Content</strong>” means prompts, context, queries, documents, logs, code, or other materials you (or your systems) submit to the Services, and outputs we return to you from processing that material.</p>
+    <p><strong>Ownership.</strong> As between you and us, you retain all rights in Customer Content you submit. We do not claim ownership of your prompts or your compressed outputs.</p>
+    <p><strong>License to operate the Services.</strong> You grant us a worldwide, non-exclusive, royalty-free license to host, process, transmit, and temporarily store Customer Content solely as needed to provide, secure, troubleshoot, and improve the Services (including idempotent request handling, abuse prevention, billing accuracy, and support you request). See the <a href="/privacy">Privacy Policy</a> for how long certain processing artifacts may be retained.</p>
+    <p><strong>Your responsibilities.</strong> You represent that you have all rights and consents needed to submit Customer Content, and that doing so does not violate law or third-party rights. Do not submit content you are not authorized to process, including unlawful content or content subject to restrictions you have not cleared.</p>
+    <p><strong>Feedback.</strong> If you send ideas, suggestions, or feedback about the Services, we may use them without obligation or compensation to you.</p>
+  </section>
+
+  <section class="legal-section" id="acceptable-use">
+    <h2>6. Acceptable use</h2>
+    <p>You agree not to, and not to allow others to:</p>
+    <ul>
+      <li>use the Services in violation of applicable law, regulation, or sanctions;</li>
+      <li>probe, scan, or attack the Services, or attempt to bypass authentication, rate limits, quotas, or billing;</li>
+      <li>interfere with or disrupt the Services or other customers’ use;</li>
+      <li>reverse engineer proprietary hosted components except to the extent such restriction is prohibited by law;</li>
+      <li>resell, sublicense, or provide the Services as a competing multi-tenant compression API without a written agreement with us;</li>
+      <li>submit malware, or content intended primarily to overload or harm our systems;</li>
+      <li>use the Services to develop a competing product by systematically extracting non-public model weights, proprietary datasets, or undisclosed algorithms from the hosted service (training on publicly documented APIs and your own outputs is not restricted by this bullet); or</li>
+      <li>misrepresent your identity or affiliation when interacting with support or billing.</li>
+    </ul>
+    <p>We may investigate suspected violations and suspend or terminate access as described below.</p>
+  </section>
+
+  <section class="legal-section" id="billing">
+    <h2>7. Plans, credits, and billing</h2>
+    <h3>7.1 Free allowance</h3>
+    <p>Unless we state otherwise for your account, hosted compression includes a monthly free token allowance (currently <strong>1,000,000 tokens per month</strong>). Free-tier limits, rate limits, and features may change. Unused free allowance does not roll over unless we expressly say so.</p>
+    <h3>7.2 Pay-as-you-go credits</h3>
+    <p>After the free allowance, usage may be billed via a prepaid credit wallet at the then-current rate (currently <strong>$0.30 per 1,000,000 tokens</strong> of billable input, subject to change with notice). Minimum credit purchases and auto-recharge options may apply as shown in the dashboard at checkout.</p>
+    <h3>7.3 Payment processor</h3>
+    <p>Payments are processed by <strong>Stripe</strong>. By enabling billing, you also agree to Stripe’s applicable terms. We do not store full payment card numbers on our servers.</p>
+    <h3>7.4 Taxes</h3>
+    <p>Prices are stated exclusive of taxes unless noted. You are responsible for any taxes, duties, or similar governmental charges associated with your purchases, except taxes based on our net income.</p>
+    <h3>7.5 Credits, refunds, and chargebacks</h3>
+    <p>Prepaid credits are generally <strong>non-refundable</strong> and non-transferable once purchased, except where required by law or where we elect, in our sole discretion, to issue a refund or credit (for example, a clear billing error caused by us). Auto-recharge may charge your saved payment method when your balance reaches zero if you enabled that option; you can disable it in the dashboard.</p>
+    <p>If you initiate a chargeback or payment dispute, we may suspend the account pending resolution and recover fees and costs we reasonably incur.</p>
+    <h3>7.6 Usage metering</h3>
+    <p>Token counts and billing calculations are based on our metering systems. We aim for accuracy; if a genuine metering error occurs, we will correct the ledger in good faith. Idempotency keys and fingerprints may be used so retries do not double-bill the same request.</p>
+  </section>
+
+  <section class="legal-section" id="open-source">
+    <h2>8. Open-source software</h2>
+    <p>Parts of SuperCompress are released under open-source licenses (including MIT for the primary repository). Those licenses govern your rights to copy, modify, and self-host that code. Nothing in these Terms reduces rights granted to you under a valid open-source license for code you obtain from our public repositories, except that use of our <em>hosted</em> infrastructure remains subject to these Terms.</p>
+  </section>
+
+  <section class="legal-section" id="ip">
+    <h2>9. Intellectual property</h2>
+    <p>We and our licensors own the Services, including software, branding, documentation, site design, and benchmarks we publish (excluding Customer Content). SuperCompress names and logos are our trademarks. You may not use them in a way that implies endorsement without permission, except for truthful factual references.</p>
+    <p>Subject to these Terms, we grant you a limited, non-exclusive, non-transferable, revocable right to access and use the Services for your internal business or personal projects.</p>
+  </section>
+
+  <section class="legal-section" id="confidentiality">
+    <h2>10. Confidentiality</h2>
+    <p>If either party receives non-public information from the other that is marked confidential or should reasonably be understood as confidential (“<strong>Confidential Information</strong>”), the receiving party will use it only to perform under these Terms and will protect it with reasonable care. Confidential Information does not include information that is public through no fault of the recipient, independently developed, or rightfully received from a third party without duty of confidentiality. We may disclose Confidential Information if required by law, after giving notice when legally permitted.</p>
+  </section>
+
+  <section class="legal-section" id="third-parties">
+    <h2>11. Third-party services</h2>
+    <p>The Services interoperate with third parties such as cloud hosts, authentication providers, payment processors, email delivery, and LLM providers you choose. Those services are governed by their own terms. We are not responsible for third-party outages, policy changes, or how those providers handle data once you send outputs to them.</p>
+  </section>
+
+  <section class="legal-section" id="disclaimers">
+    <h2>12. Disclaimers</h2>
+    <p>THE SERVICES ARE PROVIDED “<strong>AS IS</strong>” AND “<strong>AS AVAILABLE</strong>.” TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.</p>
+    <p>WITHOUT LIMITING THE FOREGOING, WE DO NOT WARRANT THAT: (A) THE SERVICES WILL BE ERROR-FREE, SECURE, OR UNINTERRUPTED; (B) COMPRESSION WILL ACHIEVE ANY PARTICULAR TOKEN SAVINGS, COST REDUCTION, OR ANSWER QUALITY FOR YOUR WORKLOADS; OR (C) OUTPUTS WILL BE COMPLETE, ACCURATE, OR SUITABLE FOR ANY REGULATED OR SAFETY-CRITICAL USE WITHOUT YOUR OWN REVIEW.</p>
+    <p>Some jurisdictions do not allow certain disclaimers; in those places, disclaimers apply to the fullest extent permitted.</p>
+  </section>
+
+  <section class="legal-section" id="liability">
+    <h2>13. Limitation of liability</h2>
+    <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, SUPERCOMPRESS AND ITS OPERATOR WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, GOODWILL, OR BUSINESS INTERRUPTION, ARISING OUT OF OR RELATED TO THESE TERMS OR THE SERVICES, WHETHER BASED ON WARRANTY, CONTRACT, TORT (INCLUDING NEGLIGENCE), STATUTE, OR ANY OTHER LEGAL THEORY, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+    <p>TO THE MAXIMUM EXTENT PERMITTED BY LAW, OUR TOTAL LIABILITY FOR ALL CLAIMS ARISING OUT OF OR RELATED TO THESE TERMS OR THE SERVICES WILL NOT EXCEED THE GREATER OF: (A) THE AMOUNTS YOU PAID TO US FOR THE SERVICES IN THE <strong>TWELVE (12) MONTHS</strong> BEFORE THE EVENT GIVING RISE TO LIABILITY; OR (B) <strong>ONE HUNDRED U.S. DOLLARS (US $100)</strong>.</p>
+    <p>These limitations are a fundamental allocation of risk and survive termination. They do not limit liability that cannot be limited under applicable law (for example, certain liability for fraud or willful misconduct where such exclusion is forbidden).</p>
+  </section>
+
+  <section class="legal-section" id="indemnity">
+    <h2>14. Indemnification</h2>
+    <p>You will defend, indemnify, and hold harmless SuperCompress and Arjun Shah from and against any claims, damages, losses, liabilities, costs, and expenses (including reasonable attorneys’ fees) arising out of or related to: (a) your Customer Content; (b) your use of the Services in violation of these Terms or law; (c) your applications’ interactions with end users or third-party providers; or (d) disputes between you and your customers or users.</p>
+  </section>
+
+  <section class="legal-section" id="suspension">
+    <h2>15. Suspension and termination</h2>
+    <p>You may stop using the Services at any time and may request account closure by contacting us. We may suspend or terminate access immediately if we reasonably believe you breached these Terms, pose a security or legal risk, fail to pay amounts due, or if required by law or a provider.</p>
+    <p>Upon termination: (a) your right to use the hosted Services ends; (b) unused prepaid credits are forfeited unless law requires otherwise or we agree in writing; and (c) sections that by nature should survive (including ownership, disclaimers, liability limits, indemnity, and governing law) will survive.</p>
+  </section>
+
+  <section class="legal-section" id="changes">
+    <h2>16. Changes to the Services or Terms</h2>
+    <p>We may update these Terms from time to time. We will post the updated Terms on this page and update the “Last updated” date. For material changes, we will provide additional notice when reasonable (for example, email or dashboard notice). Continued use after the effective date constitutes acceptance. If you do not agree, stop using the Services and contact us to close your account.</p>
+  </section>
+
+  <section class="legal-section" id="law">
+    <h2>17. Governing law and disputes</h2>
+    <p>These Terms are governed by the laws of the <strong>State of California</strong>, USA, excluding conflict-of-law rules. Exclusive venue for disputes that are not resolved informally will be the state or federal courts located in <strong>Santa Clara County, California</strong>, and you consent to personal jurisdiction there—except that we may seek injunctive relief in any jurisdiction to protect our intellectual property or the security of the Services.</p>
+    <p>Before filing a claim, you agree to try to resolve the dispute informally by emailing <a href="mailto:arjunkshah21@gmail.com">arjunkshah21@gmail.com</a> with a description of the issue; we will attempt in good faith to resolve it within 30 days.</p>
+    <p>If you are a consumer in a jurisdiction that requires different mandatory protections, those protections apply to the extent required.</p>
+  </section>
+
+  <section class="legal-section" id="misc">
+    <h2>18. General</h2>
+    <ul>
+      <li><strong>Entire agreement.</strong> These Terms and the Privacy Policy are the entire agreement between you and us regarding the Services and supersede prior agreements on that subject.</li>
+      <li><strong>Severability.</strong> If a provision is unenforceable, the remainder stays in effect.</li>
+      <li><strong>Waiver.</strong> Failure to enforce a provision is not a waiver of future enforcement.</li>
+      <li><strong>Assignment.</strong> You may not assign these Terms without our consent; we may assign them in connection with a merger, acquisition, or sale of assets.</li>
+      <li><strong>Force majeure.</strong> We are not liable for delays or failures due to events beyond reasonable control.</li>
+      <li><strong>Export.</strong> You will comply with applicable export and sanctions laws.</li>
+      <li><strong>No agency.</strong> These Terms do not create a partnership, joint venture, or employment relationship.</li>
+      <li><strong>Notices.</strong> We may notify you via email, dashboard message, or posting on the site. Legal notices to us go to the contact below.</li>
+    </ul>
+  </section>
+
+  <section class="legal-section" id="contact">
+    <h2>19. Contact</h2>
+    <p>Questions about these Terms:</p>
+    <p>
+      SuperCompress / Arjun Shah<br />
+      Email: <a href="mailto:arjunkshah21@gmail.com">arjunkshah21@gmail.com</a><br />
+      Web: <a href="https://www.supercompress.dev">https://www.supercompress.dev</a>
+    </p>
+  </section>
+</main>
+
+<footer class="df-footer">
+  <div class="df-footer-inner">
+    <div class="df-footer-grid">
+      <div class="df-footer-brand">
+        <a href="/" class="df-footer-lockup">
+          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+          <p class="df-footer-heading">Super<em>Compress</em></p>
+        </a>
+        <p>Prompt compression for AI apps.</p>
+      </div>
+      <div class="df-footer-links">
+        <div>
+          <p class="df-footer-heading">Legal</p>
+          <ul>
+            <li><a href="/terms" aria-current="page">Terms of Service</a></li>
+            <li><a href="/privacy">Privacy Policy</a></li>
+          </ul>
+        </div>
+        <div>
+          <p class="df-footer-heading">Product</p>
+          <ul>
+            <li><a href="/dashboard?signup=1">Get API key</a></li>
+            <li><a href="https://docs.supercompress.dev">Docs</a></li>
+            <li><a href="/benchmarks">Benchmarks</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <p class="df-footer-copy">© SuperCompress · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
+  </div>
+</footer>
+<script src="/assets/js/site-chrome.js?v=12"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `/terms` and `/privacy` with product-accurate coverage (API keys, prepaid credits, Stripe/Firebase/Vercel, ~48h compress replay retention, CCPA/GDPR rights, California governing law).
- Wire vercel rewrites + aliases (`/tos`, `/privacy-policy`), sitemap, robots, homepage/dashboard Legal links, and signup agreement line.

## Test plan
- [ ] `/terms` and `/privacy` render after deploy
- [ ] `/tos` and `/privacy-policy` redirect
- [ ] Dashboard auth card shows Terms/Privacy links
- [ ] `node scripts/check-api-host-routes.js` passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added publicly accessible Terms of Service and Privacy Policy pages.
  * Added legal links to authentication screens and website footers.
  * Added responsive layouts, navigation, and structured metadata for legal pages.
  * Added friendly redirects for common Terms and Privacy URL variations.

* **Documentation**
  * Updated crawler guidance and the sitemap to include the new legal pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds public Terms of Service and Privacy Policy pages and integrates them into signup, navigation, routing, and search-discovery metadata. The privacy text needs updates to cover existing affiliate tracking and CCR storage accurately.

- Adds `/terms` and `/privacy`, including responsive legal-page styling.
- Adds aliases, Vercel rewrites, sitemap entries, and robots references.
- Adds legal links to the homepage, dashboard footer, and signup agreement.
- Introduces privacy disclosures that omit a 30-day affiliate cookie and full original-context persistence in CCR.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the Privacy Policy accurately discloses the existing affiliate-tracking cookie and CCR storage of full original contexts.

The new public privacy contract omits two currently reachable data-handling behaviors: 30-day affiliate attribution on the dashboard and CCR persistence of complete original request contexts without the disclosed replay expiration.

**Files Needing Attention:** web/privacy.html, web/terms.html

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/privacy.html | Adds the privacy policy, but its cookie and Customer Content retention disclosures omit existing affiliate and CCR persistence behavior. |
| web/terms.html | Adds hosted-service terms, including a temporary-storage representation that should be reconciled with CCR persistence. |
| vercel.json | Adds legal aliases and clean-route rewrites without conflicting with existing API or catch-all routing. |
| web/dashboard.html | Adds signup consent text and footer legal links; the linked pages are reachable through the new routes. |
| web/assets/css/legal-page.css | Adds scoped long-form legal-page styling with no identified functional issue. |
| web/sitemap.xml | Adds canonical Terms and Privacy URLs with valid sitemap entries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(legal): add Terms of Service and Pr..."](https://github.com/supercompress/supercompress/commit/cbfadce944290d1ff796cb8e17433d3c63c65588) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53562015)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->