### PR TITLE
fix(legal): remove age requirement from Terms

### DIFF
--- a/web/terms.html
+++ b/web/terms.html
@@ -125,7 +125,6 @@
       <p>By creating an account, generating an API key, calling the hosted API, enabling pay-as-you-go credits, or otherwise using the Services, you agree to these Terms and our <a href="/privacy">Privacy Policy</a>. If you do not agree, do not use the Services.</p>
     </div>
     <p>If you use the Services on behalf of a company or other entity, you represent that you have authority to bind that entity, and “you” includes that entity.</p>
-    <p>You must be at least <strong>18 years old</strong> (or the age of majority where you live) to use the Services.</p>
   </section>
 
   <section class="legal-section" id="who">


### PR DESCRIPTION
## Summary
- Remove the “You must be at least 18…” sentence from `/terms`.

## Test plan
- [ ] `/terms` no longer contains the age-of-majority line after deploy

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the age-of-majority eligibility sentence from the static Terms of Service page, as described by the pull request.
- Leaves the surrounding agreement terms and HTML structure unchanged.

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge.

The change is limited to the intentional removal of one standalone paragraph, and the resulting HTML remains structurally valid with no runtime or security behavior affected.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/terms.html | Removes the specified age-requirement paragraph without introducing structural, rendering, or behavioral changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(legal): drop age-of-majority require..."](https://github.com/supercompress/supercompress/commit/afe83345fd9f48fdca613c326c09fee1031b74fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53624122)</sub>

<!-- /greptile_comment -->