### PR TITLE
fix(auth): branded password reset via Resend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
         run: node api/_lib/retention.test.js
       - name: Onboarding + power celebrate helpers
         run: node --test api/_lib/onboarding.test.js
+      - name: Password reset copy
+        run: node --test api/_lib/password-reset.test.js
       - name: Compress assets stay in sync
         run: |
           node scripts/sync-compress-assets.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Public page: https://www.supercompress.dev/changelog
 
 ## [Unreleased]
 
+### Auth
+- Password reset emails go through **Resend** (branded SuperCompress template from `hello@supercompress.dev`) instead of Firebase’s unbranded auth mail
+
 ### Ops / safety net
 - Re-enabled GitHub Actions **CI** and **Production smoke** (were `disabled_manually`)
 - Production smoke: daily cron + path-filtered `main` pushes (not `*/15`)

--- a/api/_lib/mail.js
+++ b/api/_lib/mail.js
@@ -768,6 +768,62 @@ async function sendPowerUserEmail(opts) {
   return { ...result, subject: copy.subject, text: copy.text, html: copy.html };
 }
 
+/**
+ * Branded password reset (Resend) — replaces Firebase's unbranded auth email.
+ */
+function passwordResetCopy({ email, resetUrl, firstName }) {
+  const hi = firstName ? `Hey ${firstName}` : "Hey";
+  const subject = "Reset your SuperCompress password";
+  const text = `${hi},
+
+Someone requested a password reset for your SuperCompress account (${email}).
+
+Reset your password (link expires in about an hour):
+${resetUrl}
+
+If you didn't ask for this, you can ignore this email — your password stays the same.
+
+— Arjun
+Founder, SuperCompress
+`;
+
+  const bodyHtml = `
+    ${eyebrow("Account")}
+    ${displayHeadline("Reset your password")}
+    <p style="margin:0 0 14px;">${escapeHtml(hi)},</p>
+    <p style="margin:0 0 14px;">Someone requested a password reset for <strong>${escapeHtml(email)}</strong>. Use the button below — the link expires in about an hour.</p>
+    ${ctaButton("Reset password", resetUrl)}
+    <p style="margin:16px 0 0;font-size:13px;line-height:1.5;color:${MUTED};">If the button doesn’t work, paste this into your browser:<br /><a href="${escapeHtml(resetUrl)}" style="color:${BRAND};word-break:break-all;">${escapeHtml(resetUrl)}</a></p>
+    <p style="margin:18px 0 0;font-size:14px;line-height:1.55;color:${MUTED};">Didn’t request this? Ignore the email — your password won’t change.</p>
+    ${signatureBlock()}
+  `;
+
+  const html = brandedEmailHtml({
+    preheader: "Reset your SuperCompress password — link inside.",
+    title: subject,
+    bodyHtml,
+    kind: "welcome",
+  });
+
+  return { subject, text, html, to: email };
+}
+
+async function sendPasswordResetEmail({ email, resetUrl, firstName, idempotencyKey }) {
+  if (!email || !String(email).includes("@") || !resetUrl) {
+    return { ok: false, error: "missing email or resetUrl" };
+  }
+  const copy = passwordResetCopy({
+    email: String(email).trim(),
+    resetUrl: String(resetUrl).trim(),
+    firstName,
+  });
+  const result = await sendViaResend({
+    ...copy,
+    idempotencyKey: idempotencyKey || null,
+  });
+  return { ...result, subject: copy.subject };
+}
+
 function campaignKind(campaignId) {
   const id = String(campaignId || "");
   if (id.endsWith("-ship") || id.includes("-ship")) return "ship";
@@ -1007,6 +1063,7 @@ module.exports = {
   welcomeCopy,
   powerUserCopy,
   paymentThankYouCopy,
+  passwordResetCopy,
   weeklyCopy,
   shipCopy,
   weeklyEmailCopy,
@@ -1020,6 +1077,7 @@ module.exports = {
   sendWelcomeEmail,
   sendPowerUserEmail,
   sendPaymentThankYouEmail,
+  sendPasswordResetEmail,
   sendWeeklyEmail,
   DEFAULT_FROM,
 };

--- a/api/_lib/password-reset.js
+++ b/api/_lib/password-reset.js
@@ -1,0 +1,91 @@
+/**
+ * Branded password-reset via Firebase Admin link + Resend.
+ * Public endpoint — always returns a generic success payload (no account enumeration).
+ */
+
+const { initFirebaseAdmin } = require("./auth");
+
+const SITE = "https://www.supercompress.dev";
+const CONTINUE_URL = `${SITE}/dashboard?login=1&reset=1`;
+
+function normalizeEmail(raw) {
+  return String(raw || "")
+    .trim()
+    .toLowerCase()
+    .slice(0, 254);
+}
+
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+async function generateResetLink(email) {
+  const admin = require("firebase-admin");
+  if (!initFirebaseAdmin()) {
+    const err = new Error("Auth is not configured");
+    err.status = 503;
+    throw err;
+  }
+  return admin.auth().generatePasswordResetLink(email, {
+    url: CONTINUE_URL,
+    handleCodeInApp: false,
+  });
+}
+
+/**
+ * @returns {{ ok: true, sent?: boolean, detail: string }}
+ */
+async function requestPasswordReset(emailRaw) {
+  const email = normalizeEmail(emailRaw);
+  const generic = {
+    ok: true,
+    detail: "If an account exists for that email, we sent a password reset link. Check inbox and spam.",
+  };
+  if (!isValidEmail(email)) {
+    const err = new Error("Enter a valid email address.");
+    err.status = 400;
+    throw err;
+  }
+
+  let link;
+  try {
+    link = await generateResetLink(email);
+  } catch (err) {
+    const code = String(err?.code || err?.errorInfo?.code || "");
+    // Unknown user / disabled → still look like success (no enumeration).
+    if (
+      code.includes("user-not-found") ||
+      code.includes("invalid-email") ||
+      code.includes("user-disabled")
+    ) {
+      return generic;
+    }
+    console.warn("password-reset link failed:", code || err.message || err);
+    const fail = new Error("Could not start password reset. Try again in a minute.");
+    fail.status = 503;
+    throw fail;
+  }
+
+  const { sendPasswordResetEmail } = require("./mail");
+  const result = await sendPasswordResetEmail({
+    email,
+    resetUrl: link,
+    idempotencyKey: `pwd-reset:${email}:${new Date().toISOString().slice(0, 13)}`,
+  });
+  if (!result.ok) {
+    console.warn("password-reset Resend failed:", result.error || result);
+    const fail = new Error("Could not send reset email. Try again in a minute.");
+    fail.status = 503;
+    throw fail;
+  }
+  return { ...generic, sent: true };
+}
+
+module.exports = {
+  normalizeEmail,
+  isValidEmail,
+  generateResetLink,
+  requestPasswordReset,
+  CONTINUE_URL,
+  SITE,
+};

--- a/api/_lib/password-reset.test.js
+++ b/api/_lib/password-reset.test.js
@@ -9,15 +9,15 @@ const { normalizeEmail, isValidEmail, CONTINUE_URL } = require("./password-reset
 
 describe("password reset helpers", () => {
   it("normalizes and validates email", () => {
-    assert.equal(normalizeEmail("  Foo@Bar.COM "), "foo@bar.com");
-    assert.equal(isValidEmail("a@b.co"), true);
+    assert.equal(normalizeEmail("  User@Example.COM "), "user@example.com");
+    assert.equal(isValidEmail("user@example.com"), true);
     assert.equal(isValidEmail("nope"), false);
   });
 
   it("branded copy includes reset url and site branding cues", () => {
     const url = "https://example.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=abc";
     const copy = passwordResetCopy({
-      email: "you@example.com",
+      email: "user@example.com",
       resetUrl: url,
       firstName: "Arjun",
     });

--- a/api/_lib/password-reset.test.js
+++ b/api/_lib/password-reset.test.js
@@ -1,0 +1,32 @@
+/**
+ * Password-reset copy unit tests (no Resend / Firebase).
+ * Run: node --test api/_lib/password-reset.test.js
+ */
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { passwordResetCopy } = require("./mail");
+const { normalizeEmail, isValidEmail, CONTINUE_URL } = require("./password-reset");
+
+describe("password reset helpers", () => {
+  it("normalizes and validates email", () => {
+    assert.equal(normalizeEmail("  Foo@Bar.COM "), "foo@bar.com");
+    assert.equal(isValidEmail("a@b.co"), true);
+    assert.equal(isValidEmail("nope"), false);
+  });
+
+  it("branded copy includes reset url and site branding cues", () => {
+    const url = "https://example.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=abc";
+    const copy = passwordResetCopy({
+      email: "you@example.com",
+      resetUrl: url,
+      firstName: "Arjun",
+    });
+    assert.match(copy.subject, /password/i);
+    assert.match(copy.text, /Reset your password/i);
+    assert.ok(copy.text.includes(url));
+    assert.ok(copy.html.includes("Reset password"));
+    assert.ok(copy.html.includes("oobCode=abc") || copy.html.includes(url.replace(/&/g, "&amp;")));
+    assert.ok(copy.html.includes("SuperCompress") || copy.html.includes("supercompress"));
+    assert.ok(CONTINUE_URL.includes("supercompress.dev"));
+  });
+});

--- a/api/account.js
+++ b/api/account.js
@@ -817,6 +817,39 @@ module.exports = async (req, res) => {
     }
   }
 
+  // ── Branded password reset (Resend) ──
+  if (op === "password-reset" && req.method === "POST") {
+    const body = readBody(req) || {};
+    const email = String(body.email || "").trim();
+    const { checkRateLimit, clientIp, jsonWithRateLimit } = require("./_lib/http");
+    const { checkDurableRateLimit } = require("./_lib/rate-limit-durable");
+    const { requestPasswordReset } = require("./_lib/password-reset");
+    const ip = clientIp(req);
+    const mem = checkRateLimit(`pwd-reset:${ip}`, 8, 60 * 60_000);
+    if (!mem.allowed) {
+      return jsonWithRateLimit(res, 429, { detail: "Too many reset requests. Try again later." }, mem);
+    }
+    const recipMem = checkRateLimit(`pwd-reset-to:${email.toLowerCase()}`, 3, 60 * 60_000);
+    if (!recipMem.allowed) {
+      // Still look like success — avoid hammering / enumeration.
+      return json(res, 200, {
+        ok: true,
+        detail: "If an account exists for that email, we sent a password reset link. Check inbox and spam.",
+      });
+    }
+    try {
+      const durable = await checkDurableRateLimit(`pwd-reset:${ip}`, 20, 60 * 60_000);
+      if (durable.backend === "firestore" && !durable.allowed) {
+        return jsonWithRateLimit(res, 429, { detail: "Too many reset requests. Try again later." }, durable);
+      }
+    } catch (_) {}
+    try {
+      return json(res, 200, await requestPasswordReset(email));
+    } catch (err) {
+      return json(res, err.status || 500, { detail: err.message || "Could not send reset email" });
+    }
+  }
+
   // ── Onboarding + power-user celebrate ──
   if (
     op === "onboarding" ||
@@ -884,6 +917,7 @@ module.exports = async (req, res) => {
       "weekly-drain",
       "weekly-unsubscribe",
       "weekly-unsub-link",
+      "password-reset",
       "onboarding",
       "onboarding-heard",
       "onboarding-claim",

--- a/web/assets/js/dashboard-api.js
+++ b/web/assets/js/dashboard-api.js
@@ -18,7 +18,6 @@ import {
   EmailAuthProvider,
   reauthenticateWithCredential,
   updatePassword,
-  sendPasswordResetEmail,
 } from "https://www.gstatic.com/firebasejs/11.0.2/firebase-auth.js";
 import { createOnboardingController } from "./dashboard-onboarding.js";
 
@@ -2038,6 +2037,25 @@ async function confirmPasswordChange() {
   }
 }
 
+async function requestBrandedPasswordReset(email) {
+  const clean = String(email || "").trim();
+  if (!clean) throw new Error("Enter your email to receive a password reset link.");
+  // Prefer hosted API even before detectApiMode settles (forgot-password is pre-login).
+  if (apiMode === "local" && !isHostedSite()) {
+    throw new Error("Password reset needs the hosted API. Open https://www.supercompress.dev/dashboard");
+  }
+  const headers = { "Content-Type": "application/json" };
+  if (idToken) headers.Authorization = `Bearer ${idToken}`;
+  const res = await fetch(`${API_BASE}/api/account?op=password-reset`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ email: clean }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.detail || res.statusText || "Could not send reset email.");
+  return data;
+}
+
 async function sendAccountPasswordReset() {
   const user = auth?.currentUser || currentUser;
   const email = user?.email || String($("auth-email")?.value || "").trim();
@@ -2047,8 +2065,8 @@ async function sendAccountPasswordReset() {
     return;
   }
   try {
-    await sendPasswordResetEmail(auth, email);
-    setPasswordModalOk(`Reset link sent to ${email}.`);
+    await requestBrandedPasswordReset(email);
+    setPasswordModalOk(`Reset link sent to ${email}. Check inbox (and spam) — it’s from SuperCompress.`);
     setError("");
   } catch (err) {
     setPasswordModalError(err?.message || "Could not send reset email.");
@@ -2073,22 +2091,18 @@ function initPasswordControls() {
       setError("Enter your email above, then click Forgot password.");
       return;
     }
-    if (!auth) {
-      setError("Auth is still loading — try again in a moment.");
-      return;
-    }
     try {
-      await sendPasswordResetEmail(auth, email);
+      await requestBrandedPasswordReset(email);
       setError("");
       const msg = $("auth-error");
       if (msg) {
-        msg.textContent = `Password reset email sent to ${email}.`;
+        msg.textContent = `Password reset email sent to ${email}. Check inbox and spam — from hello@supercompress.dev.`;
         msg.style.color = "#166534";
         show(msg);
         setTimeout(() => {
           msg.style.color = "";
           hide(msg);
-        }, 5000);
+        }, 7000);
       }
     } catch (err) {
       setError(err?.message || "Could not send reset email.");

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -1177,7 +1177,7 @@ npm exec supercompress setup</pre>
   <script src="/assets/js/dither-kit-lite.js?v=15"></script>
   <script src="/assets/js/analytics-data.js?v=4"></script>
   <script src="/assets/js/dashboard-analytics.js?v=6"></script>
-  <script type="module" src="/assets/js/dashboard-api.js?v=41"></script>
+  <script type="module" src="/assets/js/dashboard-api.js?v=42"></script>
   <script src="assets/js/affiliate-track.js?v=1"></script>
   <script src="/assets/js/site-chrome.js?v=12"></script>
 </body>


### PR DESCRIPTION
## Summary
- Forgot-password / dashboard reset now hits `POST /api/account?op=password-reset`
- Server generates a Firebase reset link, then emails it with the branded Resend template from `hello@supercompress.dev`
- Rate-limited; responses avoid account enumeration

## Test plan
- [x] `node --test api/_lib/password-reset.test.js`
- [ ] On production after deploy: Forgot password with a real account → email from SuperCompress (not Firebase), not spam folder
- [ ] Link still completes password reset and returns to dashboard login

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces Firebase-generated password-reset emails with a branded Resend delivery flow while retaining Firebase-generated reset links.
- Adds a public, generic-response password-reset endpoint with IP and recipient throttling.
- Adds branded HTML and plaintext reset-email content.
- Routes dashboard reset requests through the new endpoint and adds focused helper tests to CI.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking issue was established.

The new endpoint preserves generic unknown-account responses, generates reset links through Firebase, escapes recipient and URL content in the branded email, and routes both dashboard reset entry points through the same server flow.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/_lib/password-reset.js | Generates Firebase reset links, suppresses account-enumeration responses, and delegates branded delivery to Resend. |
| api/account.js | Adds the public password-reset operation with in-memory recipient/IP limits and an optional durable IP limit. |
| api/_lib/mail.js | Adds escaped branded password-reset copy and sends it through the existing Resend abstraction. |
| web/assets/js/dashboard-api.js | Replaces direct Firebase reset-email calls with requests to the branded server endpoint. |
| api/_lib/password-reset.test.js | Tests email normalization and the generated reset-email copy without invoking external services. |
| .github/workflows/ci.yml | Adds the password-reset helper test suite to CI. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User
    participant D as Dashboard
    participant A as Account API
    participant F as Firebase Admin
    participant R as Resend
    U->>D: Request password reset
    D->>A: "POST /api/account?op=password-reset"
    A->>A: Apply rate limits
    A->>F: Generate password-reset link
    F-->>A: Hosted Firebase action URL
    A->>R: Send branded reset email
    R-->>A: Delivery accepted
    A-->>D: Generic success response
    U->>F: Open reset link and set password
    F-->>D: Continue to dashboard login
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: use allowlisted example.com addres..."](https://github.com/supercompress/supercompress/commit/7203254f2ae6abe713c0e1aba94280c711d0a17a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53713777)</sub>

<!-- /greptile_comment -->