### PR TITLE
fix(proxy): restore systemMsg alias in assembleMessages for backward compatibility

### DIFF
--- a/packages/proxy/src/compressor.js
+++ b/packages/proxy/src/compressor.js
@@ -131,7 +131,7 @@ function assembleMessages(messages) {
     query = "Continue the conversation.";
   }
 
-  return { context: contextParts.join("\n\n"), query, systemMsgs };
+  return { context: contextParts.join("\n\n"), query, systemMsgs, systemMsg: systemMsgs[0] || null };
 }
 
 function detectAgentName() {

--- a/packages/proxy/src/compressor.js
+++ b/packages/proxy/src/compressor.js
@@ -95,7 +95,7 @@ function hasStructuredProtocol(messages) {
  */
 function assembleMessages(messages) {
   if (!messages || messages.length === 0) {
-    return { context: "", query: "", systemMsgs: [] };
+    return { context: "", query: "", systemMsgs: [], systemMsg: null };
   }
 
   const systemMsgs = [];
@@ -110,7 +110,7 @@ function assembleMessages(messages) {
   }
 
   if (nonSystem.length === 0) {
-    return { context: "", query: "", systemMsgs };
+    return { context: "", query: "", systemMsgs, systemMsg: systemMsgs[0] || null };
   }
 
   let query = "";

--- a/packages/proxy/test/review.js
+++ b/packages/proxy/test/review.js
@@ -249,6 +249,7 @@ async function main() {
     assert.match(a.context, /\[assistant\]: reply/);
     assert.equal(a.systemMsgs.length, 1);
     assert.equal(a.systemMsgs[0].content, "sys");
+    assert.equal(a.systemMsg?.content, "sys");
     pass("assembleMessages splits context/query");
   } catch (err) {
     fail("assembleMessages splits context/query", err.message);


### PR DESCRIPTION
### Summary
Restores the `systemMsg` alias (pointing to `systemMsgs[0] || null`) on the object returned by `assembleMessages` in `packages/proxy/src/compressor.js`.

### Problem
When `assembleMessages` was refactored to support multi-system prompts via `systemMsgs: [...]`, callers and test suites (such as `packages/proxy/test/review.js`) expecting the singular `.systemMsg` threw an unhandled `TypeError`:
```text
FAIL assembleMessages splits context/query — Cannot read properties of undefined (reading 'content')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved message handling by making the primary system instruction available alongside the complete set of system instructions.
  * Existing context and query behavior remain unchanged.
  * No visible changes to the user interface or end-user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores the singular `systemMsg` compatibility alias while retaining the complete `systemMsgs` array.
- Returns the first system message through `systemMsg`, or `null` when none exists.
- Adds an assertion for first-system-message selection in the proxy review test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/compressor.js | Adds the backward-compatible `systemMsg` alias consistently across all `assembleMessages` return paths. |
| packages/proxy/test/review.js | Verifies that the compatibility alias selects the first available system message. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(proxy): keep systemMsg alias on empt..."](https://github.com/supercompress/supercompress/commit/35686f21d9f9dc897c638edebf829120f5409adf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53649598)</sub>

<!-- /greptile_comment -->