### PR TITLE
docs: add "first 5 minutes" coding-agent setup checklist (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The **query is never compressed** — only the surrounding context.
 | **What you get** | MCP `compress_context` on big dumps | Compress before every model call |
 | **Login** | Keep your normal agent login | API key from the [dashboard](https://www.supercompress.dev/dashboard) |
 
-Docs: [coding agents](https://docs.supercompress.dev/coding-agents) · [API quickstart](https://docs.supercompress.dev/quickstart)
+Docs: [coding agents (first 5 minutes checklist)](https://docs.supercompress.dev/coding-agents#quickstart) · [API quickstart](https://docs.supercompress.dev/quickstart)
 
 ### Repo map
 

--- a/web/docs/coding-agents.html
+++ b/web/docs/coding-agents.html
@@ -97,6 +97,7 @@
         <div class="doc-toc">
           <h3>In this guide</h3>
           <ol>
+            <li><a href="#quickstart">First 5 minutes checklist</a></li>
             <li><a href="#how-it-works">How it works</a></li>
             <li><a href="#install">Install</a></li>
             <li><a href="#plugin">Detect + plugin</a></li>
@@ -106,6 +107,44 @@
             <li><a href="#proxy">Optional API proxy</a></li>
             <li><a href="#uninstall">Uninstall</a></li>
           </ol>
+        </div>
+
+        <h2 id="quickstart">First 5 minutes checklist</h2>
+        <p>Get SuperCompress running with your coding agents in 4 quick copy-paste steps:</p>
+
+        <div class="doc-steps">
+          <div class="doc-step">
+            <span class="doc-step-n">1</span>
+            <div>
+              <strong>Install &amp; link account</strong>
+              <p>Install the CLI globally and run one-time setup to connect your account and auto-configure detected agents:</p>
+              <pre><code><span class="kw">npm install</span> -g supercompress-proxy
+<span class="kw">supercompress</span> setup</code></pre>
+            </div>
+          </div>
+          <div class="doc-step">
+            <span class="doc-step-n">2</span>
+            <div>
+              <strong>Verify agent detection</strong>
+              <p>Confirm which coding agents on your machine were detected and hooked:</p>
+              <pre><code><span class="kw">supercompress</span> agents</code></pre>
+            </div>
+          </div>
+          <div class="doc-step">
+            <span class="doc-step-n">3</span>
+            <div>
+              <strong>Test MCP connectivity</strong>
+              <p>Verify that the SuperCompress MCP server is responsive locally:</p>
+              <pre><code><span class="kw">supercompress</span> mcp-check</code></pre>
+            </div>
+          </div>
+          <div class="doc-step">
+            <span class="doc-step-n">4</span>
+            <div>
+              <strong>Restart agent &amp; compress</strong>
+              <p>Restart Cursor, Claude Code, Codex, Roo Code, or Cline so the MCP server initializes. Your agent will now automatically call <code>compress_context</code> on bulky context dumps!</p>
+            </div>
+          </div>
         </div>
 
         <h2 id="how-it-works">How it works</h2>


### PR DESCRIPTION
Fixes #132

### Summary
Adds a clear, copy-paste-friendly "First 5 minutes" quickstart checklist to `web/docs/coding-agents.html` and links it from `README.md`, making it fast and effortless for new contributors and users to install, detect, verify MCP connectivity, and test compression.

---

### 🔍 Changes Made
1. **`web/docs/coding-agents.html`**:
   - Added `#quickstart` entry to the Table of Contents.
   - Added the 4-step checklist:
     1. `npm install -g supercompress-proxy && supercompress setup` (Install & link account)
     2. `supercompress agents` (Verify agent detection across Cursor, Claude Code, Codex, Roo Code, Cline, etc.)
     3. `supercompress mcp-check` (Test local MCP server response)
     4. Restart agent & enjoy automatic `compress_context` on bulky dumps.
2. **`README.md`**:
   - Linked directly to the First 5 minutes checklist under the Coding-agent plugin section.

---

### ✅ Verification
- `npm run check:version` ➔ **All version consistency checks passed successfully**
- `node test/run-all.js` ➔ **ALL 10 suites passed (passed=24 failed=0 total=24)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “First 5 minutes checklist” to the Coding Agents documentation.
  * Documented setup, agent detection, MCP connectivity checks, and restarting the coding agent.
  * Updated the product comparison table to link directly to the new quickstart section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a four-step “First 5 minutes” coding-agent checklist and links directly to it from the README.
- Adds installation, agent-detection, local MCP-check, and restart guidance.
- Adds the checklist to the page table of contents and links its anchor from the README.
- Two checklist statements overstate what the underlying CLI setup and verification commands guarantee.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after correcting two non-blocking but misleading onboarding claims about automatic compression and hook verification.

The new checklist links and commands are valid, but Roo Code and Cline receive only MCP registration rather than automatic compression wiring, and `supercompress agents` reports detection rather than verifying installed hooks.

**Files Needing Attention:** web/docs/coding-agents.html

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| web/docs/coding-agents.html | Adds the onboarding checklist, but overstates automatic compression support for Roo Code/Cline and what the `agents` command verifies. |
| README.md | Updates the coding-agent documentation link to target the new quickstart anchor without introducing an independent issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add first 5 minutes coding-agent s..."](https://github.com/supercompress/supercompress/commit/7b0f5acec7ce3e22e9e04accffb8d4a27c826138) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55495379)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->