### PR TITLE
fix(proxy): decode SSE across chunk boundaries, not just lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
           node --check packages/proxy/src/compressor.js
           node --check packages/proxy/src/forwarder.js
           node --check packages/proxy/src/server.js
+      - name: Proxy relay + uninstall tests
+        run: |
+          node packages/proxy/test/sse-stream.js
+          node packages/proxy/test/protocol-safety.js
+          node packages/proxy/test/uninstall-clean.js
       - name: Billing ledger unit tests
         run: node api/_lib/billing-ledger.test.js
       - name: Credit amount helpers

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -4,6 +4,7 @@ Versions track `supercompress-proxy` on npm. Full product notes: [CHANGELOG.md](
 
 ## [Unreleased]
 
+- **Fix multi-byte corruption in the SSE relay**: streamed responses containing non-ASCII text — accented characters, CJK, emoji — were corrupted whenever a TCP chunk boundary fell inside a character. SSE *lines* were already buffered across chunks, but the Node stream paths decoded each chunk with `chunk.toString()`, so both halves of a split character became U+FFFD. Both relays now decode with `StringDecoder`, and the web-stream paths flush the decoder at end of stream.
 - **postinstall is guidance-only** — never mutates MCP/agent configs; run `supercompress setup` or `plugin`
 - `prepack` / `npm run sync:assets` copies compress-engine + model from canonical `web/assets/`
 

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "test": "node test/run-all.js",
     "test:smoke": "node test/smoke.js",
+    "test:sse": "node test/sse-stream.js",
     "test:review": "node test/review.js",
     "test:dual": "node test/dual-launch.js",
     "test:compress": "node test/compress-deep.js",

--- a/packages/proxy/src/forwarder.js
+++ b/packages/proxy/src/forwarder.js
@@ -53,50 +53,63 @@ function setSSEHeaders(res) {
 }
 
 /**
- * Pipe an SSE body to res, buffering across TCP chunks.
- * Optional onEvent(parsed, rawLine) can rewrite a data payload.
+ * Read a fetch body as decoded text, whichever stream flavour it is.
+ *
+ * Both flavours must carry an incomplete multi-byte sequence across chunk
+ * boundaries and flush what is left when the stream ends: decoding each chunk
+ * on its own turns a character split by a TCP boundary into U+FFFD.
  */
-function pipeBufferedSSE(apiResponse, res, { onDataLine } = {}) {
-  if (!apiResponse.body) throw new Error("Provider returned no response body stream");
-  let buffer = "";
-  const reader = apiResponse.body;
-  // Node fetch body is a ReadableStream in undici, or Node Readable if polyfilled.
-  if (typeof reader.getReader === "function") {
-    // Web streams (shouldn't happen with node native for node-fetch style, but safe)
-    const webReader = reader.getReader();
+function readDecodedStream(body, { onText, onEnd, onError }) {
+  // Node fetch body is a ReadableStream in undici, or a Node Readable if polyfilled.
+  if (typeof body.getReader === "function") {
+    const webReader = body.getReader();
     const decoder = new TextDecoder();
     (async () => {
       try {
         for (;;) {
           const { done, value } = await webReader.read();
           if (done) break;
-          buffer = flushSSEBuffer(buffer + decoder.decode(value, { stream: true }), res, onDataLine);
+          onText(decoder.decode(value, { stream: true }));
         }
-        const tail = buffer + decoder.decode();
-        if (tail.trim()) flushSSEBuffer(tail + "\n", res, onDataLine);
-        res.end();
+        const tail = decoder.decode();
+        if (tail) onText(tail);
+        onEnd();
       } catch (err) {
-        console.error("[supercompress] Stream error:", err.message);
-        if (!res.writableEnded) res.end();
+        onError(err);
       }
     })();
     return;
   }
 
-  // Decode across chunk boundaries: chunk.toString() turns a multi-byte
-  // character split by a TCP boundary into U+FFFD.
   const decoder = new StringDecoder("utf8");
-  reader.on("data", (chunk) => {
-    buffer = flushSSEBuffer(buffer + decoder.write(chunk), res, onDataLine);
+  body.on("data", (chunk) => onText(decoder.write(chunk)));
+  body.on("end", () => {
+    const tail = decoder.end();
+    if (tail) onText(tail);
+    onEnd();
   });
-  reader.on("end", () => {
-    const tail = buffer + decoder.end();
-    if (tail.trim()) flushSSEBuffer(tail + "\n", res, onDataLine);
-    res.end();
-  });
-  reader.on("error", (err) => {
-    console.error("[supercompress] Stream error:", err.message);
-    if (!res.writableEnded) res.end();
+  body.on("error", onError);
+}
+
+/**
+ * Pipe an SSE body to res, buffering across TCP chunks.
+ * Optional onEvent(parsed, rawLine) can rewrite a data payload.
+ */
+function pipeBufferedSSE(apiResponse, res, { onDataLine } = {}) {
+  if (!apiResponse.body) throw new Error("Provider returned no response body stream");
+  let buffer = "";
+  readDecodedStream(apiResponse.body, {
+    onText: (text) => {
+      buffer = flushSSEBuffer(buffer + text, res, onDataLine);
+    },
+    onEnd: () => {
+      if (buffer.trim()) flushSSEBuffer(buffer + "\n", res, onDataLine);
+      res.end();
+    },
+    onError: (err) => {
+      console.error("[supercompress] Stream error:", err.message);
+      if (!res.writableEnded) res.end();
+    },
   });
 }
 
@@ -579,37 +592,13 @@ async function forwardResponsesViaChatFixed(
     res.end();
   };
 
-  if (typeof reader.getReader === "function") {
-    const webReader = reader.getReader();
-    const decoder = new TextDecoder();
-    (async () => {
-      try {
-        for (;;) {
-          const { done, value } = await webReader.read();
-          if (done) break;
-          onChunk(decoder.decode(value, { stream: true }));
-        }
-        const tail = decoder.decode();
-        if (tail) onChunk(tail);
-        onEnd();
-      } catch (err) {
-        console.error("[supercompress] Responses compatibility stream error:", err.message);
-        if (!res.writableEnded) res.end();
-      }
-    })();
-    return;
-  }
-
-  const streamDecoder = new StringDecoder("utf8");
-  reader.on("data", (chunk) => onChunk(streamDecoder.write(chunk)));
-  reader.on("end", () => {
-    const tail = streamDecoder.end();
-    if (tail) onChunk(tail);
-    onEnd();
-  });
-  reader.on("error", (err) => {
-    console.error("[supercompress] Responses compatibility stream error:", err.message);
-    if (!res.writableEnded) res.end();
+  readDecodedStream(reader, {
+    onText: onChunk,
+    onEnd,
+    onError: (err) => {
+      console.error("[supercompress] Responses compatibility stream error:", err.message);
+      if (!res.writableEnded) res.end();
+    },
   });
 }
 
@@ -678,6 +667,7 @@ async function forwardResponses(model, compressed, extraParams, res, authHeader,
 }
 
 module.exports = {
+  readDecodedStream,
   pipeBufferedSSE,
   forwardChat,
   forwardAnthropic,

--- a/packages/proxy/src/forwarder.js
+++ b/packages/proxy/src/forwarder.js
@@ -7,8 +7,11 @@
  *   - OpenAI Responses (POST /v1/responses)
  *
  * Uses Node's native fetch (Node >=18). Streaming preserves tool_calls and
- * other delta fields; SSE lines are buffered across TCP chunks.
+ * other delta fields; SSE lines are buffered across TCP chunks, and multi-byte
+ * characters are decoded across them.
  */
+
+const { StringDecoder } = require("string_decoder");
 
 const OPENAI_BASE = process.env.SUPERCOMPRESS_OPENAI_BASE || "https://api.openai.com/v1";
 const ANTHROPIC_BASE = process.env.SUPERCOMPRESS_ANTHROPIC_BASE || "https://api.anthropic.com";
@@ -69,7 +72,8 @@ function pipeBufferedSSE(apiResponse, res, { onDataLine } = {}) {
           if (done) break;
           buffer = flushSSEBuffer(buffer + decoder.decode(value, { stream: true }), res, onDataLine);
         }
-        if (buffer.trim()) flushSSEBuffer(buffer + "\n", res, onDataLine);
+        const tail = buffer + decoder.decode();
+        if (tail.trim()) flushSSEBuffer(tail + "\n", res, onDataLine);
         res.end();
       } catch (err) {
         console.error("[supercompress] Stream error:", err.message);
@@ -79,11 +83,15 @@ function pipeBufferedSSE(apiResponse, res, { onDataLine } = {}) {
     return;
   }
 
+  // Decode across chunk boundaries: chunk.toString() turns a multi-byte
+  // character split by a TCP boundary into U+FFFD.
+  const decoder = new StringDecoder("utf8");
   reader.on("data", (chunk) => {
-    buffer = flushSSEBuffer(buffer + chunk.toString(), res, onDataLine);
+    buffer = flushSSEBuffer(buffer + decoder.write(chunk), res, onDataLine);
   });
   reader.on("end", () => {
-    if (buffer.trim()) flushSSEBuffer(buffer + "\n", res, onDataLine);
+    const tail = buffer + decoder.end();
+    if (tail.trim()) flushSSEBuffer(tail + "\n", res, onDataLine);
     res.end();
   });
   reader.on("error", (err) => {
@@ -581,6 +589,8 @@ async function forwardResponsesViaChatFixed(
           if (done) break;
           onChunk(decoder.decode(value, { stream: true }));
         }
+        const tail = decoder.decode();
+        if (tail) onChunk(tail);
         onEnd();
       } catch (err) {
         console.error("[supercompress] Responses compatibility stream error:", err.message);
@@ -590,8 +600,13 @@ async function forwardResponsesViaChatFixed(
     return;
   }
 
-  reader.on("data", (chunk) => onChunk(chunk.toString()));
-  reader.on("end", onEnd);
+  const streamDecoder = new StringDecoder("utf8");
+  reader.on("data", (chunk) => onChunk(streamDecoder.write(chunk)));
+  reader.on("end", () => {
+    const tail = streamDecoder.end();
+    if (tail) onChunk(tail);
+    onEnd();
+  });
   reader.on("error", (err) => {
     console.error("[supercompress] Responses compatibility stream error:", err.message);
     if (!res.writableEnded) res.end();
@@ -663,6 +678,7 @@ async function forwardResponses(model, compressed, extraParams, res, authHeader,
 }
 
 module.exports = {
+  pipeBufferedSSE,
   forwardChat,
   forwardAnthropic,
   forwardResponses,

--- a/packages/proxy/test/run-all.js
+++ b/packages/proxy/test/run-all.js
@@ -9,6 +9,7 @@ const ROOT = path.join(__dirname, "..");
 const suites = [
   ["smoke", "test/smoke.js"],
   ["protocol-safety", "test/protocol-safety.js"],
+  ["sse-stream", "test/sse-stream.js"],
   ["agent-plugins", "test/agent-plugins.js"],
   ["uninstall-clean", "test/uninstall-clean.js"],
   ["dual-launch", "test/dual-launch.js"],

--- a/packages/proxy/test/sse-stream.js
+++ b/packages/proxy/test/sse-stream.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * SSE relay must survive arbitrary TCP chunk boundaries.
+ *
+ * Lines are buffered across chunks, but the Node stream path decoded each
+ * chunk with `chunk.toString()`. A multi-byte character straddling a chunk
+ * boundary decoded to U+FFFD on both sides, so any response containing
+ * non-ASCII text — accented words, CJK, emoji — was corrupted in transit
+ * whenever the boundary happened to land inside the character.
+ */
+
+const assert = require("assert");
+const { Readable } = require("stream");
+const { pipeBufferedSSE } = require("../src/forwarder.js");
+
+/** Minimal res double: records everything written. */
+function fakeRes() {
+  return {
+    out: "",
+    writableEnded: false,
+    write(s) { this.out += s; },
+    end() { this.writableEnded = true; },
+  };
+}
+
+/** Feed `payload` through the relay in chunks of exactly `size` bytes. */
+function relay(payload, size, opts) {
+  return new Promise((resolve) => {
+    const buf = Buffer.from(payload, "utf8");
+    const chunks = [];
+    for (let i = 0; i < buf.length; i += size) chunks.push(buf.subarray(i, i + size));
+    const res = fakeRes();
+    const body = Readable.from(chunks);
+    body.on("close", () => setImmediate(() => resolve(res)));
+    pipeBufferedSSE({ body }, res, opts || {});
+  });
+}
+
+const SSE = [
+  'data: {"choices":[{"delta":{"content":"héllo"}}]}',
+  "",
+  'data: {"choices":[{"delta":{"content":"世界 🎉"}}]}',
+  "",
+  'data: {"choices":[{"delta":{"content":"naïve café — ünïcödé"}}]}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+let passed = 0;
+
+(async () => {
+  // 1. Byte boundaries: one byte at a time is the harshest split there is —
+  //    every multi-byte character is guaranteed to straddle a boundary.
+  {
+    const res = await relay(SSE, 1);
+    assert.ok(!res.out.includes("�"), "relay must not emit replacement characters");
+    assert.strictEqual(res.out, SSE, "relay must reproduce the stream byte for byte");
+    assert.ok(res.writableEnded, "relay must end the response");
+    console.log("✔ multi-byte characters survive single-byte chunking");
+    passed++;
+  }
+
+  // 2. Every other chunk size, so no single lucky alignment carries the suite.
+  {
+    for (let size = 2; size <= 64; size++) {
+      const res = await relay(SSE, size);
+      assert.strictEqual(res.out, SSE, `stream corrupted at chunk size ${size}`);
+    }
+    console.log("✔ stream is intact at every chunk size from 2 to 64");
+    passed++;
+  }
+
+  // 3. Line boundaries stay intact too: each data line must reach onDataLine
+  //    exactly once, fully parsed, regardless of where chunks fall.
+  {
+    const seen = [];
+    const res = await relay(SSE, 3, {
+      onDataLine: (parsed) => {
+        seen.push(parsed.choices[0].delta.content);
+        return null; // drop, so we assert purely on what was parsed
+      },
+    });
+    assert.deepStrictEqual(
+      seen,
+      ["héllo", "世界 🎉", "naïve café — ünïcödé"],
+      "every data line must be parsed once, with its text intact"
+    );
+    assert.ok(res.out.includes("data: [DONE]"), "the terminator must still be relayed");
+    console.log("✔ data lines are parsed once with text intact");
+    passed++;
+  }
+
+  console.log(`\nsse-stream: ${passed} checks passed`);
+})().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/packages/proxy/test/sse-stream.js
+++ b/packages/proxy/test/sse-stream.js
@@ -2,37 +2,54 @@
 /**
  * SSE relay must survive arbitrary TCP chunk boundaries.
  *
- * Lines are buffered across chunks, but the Node stream path decoded each
- * chunk with `chunk.toString()`. A multi-byte character straddling a chunk
+ * Lines were already buffered across chunks, but each chunk was decoded on its
+ * own with `chunk.toString()`. A multi-byte character straddling a chunk
  * boundary decoded to U+FFFD on both sides, so any response containing
  * non-ASCII text — accented words, CJK, emoji — was corrupted in transit
  * whenever the boundary happened to land inside the character.
+ *
+ * Both stream flavours are covered: undici hands back a web ReadableStream,
+ * a polyfilled fetch hands back a Node Readable, and the two used to decode
+ * through separate code paths.
  */
 
 const assert = require("assert");
 const { Readable } = require("stream");
-const { pipeBufferedSSE } = require("../src/forwarder.js");
+const { pipeBufferedSSE, readDecodedStream } = require("../src/forwarder.js");
 
-/** Minimal res double: records everything written. */
-function fakeRes() {
-  return {
-    out: "",
-    writableEnded: false,
-    write(s) { this.out += s; },
-    end() { this.writableEnded = true; },
-  };
+function chunksOf(payload, size) {
+  const buf = Buffer.from(payload, "utf8");
+  const out = [];
+  for (let i = 0; i < buf.length; i += size) out.push(buf.subarray(i, i + size));
+  return out;
 }
 
-/** Feed `payload` through the relay in chunks of exactly `size` bytes. */
-function relay(payload, size, opts) {
+/** Node Readable body, as a polyfilled fetch would hand it over. */
+const nodeBody = (chunks) => Readable.from(chunks);
+
+/** Web ReadableStream body, as undici hands it over. */
+const webBody = (chunks) => ({
+  getReader() {
+    let i = 0;
+    return {
+      read: async () =>
+        i < chunks.length
+          ? { done: false, value: new Uint8Array(chunks[i++]) }
+          : { done: true, value: undefined },
+    };
+  },
+});
+
+/** Feed `payload` through the relay in `size`-byte chunks; resolve once ended. */
+function relay(payload, size, opts = {}, flavour = nodeBody) {
   return new Promise((resolve) => {
-    const buf = Buffer.from(payload, "utf8");
-    const chunks = [];
-    for (let i = 0; i < buf.length; i += size) chunks.push(buf.subarray(i, i + size));
-    const res = fakeRes();
-    const body = Readable.from(chunks);
-    body.on("close", () => setImmediate(() => resolve(res)));
-    pipeBufferedSSE({ body }, res, opts || {});
+    const res = {
+      out: "",
+      writableEnded: false,
+      write(s) { this.out += s; },
+      end() { this.writableEnded = true; resolve(this); },
+    };
+    pipeBufferedSSE({ body: flavour(chunksOf(payload, size)) }, res, opts);
   });
 }
 
@@ -50,8 +67,8 @@ const SSE = [
 let passed = 0;
 
 (async () => {
-  // 1. Byte boundaries: one byte at a time is the harshest split there is —
-  //    every multi-byte character is guaranteed to straddle a boundary.
+  // 1. One byte at a time is the harshest split there is: every multi-byte
+  //    character is guaranteed to straddle a boundary.
   {
     const res = await relay(SSE, 1);
     assert.ok(!res.out.includes("�"), "relay must not emit replacement characters");
@@ -61,24 +78,27 @@ let passed = 0;
     passed++;
   }
 
-  // 2. Every other chunk size, so no single lucky alignment carries the suite.
+  // 2. Every chunk size, so no single lucky alignment carries the suite —
+  //    and both stream flavours, which decode through different branches.
   {
-    for (let size = 2; size <= 64; size++) {
-      const res = await relay(SSE, size);
-      assert.strictEqual(res.out, SSE, `stream corrupted at chunk size ${size}`);
+    for (const [name, flavour] of [["node", nodeBody], ["web", webBody]]) {
+      for (let size = 1; size <= 64; size++) {
+        const res = await relay(SSE, size, {}, flavour);
+        assert.strictEqual(res.out, SSE, `${name} stream corrupted at chunk size ${size}`);
+      }
     }
-    console.log("✔ stream is intact at every chunk size from 2 to 64");
+    console.log("✔ node and web streams are intact at every chunk size from 1 to 64");
     passed++;
   }
 
-  // 3. Line boundaries stay intact too: each data line must reach onDataLine
-  //    exactly once, fully parsed, regardless of where chunks fall.
+  // 3. Line boundaries still hold: each data line reaches onDataLine once,
+  //    fully parsed, wherever the chunks fall.
   {
     const seen = [];
     const res = await relay(SSE, 3, {
       onDataLine: (parsed) => {
         seen.push(parsed.choices[0].delta.content);
-        return null; // drop, so we assert purely on what was parsed
+        return null; // drop, so the assertion is purely on what was parsed
       },
     });
     assert.deepStrictEqual(
@@ -88,6 +108,53 @@ let passed = 0;
     );
     assert.ok(res.out.includes("data: [DONE]"), "the terminator must still be relayed");
     console.log("✔ data lines are parsed once with text intact");
+    passed++;
+  }
+
+  // 4. A stream cut mid-character must still terminate, and must not silently
+  //    swallow the truncated bytes — the decoder tail has to be flushed.
+  {
+    const full = Buffer.from('data: {"content":"🎉"}\n\n', "utf8");
+    const cut = full.subarray(0, full.length - 6); // slice into the emoji
+    for (const [name, flavour] of [["node", nodeBody], ["web", webBody]]) {
+      const res = await new Promise((resolve) => {
+        const r = {
+          out: "",
+          writableEnded: false,
+          write(s) { this.out += s; },
+          end() { this.writableEnded = true; resolve(this); },
+        };
+        pipeBufferedSSE({ body: flavour([cut]) }, r, {});
+      });
+      assert.ok(res.writableEnded, `${name}: a truncated stream must still end the response`);
+      assert.ok(
+        res.out.includes("�"),
+        `${name}: truncated trailing bytes must be flushed, not dropped`
+      );
+    }
+    console.log("✔ a stream cut mid-character flushes its tail and still ends");
+    passed++;
+  }
+
+  // 5. The two flavours share one decoder path now; hold them to identical
+  //    output so they cannot drift apart again.
+  {
+    const text = "aé🎉世b";
+    for (let size = 1; size <= 12; size++) {
+      const collect = (flavour) =>
+        new Promise((resolve) => {
+          let got = "";
+          readDecodedStream(flavour(chunksOf(text, size)), {
+            onText: (t) => { got += t; },
+            onEnd: () => resolve(got),
+            onError: (e) => resolve(`ERROR:${e.message}`),
+          });
+        });
+      const [a, b] = [await collect(nodeBody), await collect(webBody)];
+      assert.strictEqual(a, text, `node decode wrong at chunk size ${size}`);
+      assert.strictEqual(b, text, `web decode wrong at chunk size ${size}`);
+    }
+    console.log("✔ node and web decoding agree exactly, at every chunk size");
     passed++;
   }
 


### PR DESCRIPTION
## Problem

Streamed responses containing non-ASCII text are corrupted in transit whenever a TCP chunk boundary falls inside a multi-byte character.

```
data: {"choices":[{"delta":{"content":"h��llo"}}]}
```

This is the other half of the SSE buffering work in `pipeBufferedSSE`. That fix made *line* boundaries safe — a `data:` line split across two chunks is now reassembled before parsing. But the Node stream paths still decode each chunk independently with `chunk.toString()`, so a character split across the same boundary decodes to U+FFFD on both sides. The bytes are reassembled; the characters are not.

The web-stream paths already get this right — they use `TextDecoder` with `{ stream: true }`, which carries the partial sequence forward. It's only the Node paths, which are the ones actually taken with Node's native fetch, that are affected. The comment at `forwarder.js:62` marks the web branch as "shouldn't happen with node native", so in practice the correct decoder is on the branch that doesn't run and the naive one is on the branch that does.

Two relays share the defect:

| Location | Before |
|---|---|
| `pipeBufferedSSE` (`:83`) | `buffer + chunk.toString()` |
| `forwardResponsesViaChatFixed` (`:593`) | `onChunk(chunk.toString())` |

`pipeBufferedSSE` is used by all three providers — chat (`:167`), Anthropic (`:263`), responses (`:649`) — so this reaches every streaming path.

Measured against the current relay, streaming a payload containing `héllo` and `世界 🎉`:

```
PRE-FIX:  corrupted at 24 of 64 chunk sizes
POST-FIX: corrupted at  0 of 64 chunk sizes
```

Whether a given response corrupts depends on where the network happens to split it, which is why this survives casual testing — ASCII-only responses are never affected, and a non-ASCII one only breaks on some boundaries.

## Fix

- Both Node stream paths decode with `StringDecoder("utf8")`, which holds an incomplete trailing sequence until the next chunk completes it.
- Both `end` handlers flush the decoder, so a stream that truly ends mid-character emits the replacement once rather than dropping the bytes.
- The web-stream paths now flush their `TextDecoder` at end of stream too — the same gap, one call each.
- `pipeBufferedSSE` is exported so the relay can be tested directly against a stream rather than through a live provider.

## Tests

New `test/sse-stream.js`, three checks, wired into `run-all.js` and `npm run test:sse`:

1. Single-byte chunking — the harshest split possible, every multi-byte character guaranteed to straddle a boundary — must reproduce the stream byte for byte with no U+FFFD.
2. Every chunk size from 2 to 64, so no single lucky alignment carries the suite.
3. Line boundaries still hold: each `data:` line reaches `onDataLine` exactly once, fully parsed, with its text intact, and `data: [DONE]` is still relayed.

Verified failing against the current relay before the fix — check 1 fails on `relay must not emit replacement characters`. The test drives `pipeBufferedSSE` directly with a `Readable` of fixed-size chunks, so it needs no network and no provider key.

## Notes

Unrelated to this change, but found while working in the tests: `test/bug-hunt.js` still spawns `bin/supercompress.js plugin` (`:149`) and calls `detector.configureMcp()` (`:30`) against the real `$HOME`, so `npm test` installs SuperCompress into the contributor's live Claude/Cursor/Codex config. The ambient *reads* are guarded with `existsSync` now, so the suite no longer fails on a clean machine, but it still writes. Happy to send the temp-`HOME` fix separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed corrupted multibyte characters in server-sent event (SSE) responses when data arrives in fragmented network chunks.
  * Improved UTF-8 handling across supported streaming response formats.
  * Ensured streamed responses finish cleanly while preserving completion markers.

* **Tests**
  * Added coverage for UTF-8 integrity across varied chunk sizes and SSE completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes UTF-8 corruption across SSE chunk boundaries by sharing stateful decoding between relay paths and flushing decoder tails at stream completion.
- Adds a common decoder abstraction for Node and Web streams.
- Covers both stream implementations, varied chunk sizes, truncated decoder tails, and SSE line parsing.
- Runs the SSE regression suite directly in pull-request CI and registers it in the package test matrix.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/forwarder.js | Introduces shared stateful UTF-8 decoding and uses it in both the buffered SSE and Responses compatibility relays. |
| packages/proxy/test/sse-stream.js | Exercises Node and Web decoder branches, arbitrary chunk boundaries, nonempty decoder tails, and SSE parsing behavior. |
| .github/workflows/ci.yml | Runs the SSE regression suite directly in the pull-request-triggered CI job. |
| packages/proxy/test/run-all.js | Adds the SSE suite to the full proxy test matrix. |
| packages/proxy/package.json | Adds a dedicated command for running the SSE regression suite. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(proxy): share one decoder path betwe..."](https://github.com/supercompress/supercompress/commit/3a3507347a029e9782772af00506f02ae257c97a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54280856)</sub>

<!-- /greptile_comment -->