### PR TITLE
feat(detector): auto-detect VS Code globalStorage MCP settings for Roo Code & Cline

### DIFF
--- a/packages/proxy/src/detector.js
+++ b/packages/proxy/src/detector.js
@@ -404,6 +404,7 @@ function resolveExtensionMcpTargets() {
   if (process.env.APPDATA) {
     baseDirs.push(
       path.join(process.env.APPDATA, "Code", "User", "globalStorage"),
+      path.join(process.env.APPDATA, "Code - Insiders", "User", "globalStorage"),
       path.join(process.env.APPDATA, "Cursor", "User", "globalStorage"),
       path.join(process.env.APPDATA, "VSCodium", "User", "globalStorage"),
       path.join(process.env.APPDATA, "Windsurf", "User", "globalStorage")

--- a/packages/proxy/src/detector.js
+++ b/packages/proxy/src/detector.js
@@ -379,6 +379,58 @@ function shouldWriteMcpTarget(name, filePath, detect) {
   return false;
 }
 
+function resolveExtensionMcpTargets() {
+  const targets = [];
+  const baseDirs = [];
+
+  if (process.platform === "darwin") {
+    baseDirs.push(
+      path.join(HOME, "Library", "Application Support", "Code", "User", "globalStorage"),
+      path.join(HOME, "Library", "Application Support", "Cursor", "User", "globalStorage"),
+      path.join(HOME, "Library", "Application Support", "VSCodium", "User", "globalStorage"),
+      path.join(HOME, "Library", "Application Support", "Windsurf", "User", "globalStorage"),
+      path.join(HOME, "Library", "Application Support", "Code - Insiders", "User", "globalStorage")
+    );
+  }
+
+  baseDirs.push(
+    path.join(HOME, ".config", "Code", "User", "globalStorage"),
+    path.join(HOME, ".config", "Cursor", "User", "globalStorage"),
+    path.join(HOME, ".config", "VSCodium", "User", "globalStorage"),
+    path.join(HOME, ".config", "Windsurf", "User", "globalStorage"),
+    path.join(HOME, ".config", "Code - Insiders", "User", "globalStorage")
+  );
+
+  if (process.env.APPDATA) {
+    baseDirs.push(
+      path.join(process.env.APPDATA, "Code", "User", "globalStorage"),
+      path.join(process.env.APPDATA, "Cursor", "User", "globalStorage"),
+      path.join(process.env.APPDATA, "VSCodium", "User", "globalStorage"),
+      path.join(process.env.APPDATA, "Windsurf", "User", "globalStorage")
+    );
+  }
+
+  const extensions = [
+    { name: "Roo Code", id: "rooveterinaryinc.roo-cline", file: "cline_mcp_settings.json" },
+    { name: "Cline", id: "saoudrizwan.claude-dev", file: "cline_mcp_settings.json" },
+    { name: "Kodu", id: "kodu.kodu", file: "cline_mcp_settings.json" },
+  ];
+
+  for (const base of baseDirs) {
+    for (const ext of extensions) {
+      const extDir = path.join(base, ext.id);
+      const settingsPath = path.join(extDir, "settings", ext.file);
+      targets.push([
+        ext.name,
+        settingsPath,
+        () => fs.existsSync(extDir) || fs.existsSync(settingsPath),
+      ]);
+    }
+  }
+
+  return targets;
+}
+
 function configureMcp() {
   const configured = [];
 
@@ -409,6 +461,7 @@ function configureMcp() {
       commandExists("roo") || fs.existsSync(path.join(HOME, ".roo"))],
     ["Cline", path.join(HOME, ".cline", "mcp.json"), () =>
       fs.existsSync(path.join(HOME, ".cline"))],
+    ...resolveExtensionMcpTargets(),
   ];
 
   for (const [name, filePath, detect] of mcpJsonTargets) {
@@ -420,7 +473,7 @@ function configureMcp() {
       }
       backupFile(filePath);
       writeMcpJson(filePath);
-      configured.push(name);
+      if (!configured.includes(name)) configured.push(name);
     } catch (err) {
       console.error(`  ✗ Failed to configure ${name} MCP: ${err.message}`);
     }
@@ -1726,4 +1779,5 @@ module.exports = {
   writeAgentInstructionFiles,
   installAutoPlugin,
   agentPlugins,
+  resolveExtensionMcpTargets,
 };

--- a/packages/proxy/test/review.js
+++ b/packages/proxy/test/review.js
@@ -557,7 +557,9 @@ async function main() {
     const targetNames = extTargets.map(([name]) => name);
     assert.ok(targetNames.includes("Roo Code"), "Extension targets include Roo Code");
     assert.ok(targetNames.includes("Cline"), "Extension targets include Cline");
+    assert.ok(targetNames.includes("Kodu"), "Extension targets include Kodu");
     assert.ok(extTargets.every(([_, p]) => p.endsWith("cline_mcp_settings.json")), "Extension targets target cline_mcp_settings.json");
+    assert.ok(extTargets.some(([_, p]) => String(p).includes("Code - Insiders")), "targets include Code - Insiders");
     pass("VS Code extension globalStorage MCP targets resolved", `${extTargets.length} targets`);
   } catch (err) {
     fail("live install wiring checks", err.message);

--- a/packages/proxy/test/review.js
+++ b/packages/proxy/test/review.js
@@ -549,6 +549,16 @@ async function main() {
     assert.doesNotMatch(codex, /^\s*openai_base_url\s*=\s*"http:\/\/localhost:8080\/v1"/m);
     assert.match(codex, /\[mcp_servers\.supercompress\]/);
     pass("Codex uses MCP plugin, not openai_base_url proxy");
+
+    // Extension MCP targets validation (Roo Code, Cline, Kodu)
+    const { resolveExtensionMcpTargets } = require(path.join(ROOT, "src/detector.js"));
+    const extTargets = resolveExtensionMcpTargets();
+    assert.ok(Array.isArray(extTargets) && extTargets.length > 0, "resolveExtensionMcpTargets returns array of targets");
+    const targetNames = extTargets.map(([name]) => name);
+    assert.ok(targetNames.includes("Roo Code"), "Extension targets include Roo Code");
+    assert.ok(targetNames.includes("Cline"), "Extension targets include Cline");
+    assert.ok(extTargets.every(([_, p]) => p.endsWith("cline_mcp_settings.json")), "Extension targets target cline_mcp_settings.json");
+    pass("VS Code extension globalStorage MCP targets resolved", `${extTargets.length} targets`);
   } catch (err) {
     fail("live install wiring checks", err.message);
   }


### PR DESCRIPTION
### Summary
Adds cross-platform auto-discovery of VS Code / Cursor / VSCodium / Windsurf `globalStorage` settings for **Roo Code** (`rooveterinaryinc.roo-cline`), **Cline** (`saoudrizwan.claude-dev`), and **Kodu** (`kodu.kodu`).

### Problem
Roo Code and Cline in VS Code/Cursor store their active MCP settings file at `globalStorage/<extension-id>/settings/cline_mcp_settings.json` (macOS `~/Library/Application Support/Code/...`, Linux `~/.config/Code/...`, Windows `%APPDATA%/Code/...`).
Previously, `supercompress setup` only checked home stubs `~/.roo` and `~/.cline`, missing actual VS Code extension installations for developers using Roo Code and Cline.

### Solution
1. Added `resolveExtensionMcpTargets()` in `packages/proxy/src/detector.js` to scan platform `globalStorage` directories across macOS, Linux, and Windows.
2. Injected targets into `configureMcp()` with deduplication.
3. Added unit tests in `packages/proxy/test/review.js` asserting resolution of extension MCP targets.

### Verification
- `node test/review.js` ➔ 24/24 passed cleanly (including 30 resolved extension storage targets)
- `node test/protocol-safety.js` ➔ 7/7 passed cleanly
- `node test/smoke.js` ➔ Passed
- `npm run check:version` ➔ Passed
- `npm run check:stylesheet-paths` ➔ Passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds cross-platform discovery of Roo Code, Cline, and Kodu MCP settings in supported editors’ globalStorage directories.
- Adds editor- and platform-specific extension storage targets to MCP configuration.
- Includes Windows VS Code Insiders discovery.
- Deduplicates configured client names.
- Adds resolver validation to the review test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/detector.js | Adds extension globalStorage target resolution and integrates detected targets into MCP configuration. |
| packages/proxy/test/review.js | Adds validation that extension target resolution returns the expected target categories. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(detector): include Windows Code - In..."](https://github.com/supercompress/supercompress/commit/6c834534367f0caf469c9a4aa16f54074a374d53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53650648)</sub>

<!-- /greptile_comment -->