### PR TITLE
feat(web): footer Social links — GitHub + X

### DIFF
--- a/web/404.html
+++ b/web/404.html
@@ -25,7 +25,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/landing-motion.css?v=8" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     .nf {
       min-height: calc(100vh - var(--nav-h) - 120px);
@@ -147,8 +147,7 @@
     </div>
   </header>
   <div class="df-header-spacer" aria-hidden="true"></div>
-
-  <main class="nf">
+<main class="nf">
     <div class="nf-inner">
       <p class="nf-kicker">404</p>
       <h1 class="nf-code" aria-label="404">4<em>0</em>4</h1>
@@ -187,20 +186,59 @@
               <li><a href="/changelog">Changelog</a></li>
               <li><a href="https://docs.supercompress.dev">Docs</a></li>
               <li><a href="/dashboard?signup=1">Get API key</a></li>
+              <li><a href="/dashboard?login=1">Log in</a></li>
             </ul>
           </div>
           <div>
             <p class="df-footer-heading">Resources</p>
             <ul>
               <li><a href="/playground">Playground</a></li>
-              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
               <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
               <li><a href="/compare">Compare methods</a></li>
+              <li><a href="/research">Research</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Blog</p>
+            <ul>
+              <li><a href="/reduce-llm-costs">Reduce LLM costs</a></li>
+              <li><a href="/token-compression">Token compression</a></li>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/supercompress-vs-headroom">vs Headroom</a></li>
+              <li><a href="/supercompress-vs-truncation">Vs truncation</a></li>
+              <li><a href="/supercompress-vs-summarization">Vs summarization</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="https://docs.supercompress.dev">Documentation</a></li>
+              <li><a href="https://docs.supercompress.dev/quickstart">Quickstart</a></li>
+              <li><a href="https://docs.supercompress.dev/api-reference">API reference</a></li>
+              <li><a href="https://docs.supercompress.dev/environment">Environment</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
 

--- a/web/affiliates.html
+++ b/web/affiliates.html
@@ -23,7 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <meta name="theme-color" content="rgb(251,251,248)" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=111" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     /* ── Affiliate self-serve page ── */
     .aff-hero {
@@ -854,11 +854,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/agent-memory-compression.html
+++ b/web/agent-memory-compression.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -182,11 +182,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/ai-search.html
+++ b/web/ai-search.html
@@ -23,7 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -282,11 +282,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/aiscore.html
+++ b/web/aiscore.html
@@ -12,7 +12,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/aiscore.css?v=3" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 </head>
 <body>
 <header class="df-header">
@@ -171,11 +171,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/aiscore.js?v=3"></script>

--- a/web/analytics.html
+++ b/web/analytics.html
@@ -10,11 +10,131 @@
   <script>
     location.replace("/dashboard?panel=analytics");
   </script>
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 </head>
 <body>
-  <p style="font-family:system-ui,sans-serif;padding:24px">
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="https://docs.supercompress.dev">Docs</a>
+        </nav>
+        <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="https://docs.supercompress.dev">Docs</a>
+      <a href="/dashboard?signup=1">Get API key</a>
+      <a href="/dashboard?login=1">Log in</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
+<p style="font-family:system-ui,sans-serif;padding:24px">
     Analytics lives in the API dashboard —
     <a href="/dashboard?panel=analytics">continue</a>.
   </p>
+<footer class="df-footer">
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
+        </div>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="https://docs.supercompress.dev">Docs</a></li>
+              <li><a href="/dashboard?signup=1">Get API key</a></li>
+              <li><a href="/dashboard?login=1">Log in</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+              <li><a href="/compare">Compare methods</a></li>
+              <li><a href="/research">Research</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Blog</p>
+            <ul>
+              <li><a href="/reduce-llm-costs">Reduce LLM costs</a></li>
+              <li><a href="/token-compression">Token compression</a></li>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/supercompress-vs-headroom">vs Headroom</a></li>
+              <li><a href="/supercompress-vs-truncation">Vs truncation</a></li>
+              <li><a href="/supercompress-vs-summarization">Vs summarization</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="https://docs.supercompress.dev">Documentation</a></li>
+              <li><a href="https://docs.supercompress.dev/quickstart">Quickstart</a></li>
+              <li><a href="https://docs.supercompress.dev/api-reference">API reference</a></li>
+              <li><a href="https://docs.supercompress.dev/environment">Environment</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
+    </div>
+  </footer>
+  <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>
 </html>

--- a/web/assets/partials/site-footer.html
+++ b/web/assets/partials/site-footer.html
@@ -60,11 +60,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
 <!-- SITE_FOOTER_END -->

--- a/web/benchmarks.html
+++ b/web/benchmarks.html
@@ -27,7 +27,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     .bench-head { text-align: center; padding: 60px 20px 20px; max-width: 860px; margin: 0 auto; }
     .bench-head h1 { font-family: var(--serif); font-weight: 300; font-size: 2.6rem; line-height: 1.15; }
@@ -684,11 +684,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   </div>

--- a/web/better-than-headroom.html
+++ b/web/better-than-headroom.html
@@ -26,7 +26,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -273,11 +273,19 @@ npx supercompress setup</pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/blog.html
+++ b/web/blog.html
@@ -24,7 +24,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=113" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     /* ── Blog-specific overrides ── */
 
@@ -1413,11 +1413,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
 

--- a/web/cache-aligner-prefix-stabilization.html
+++ b/web/cache-aligner-prefix-stabilization.html
@@ -24,7 +24,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -308,11 +308,19 @@ console.log(wrapped);         // Fully wrapped output, ready to send to any LLM<
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -22,7 +22,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=117" />
   <link rel="stylesheet" href="/assets/css/sc-sm.css?v=4" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     /* Changelog uses sc-nav chrome from sc-sm + df-footer from supercompress.css */
     body { background: var(--bg, #fff); }
@@ -508,11 +508,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/coding-agent-proxy.html
+++ b/web/coding-agent-proxy.html
@@ -21,7 +21,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <link rel="stylesheet" href="/assets/css/style.css?v=110" />
@@ -566,11 +566,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
 

--- a/web/compare.html
+++ b/web/compare.html
@@ -322,7 +322,7 @@
     "license": "https://opensource.org/licenses/MIT"
   }
   </script>
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 </head>
 <body>
 <header class="df-header">
@@ -730,11 +730,19 @@ Response Format:
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/context-compression.html
+++ b/web/context-compression.html
@@ -26,7 +26,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -283,11 +283,19 @@ def rag_with_compression(query, retriever, llm):
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/cut-api-costs.html
+++ b/web/cut-api-costs.html
@@ -26,7 +26,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -435,11 +435,19 @@ print(result.compressed_text, result.tokens_saved_pct)</pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -27,7 +27,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <meta name="theme-color" content="rgb(251,251,248)" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=113" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/dashboard-analytics.css?v=3" />
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet" />
 <style>
@@ -1156,6 +1156,7 @@ npm exec supercompress setup</pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
             </ul>
           </div>
           <div>

--- a/web/domain-preprocessors.html
+++ b/web/domain-preprocessors.html
@@ -23,7 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -359,11 +359,19 @@ console.log(`Preprocessor: ${result.preprocessor}`); // "json", "code", "log", o
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/firecrawl-context-compression.html
+++ b/web/firecrawl-context-compression.html
@@ -20,7 +20,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -212,11 +212,19 @@ print(compressed.stats)</code></pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/founder.html
+++ b/web/founder.html
@@ -720,7 +720,7 @@
       .int-auth { padding-top: 36px; }
     }
   </style>
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/dashboard-analytics.css?v=4" />
 </head>
 <body>
@@ -1743,11 +1743,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/headroom-api.html
+++ b/web/headroom-api.html
@@ -26,7 +26,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -309,11 +309,19 @@ npx supercompress setup</code></pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/how-prompt-compression-works.html
+++ b/web/how-prompt-compression-works.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -195,11 +195,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -37,7 +37,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Platypi:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
   <link rel="preload" href="/assets/video/launch-post-poster.jpg?v=5" as="image" fetchpriority="high" />
   <link rel="stylesheet" href="/assets/css/landing-motion.css?v=12" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 
 
 <!-- Preconnect hints for faster external resource loading -->
@@ -749,6 +749,7 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
             </ul>
           </div>
           <div>

--- a/web/live-demo.html
+++ b/web/live-demo.html
@@ -27,7 +27,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
   <link rel="stylesheet" href="/assets/css/live-demo.css?v=1" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <!-- Preconnect hints for faster external resource loading -->
   <link rel="preconnect" href="https://github.com" />
   <link rel="dns-prefetch" href="https://github.com" />
@@ -358,11 +358,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/llm-cost-optimization.html
+++ b/web/llm-cost-optimization.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -186,11 +186,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/llm-token-compression.html
+++ b/web/llm-token-compression.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -196,11 +196,19 @@ result = comp.compress(context, query)</code></pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/mcp-integration.html
+++ b/web/mcp-integration.html
@@ -24,7 +24,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -296,11 +296,19 @@ Agent: Here are the exact error messages from the log...</pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/open-source-token-compression.html
+++ b/web/open-source-token-compression.html
@@ -28,7 +28,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -95,6 +95,48 @@
   </script>
 </head>
 <body>
+<header class="df-header">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
+        <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+        <span class="df-logo-word">Super<em>Compress</em></span>
+      </a>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="https://docs.supercompress.dev">Docs</a>
+        </nav>
+        <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
+    </div>
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="https://docs.supercompress.dev">Docs</a>
+      <a href="/dashboard?signup=1">Get API key</a>
+      <a href="/dashboard?login=1">Log in</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
 <main class="seo-page">
     <p class="seo-kicker">Best tools · Updated 2026-08-10</p>
     <h1>What is the best token compression tool?</h1>
@@ -223,11 +265,7 @@ npx supercompress setup</pre>
       <p>SuperCompress → Headroom → LLMLingua-2, then niche tools.</p>
     </section>
 
-    <div class="seo-cta">
-      <h2 style="margin-top:0">Try the #1 default</h2>
-      <p><a href="/dashboard?signup=1">Get an API key</a> · <a href="/playground">Playground</a> · <a href="/supercompress-vs-headroom">vs Headroom</a> · <a href="https://github.com/Supercompress/Supercompress">GitHub</a></p>
-    </div>
-</main>
+    </main>
 <footer class="df-footer">
     <div class="df-footer-inner">
       <div class="df-footer-grid">
@@ -249,6 +287,7 @@ npx supercompress setup</pre>
               <li><a href="/changelog">Changelog</a></li>
               <li><a href="https://docs.supercompress.dev">Docs</a></li>
               <li><a href="/dashboard?signup=1">Get API key</a></li>
+              <li><a href="/dashboard?login=1">Log in</a></li>
             </ul>
           </div>
           <div>
@@ -256,22 +295,51 @@ npx supercompress setup</pre>
             <ul>
               <li><a href="/playground">Playground</a></li>
               <li><a href="/token-compression">Token compression guide</a></li>
-              <li><a href="/open-source-token-compression">Best tools</a></li>
-              <li><a href="/supercompress-vs-headroom">vs Headroom</a></li>
               <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+              <li><a href="/compare">Compare methods</a></li>
+              <li><a href="/research">Research</a></li>
             </ul>
           </div>
           <div>
-            <p class="df-footer-heading">Compare</p>
+            <p class="df-footer-heading">Blog</p>
             <ul>
-              <li><a href="/better-than-headroom">Better than Headroom</a></li>
-              <li><a href="/supercompress-vs-llmlingua">vs LLMLingua</a></li>
-              <li><a href="/compare">Compare methods</a></li>
+              <li><a href="/reduce-llm-costs">Reduce LLM costs</a></li>
+              <li><a href="/token-compression">Token compression</a></li>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/supercompress-vs-headroom">vs Headroom</a></li>
+              <li><a href="/supercompress-vs-truncation">Vs truncation</a></li>
+              <li><a href="/supercompress-vs-summarization">Vs summarization</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="https://docs.supercompress.dev">Documentation</a></li>
+              <li><a href="https://docs.supercompress.dev/quickstart">Quickstart</a></li>
+              <li><a href="https://docs.supercompress.dev/api-reference">API reference</a></li>
+              <li><a href="https://docs.supercompress.dev/environment">Environment</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/playground.html
+++ b/web/playground.html
@@ -203,7 +203,7 @@
     "license": "https://opensource.org/licenses/MIT"
   }
   </script>
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
 </head>
 <body>
   <header class="df-header">
@@ -577,11 +577,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/precision-mode-compression.html
+++ b/web/precision-mode-compression.html
@@ -23,7 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -320,11 +320,19 @@ console.log(`Confidence: ${result.confidence}, Budget: ${result.budget_ratio}`);
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -21,7 +21,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/legal-page.css?v=2" />
   <script type="application/ld+json">
   {
@@ -37,42 +37,47 @@
 </head>
 <body>
 <header class="df-header">
-  <div class="df-header-blur" aria-hidden="true"></div>
-  <div class="df-header-inner">
-    <a href="/" class="df-logo-desktop">
-      <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-      <span class="df-logo-word">Super<em>Compress</em></span>
-    </a>
-    <div class="df-header-end">
-      <nav class="df-nav-pill" aria-label="Main">
-        <a href="/benchmarks">Benchmarks</a>
-        <a href="/#agents">Agents</a>
-        <a href="/blog">Blog</a>
-        <a href="/changelog">Changelog</a>
-        <a href="https://docs.supercompress.dev">Docs</a>
-      </nav>
-      <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
-    </div>
-    <div class="df-mobile-bar">
-      <a href="/" class="df-logo-mobile">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-        <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        <span class="df-logo-word">Super<em>Compress</em></span>
       </a>
-      <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
-      <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="https://docs.supercompress.dev">Docs</a>
+        </nav>
+        <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
     </div>
-  </div>
-  <div class="df-mobile-nav" id="df-mobile-nav">
-    <a href="/benchmarks">Benchmarks</a>
-    <a href="/blog">Blog</a>
-    <a href="https://docs.supercompress.dev">Docs</a>
-    <a href="/terms">Terms</a>
-    <a href="/privacy" aria-current="page">Privacy</a>
-    <a href="/dashboard?signup=1">Get API key</a>
-  </div>
-</header>
-<div class="df-header-spacer" aria-hidden="true"></div>
-
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="https://docs.supercompress.dev">Docs</a>
+      <a href="/dashboard?signup=1">Get API key</a>
+      <a href="/dashboard?login=1">Log in</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
 <main class="legal-page">
   <p class="legal-kicker">Legal</p>
   <h1>Privacy Policy</h1>
@@ -317,36 +322,81 @@
 </main>
 
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps.</p>
-      </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Legal</p>
-          <ul>
-            <li><a href="/terms">Terms of Service</a></li>
-            <li><a href="/privacy" aria-current="page">Privacy Policy</a></li>
-          </ul>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
         </div>
-        <div>
-          <p class="df-footer-heading">Product</p>
-          <ul>
-            <li><a href="/dashboard?signup=1">Get API key</a></li>
-            <li><a href="https://docs.supercompress.dev">Docs</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-          </ul>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="https://docs.supercompress.dev">Docs</a></li>
+              <li><a href="/dashboard?signup=1">Get API key</a></li>
+              <li><a href="/dashboard?login=1">Log in</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+              <li><a href="/compare">Compare methods</a></li>
+              <li><a href="/research">Research</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Blog</p>
+            <ul>
+              <li><a href="/reduce-llm-costs">Reduce LLM costs</a></li>
+              <li><a href="/token-compression">Token compression</a></li>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/supercompress-vs-headroom">vs Headroom</a></li>
+              <li><a href="/supercompress-vs-truncation">Vs truncation</a></li>
+              <li><a href="/supercompress-vs-summarization">Vs summarization</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="https://docs.supercompress.dev">Documentation</a></li>
+              <li><a href="https://docs.supercompress.dev/quickstart">Quickstart</a></li>
+              <li><a href="https://docs.supercompress.dev/api-reference">API reference</a></li>
+              <li><a href="https://docs.supercompress.dev/environment">Environment</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy" aria-current="page">Privacy Policy</a></li>
+            </ul>
+          </div>
         </div>
       </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy" aria-current="page">Privacy</a></p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
-  </div>
-</footer>
+  </footer>
 <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>
 </html>

--- a/web/prompt-compression-guide.html
+++ b/web/prompt-compression-guide.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <meta charset="UTF-8" />
@@ -451,11 +451,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/prompt-compression.html
+++ b/web/prompt-compression.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -256,11 +256,19 @@ print(f"Removed {result.tokens_removed} tokens")</code></pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/reduce-llm-costs.html
+++ b/web/reduce-llm-costs.html
@@ -26,7 +26,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -421,11 +421,19 @@ print(result.compressed_text, result.tokens_saved_pct)</pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/reduce-openai-costs.html
+++ b/web/reduce-openai-costs.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -188,11 +188,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/research.html
+++ b/web/research.html
@@ -27,7 +27,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <!-- Preconnect hints for faster external resource loading -->
   <link rel="preconnect" href="https://github.com" />
   <link rel="dns-prefetch" href="https://github.com" />
@@ -529,11 +529,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   </div>

--- a/web/reversible-compression-ccr.html
+++ b/web/reversible-compression-ccr.html
@@ -23,7 +23,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -344,11 +344,19 @@ console.log(`Cache: ${stats.entries} entries, ${stats.bytes} bytes`);</pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/supercompress-architecture.html
+++ b/web/supercompress-architecture.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <meta charset="UTF-8" />
@@ -436,11 +436,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/supercompress-vs-alternatives.html
+++ b/web/supercompress-vs-alternatives.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron-48.png?v=3" type="image/png" sizes="48x48" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <meta charset="UTF-8" />
@@ -381,11 +381,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/supercompress-vs-headroom.html
+++ b/web/supercompress-vs-headroom.html
@@ -26,7 +26,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -297,11 +297,19 @@ npx supercompress setup</code></pre>
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/supercompress-vs-llmlingua.html
+++ b/web/supercompress-vs-llmlingua.html
@@ -55,7 +55,7 @@
   }
   </script>
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 </head>
@@ -238,11 +238,19 @@ curl -X POST https://www.supercompress.dev/api/v1/compress \
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
 </body>

--- a/web/supercompress-vs-summarization.html
+++ b/web/supercompress-vs-summarization.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -186,11 +186,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/supercompress-vs-truncation.html
+++ b/web/supercompress-vs-truncation.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -188,11 +188,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/terms.html
+++ b/web/terms.html
@@ -21,7 +21,7 @@
   <link rel="icon" href="/assets/img/favicon-chevron.svg?v=3" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/legal-page.css?v=2" />
   <script type="application/ld+json">
   {
@@ -37,42 +37,47 @@
 </head>
 <body>
 <header class="df-header">
-  <div class="df-header-blur" aria-hidden="true"></div>
-  <div class="df-header-inner">
-    <a href="/" class="df-logo-desktop">
-      <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-      <span class="df-logo-word">Super<em>Compress</em></span>
-    </a>
-    <div class="df-header-end">
-      <nav class="df-nav-pill" aria-label="Main">
-        <a href="/benchmarks">Benchmarks</a>
-        <a href="/#agents">Agents</a>
-        <a href="/blog">Blog</a>
-        <a href="/changelog">Changelog</a>
-        <a href="https://docs.supercompress.dev">Docs</a>
-      </nav>
-      <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
-    </div>
-    <div class="df-mobile-bar">
-      <a href="/" class="df-logo-mobile">
+    <div class="df-header-blur" aria-hidden="true"></div>
+    <div class="df-header-inner">
+      <a href="/" class="df-logo-desktop">
         <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
-        <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        <span class="df-logo-word">Super<em>Compress</em></span>
       </a>
-      <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
-      <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      <div class="df-header-end">
+        <nav class="df-nav-pill" aria-label="Main">
+          <a href="/benchmarks">Benchmarks</a>
+          <a href="/#agents">Agents</a>
+          <a href="/blog">Blog</a>
+          <a href="/changelog">Changelog</a>
+          <a href="https://docs.supercompress.dev">Docs</a>
+        </nav>
+        <a href="/dashboard?signup=1" class="df-nav-cta">Get API key</a>
+        <a href="https://github.com/Supercompress/Supercompress" class="df-github-link" target="_blank" rel="noopener" aria-label="GitHub">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+      <div class="df-mobile-bar">
+        <a href="/" class="df-logo-mobile">
+          <img src="/assets/img/logo-chevrons.png" alt="" aria-hidden="true" class="sc-logo-mark" width="28" height="28" />
+          <span class="df-logo-word" style="font-size:18px">Super<em>Compress</em></span>
+        </a>
+        <a href="/dashboard?signup=1" class="df-nav-cta df-nav-cta--compact">Get key</a>
+        <button type="button" class="df-menu-btn" aria-label="Menu" aria-expanded="false"><span></span><span></span><span></span></button>
+      </div>
     </div>
-  </div>
-  <div class="df-mobile-nav" id="df-mobile-nav">
-    <a href="/benchmarks">Benchmarks</a>
-    <a href="/blog">Blog</a>
-    <a href="https://docs.supercompress.dev">Docs</a>
-    <a href="/terms" aria-current="page">Terms</a>
-    <a href="/privacy">Privacy</a>
-    <a href="/dashboard?signup=1">Get API key</a>
-  </div>
-</header>
-<div class="df-header-spacer" aria-hidden="true"></div>
-
+    <div class="df-mobile-nav" id="df-mobile-nav">
+      <a href="/benchmarks">Benchmarks</a>
+      <a href="/#agents">Agents</a>
+      <a href="/blog">Blog</a>
+      <a href="/changelog">Changelog</a>
+      <a href="https://docs.supercompress.dev">Docs</a>
+      <a href="/dashboard?signup=1">Get API key</a>
+      <a href="/dashboard?login=1">Log in</a>
+      <a href="/playground">Playground</a>
+      <a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a>
+    </div>
+  </header>
+  <div class="df-header-spacer" aria-hidden="true"></div>
 <main class="legal-page">
   <p class="legal-kicker">Legal</p>
   <h1>Terms of Service</h1>
@@ -279,36 +284,81 @@
 </main>
 
 <footer class="df-footer">
-  <div class="df-footer-inner">
-    <div class="df-footer-grid">
-      <div class="df-footer-brand">
-        <a href="/" class="df-footer-lockup">
-          <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
-          <p class="df-footer-heading">Super<em>Compress</em></p>
-        </a>
-        <p>Prompt compression for AI apps.</p>
-      </div>
-      <div class="df-footer-links">
-        <div>
-          <p class="df-footer-heading">Legal</p>
-          <ul>
-            <li><a href="/terms" aria-current="page">Terms of Service</a></li>
-            <li><a href="/privacy">Privacy Policy</a></li>
-          </ul>
+    <div class="df-footer-inner">
+      <div class="df-footer-grid">
+        <div class="df-footer-brand">
+          <a href="/" class="df-footer-lockup">
+            <img src="/assets/img/logo-chevrons.png" alt="" class="df-footer-mark" width="28" height="28" />
+            <p class="df-footer-heading">Super<em>Compress</em></p>
+          </a>
+          <p>Prompt compression for AI apps — reduce input tokens before inference.<br />Python library · hosted API · browser demo.</p>
+          <a href="https://github.com/Supercompress/Supercompress" class="df-footer-email">github.com/Supercompress/Supercompress</a>
         </div>
-        <div>
-          <p class="df-footer-heading">Product</p>
-          <ul>
-            <li><a href="/dashboard?signup=1">Get API key</a></li>
-            <li><a href="https://docs.supercompress.dev">Docs</a></li>
-            <li><a href="/benchmarks">Benchmarks</a></li>
-          </ul>
+        <div class="df-footer-links">
+          <div>
+            <p class="df-footer-heading">Navigation</p>
+            <ul>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="/#agents">Agents</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/changelog">Changelog</a></li>
+              <li><a href="https://docs.supercompress.dev">Docs</a></li>
+              <li><a href="/dashboard?signup=1">Get API key</a></li>
+              <li><a href="/dashboard?login=1">Log in</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Resources</p>
+            <ul>
+              <li><a href="/playground">Playground</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
+              <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+              <li><a href="/compare">Compare methods</a></li>
+              <li><a href="/research">Research</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Blog</p>
+            <ul>
+              <li><a href="/reduce-llm-costs">Reduce LLM costs</a></li>
+              <li><a href="/token-compression">Token compression</a></li>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/supercompress-vs-headroom">vs Headroom</a></li>
+              <li><a href="/supercompress-vs-truncation">Vs truncation</a></li>
+              <li><a href="/supercompress-vs-summarization">Vs summarization</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Documentation</p>
+            <ul>
+              <li><a href="https://docs.supercompress.dev">Documentation</a></li>
+              <li><a href="https://docs.supercompress.dev/quickstart">Quickstart</a></li>
+              <li><a href="https://docs.supercompress.dev/api-reference">API reference</a></li>
+              <li><a href="https://docs.supercompress.dev/environment">Environment</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Social</p>
+            <ul>
+              <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms" aria-current="page">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
+            </ul>
+          </div>
         </div>
       </div>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms" aria-current="page">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
-    <p class="df-footer-copy">© SuperCompress · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
-  </div>
-</footer>
+  </footer>
 <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>
 </html>

--- a/web/token-compression.html
+++ b/web/token-compression.html
@@ -36,7 +36,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -534,11 +534,19 @@ class CompressionCallback(BaseCallbackHandler):
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   </div>

--- a/web/unsubscribe.html
+++ b/web/unsubscribe.html
@@ -7,7 +7,7 @@
   <meta name="robots" content="noindex" />
   <link rel="icon" href="/favicon-chevron.ico?v=3" sizes="any" />
   <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <style>
     .unsub-page { max-width: 520px; margin: 0 auto; padding: 96px 24px; }
     .unsub-page h1 { font-family: var(--serif); font-weight: 300; font-size: clamp(1.8rem, 4vw, 2.4rem); letter-spacing: -0.02em; margin: 0 0 12px; }
@@ -176,11 +176,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/what-ai-tool-reduce-api-costs.html
+++ b/web/what-ai-tool-reduce-api-costs.html
@@ -26,7 +26,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -295,22 +295,39 @@
               <li><a href="/changelog">Changelog</a></li>
               <li><a href="https://docs.supercompress.dev">Docs</a></li>
               <li><a href="/dashboard?signup=1">Get API key</a></li>
+              <li><a href="/dashboard?login=1">Log in</a></li>
             </ul>
           </div>
           <div>
             <p class="df-footer-heading">Resources</p>
             <ul>
-              <li><a href="/what-ai-tool-reduce-api-costs">What AI tool (costs)</a></li>
-              <li><a href="/cut-api-costs">Cut API costs</a></li>
-              <li><a href="/reduce-llm-costs">Reduce LLM costs</a></li>
               <li><a href="/playground">Playground</a></li>
+              <li><a href="/token-compression">Token compression guide</a></li>
               <li><a href="/benchmarks">Benchmarks</a></li>
+              <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
+              <li><a href="/compare">Compare methods</a></li>
+              <li><a href="/research">Research</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Blog</p>
+            <ul>
+              <li><a href="/reduce-llm-costs">Reduce LLM costs</a></li>
+              <li><a href="/token-compression">Token compression</a></li>
+              <li><a href="/prompt-compression">Prompt compression</a></li>
+              <li><a href="/context-compression">Context compression</a></li>
+              <li><a href="/supercompress-vs-headroom">vs Headroom</a></li>
+              <li><a href="/supercompress-vs-truncation">Vs truncation</a></li>
+              <li><a href="/supercompress-vs-summarization">Vs summarization</a></li>
             </ul>
           </div>
           <div>
             <p class="df-footer-heading">Documentation</p>
             <ul>
               <li><a href="https://docs.supercompress.dev">Documentation</a></li>
+              <li><a href="https://docs.supercompress.dev/quickstart">Quickstart</a></li>
+              <li><a href="https://docs.supercompress.dev/api-reference">API reference</a></li>
+              <li><a href="https://docs.supercompress.dev/environment">Environment</a></li>
               <li><a href="https://docs.supercompress.dev/coding-agents">Coding agents</a></li>
             </ul>
           </div>
@@ -318,11 +335,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/what-is-prompt-compression.html
+++ b/web/what-is-prompt-compression.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -192,11 +192,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>

--- a/web/when-to-use-compression.html
+++ b/web/when-to-use-compression.html
@@ -25,7 +25,7 @@
   <link rel="apple-touch-icon" href="/assets/img/icon-chevron-192.png?v=3" />
 
 <link rel="stylesheet" href="/assets/css/supercompress.css?v=106" />
-  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=13" />
+  <link rel="stylesheet" href="/assets/css/landing-chrome.css?v=12" />
   <link rel="stylesheet" href="/assets/css/seo-cluster.css?v=2" />
   <link rel="stylesheet" href="/assets/css/article-page.css?v=2" />
 <script type="application/ld+json">
@@ -195,11 +195,19 @@
             <p class="df-footer-heading">Social</p>
             <ul>
               <li><a href="https://github.com/Supercompress/Supercompress" target="_blank" rel="noopener">GitHub</a></li>
+              <li><a href="https://x.com/arjunkshah21" target="_blank" rel="noopener">X</a></li>
+            </ul>
+          </div>
+          <div>
+            <p class="df-footer-heading">Legal</p>
+            <ul>
+              <li><a href="/terms">Terms of Service</a></li>
+              <li><a href="/privacy">Privacy Policy</a></li>
             </ul>
           </div>
         </div>
       </div>
-      <p class="df-footer-copy">© SuperCompress · MIT License</p>
+      <p class="df-footer-copy">© SuperCompress · MIT License · <a href="/terms">Terms</a> · <a href="/privacy">Privacy</a></p>
     </div>
   </footer>
   <script src="/assets/js/site-chrome.js?v=12"></script>


### PR DESCRIPTION
## Summary
- Add **GitHub** (repo) and **X** (`https://x.com/arjunkshah21`) under footer Social
- Keep Legal (Terms / Privacy) in the canonical footer so sync does not drop it
- Sync site chrome across marketing HTML pages

## Test plan
- [ ] Footer Social shows GitHub → https://github.com/Supercompress/Supercompress
- [ ] Footer Social shows X → https://x.com/arjunkshah21
- [ ] Spot-check `/`, `/blog`, `/dashboard` footers after deploy

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds GitHub and X links plus canonical Terms and Privacy navigation to the shared footer, then synchronizes that footer across the marketing site.
- Adds an X link to the Social section.
- Adds a dedicated Legal section and compact legal links in the copyright row.
- Updates the duplicated footer markup across 48 static pages.
- Changes the landing chrome stylesheet query from v13 back to v12.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, although the reused stylesheet cache key and unbalanced six-group desktop footer should be corrected.

The requested links are consistently present, but the pages reuse an older stylesheet URL and the canonical six-group footer does not align with the existing five-column desktop grid.

**Files Needing Attention:** web/index.html, web/assets/partials/site-footer.html, web/assets/css/landing-chrome.css

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/assets/partials/site-footer.html | Adds the requested Social and Legal links, but increases the canonical footer to six groups without a matching desktop grid update. |
| web/assets/css/landing-chrome.css | Its responsive footer rules still define five columns at desktop widths, producing an uneven final row for the six-group footer. |
| web/index.html | Receives the synchronized footer correctly but downgrades the chrome stylesheet cache key from v13 to the previously used v12. |
| web/dashboard.html | Receives the canonical footer additions and shares the site-wide stale stylesheet-key concern. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  P[Canonical site-footer partial] --> S[Footer synchronization script]
  S --> M[Marketing HTML pages]
  M --> G[Six footer link groups]
  G --> B2[Two-column mobile grid]
  G --> B3[Three-column tablet grid]
  G --> B5[Five-column desktop grid]
  B5 --> W[Legal group wraps to second row]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add GitHub and X links to sit..."](https://github.com/supercompress/supercompress/commit/995e973285bb4285988e17ba6ce8d45b44b05c86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53647353)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->