### PR TITLE
docs: prefer GitHub private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,14 +8,18 @@ Please report vulnerabilities against the latest published PyPI release and the 
 
 Do **not** open a public issue for security reports.
 
-Email [arjunkshah21@gmail.com](mailto:arjunkshah21@gmail.com), and include:
+**Preferred:** [GitHub Private vulnerability reporting](https://github.com/Supercompress/Supercompress/security/advisories/new) on this repository (Settings → Code security and analysis → Private vulnerability reporting). Use this for full reproduction steps, PoCs, and proposed fixes.
+
+**Also accepted:** email [arjunkshah21@gmail.com](mailto:arjunkshah21@gmail.com) for initial contact only. If the report includes exploit details, we will ask you to move the full write-up to GitHub private reporting or another encrypted channel.
+
+Include:
 
 - Description of the issue
 - Steps to reproduce
 - Impact assessment (auth bypass, key leakage, data exposure, DoS, etc.)
 - Any proof-of-concept limited to a private report
 
-We will acknowledge receipt and work on a fix before any public disclosure.
+We will acknowledge receipt within a few business days and work on a fix before any public disclosure.
 
 ## API keys
 


### PR DESCRIPTION
## Summary
- Prefer GitHub Private vulnerability reporting for full PoCs / repro steps
- Keep email for initial contact only
- Responds to an external researcher request for a secure channel

## Test plan
- [x] Read SECURITY.md locally
- [ ] Enable Private vulnerability reporting in repo Settings (manual org toggle)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the security policy to make GitHub Private Vulnerability Reporting the preferred channel for complete vulnerability reports while retaining email for initial contact.

- Adds a direct link to GitHub’s private advisory form.
- Clarifies which details researchers should include and sets an acknowledgment target of a few business days.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge once the already-documented private vulnerability reporting setting is enabled.

No actionable code or documentation defect remains beyond the operational prerequisite explicitly tracked in the PR test plan.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SECURITY.md | Clearly redirects sensitive vulnerability details to private reporting and retains email as an initial-contact option; the required GitHub setting is already identified as a manual prerequisite. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: prefer GitHub private vulnerabilit..."](https://github.com/supercompress/supercompress/commit/ca9738ee03125601254807976bc9249d22121b7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54971787)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vulnerability-reporting guidance to prioritize GitHub Private vulnerability reporting.
  * Clarified that email is for initial contact only and exploit details must be encrypted.
  * Added expected acknowledgment timing for submitted reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->