### PR TITLE
fix: make repo Sponsor button clickable

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,12 @@
 # Sponsor button on https://github.com/Supercompress/Supercompress
-github: arjunkshah12345-hash
+#
+# `github: <user>` only works when that account has an *active* GitHub Sponsors
+# listing. @arjunkshah12345-hash does not yet (sponsors URL 302s to the profile,
+# fundingLinks is empty, /sponsor_button returns blank) — so the heart button
+# was unclickable.
+#
+# Use a working custom link until Sponsors is enabled at:
+#   https://github.com/sponsors/accounts
+# Then you can restore:  github: arjunkshah12345-hash
+custom:
+  - "https://www.supercompress.dev/dashboard?signup=1"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="https://www.npmjs.com/package/supercompress-proxy"><img src="https://img.shields.io/npm/v/supercompress-proxy?style=flat&logo=npm&logoColor=white&label=npm" alt="npm" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-3da639?style=flat" alt="MIT License" /></a>
   <a href="https://github.com/Supercompress/Supercompress"><img src="https://img.shields.io/badge/GitHub-Supercompress-181717?style=flat&logo=github&logoColor=white" alt="GitHub" /></a>
-  <a href="https://github.com/sponsors/arjunkshah12345-hash"><img src="https://img.shields.io/badge/Sponsor-EA4AAA?style=flat&logo=githubsponsors&logoColor=white" alt="Sponsor on GitHub" /></a>
+  <a href="https://www.supercompress.dev/dashboard?signup=1"><img src="https://img.shields.io/badge/Sponsor-EA4AAA?style=flat&logo=githubsponsors&logoColor=white" alt="Sponsor SuperCompress" /></a>
 </p>
 
 ---
@@ -165,7 +165,7 @@ More: [vs truncation](https://www.supercompress.dev/supercompress-vs-truncation)
   <sub>
     <a href="https://www.supercompress.dev">supercompress.dev</a> ·
     <a href="./LICENSE">MIT License</a> ·
-    <a href="https://github.com/sponsors/arjunkshah12345-hash">Sponsor</a> ·
+    <a href="https://www.supercompress.dev/dashboard?signup=1">Sponsor</a> ·
     built by <a href="https://github.com/arjunkshah12345-hash">Arjun Shah</a>
   </sub>
 </p>


### PR DESCRIPTION
## Summary
- GitHub Sponsors for `@arjunkshah12345-hash` is not active (sponsors URL redirects to the profile; `fundingLinks` is empty; `/sponsor_button` returns blank), so the repo heart/Sponsor control was unclickable.
- Point `.github/FUNDING.yml` + README Sponsor links at a working custom URL (`/dashboard?signup=1`) until Sponsors is enabled at https://github.com/sponsors/accounts.

## Test plan
- [ ] After merge, hard-refresh https://github.com/Supercompress/Supercompress
- [ ] Sponsor / heart control opens a funding link (not a dead/empty button)
- [ ] README Sponsor badge navigates to the dashboard signup URL
- [ ] Optional follow-up: enable GitHub Sponsors for `@arjunkshah12345-hash`, then restore `github: arjunkshah12345-hash` in `FUNDING.yml`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated sponsorship links in the README to direct visitors to the SuperCompress dashboard signup page.
  - Refreshed the project’s funding configuration to use the new signup destination.
  - Added supporting notes explaining the updated funding link and potential future restoration of the previous sponsorship option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the inactive GitHub Sponsors account link with a working custom dashboard signup URL so the repository Sponsor control and README links remain clickable.
- Configures GitHub’s repository funding control to use `https://www.supercompress.dev/dashboard?signup=1`.
- Updates both README Sponsor links and their accessible label to match the custom destination.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with all Sponsor links consistently targeting the explicitly intended temporary dashboard signup URL.

The funding configuration uses GitHub’s supported custom-link shape, and the README links consistently match the destination documented in the PR.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/FUNDING.yml | Replaces the inactive GitHub Sponsors account with a valid custom funding URL and documents when the original configuration can be restored. |
| README.md | Updates the Sponsor badge and footer link to use the same dashboard signup destination as the repository funding configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make repo Sponsor button clickable"](https://github.com/supercompress/supercompress/commit/cf43cf3d7d7519e5197debeffd007786121e6fd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53646613)</sub>

<!-- /greptile_comment -->