### PR TITLE
ci: surface version-check failures with remediation hints (#133)

### DIFF
--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -18,14 +18,22 @@ function readJson(relPath) {
   }
 }
 
-console.log('🔍 Checking version consistency across SuperCompress packages...');
-
 let hasErrors = false;
+const remediationHints = [];
+
+function recordError(msg, hint) {
+  console.error(`❌ ${msg}`);
+  hasErrors = true;
+  if (hint) {
+    remediationHints.push({ error: msg, hint });
+  }
+}
 
 // 1. Read packages/proxy/package.json
 const proxyPkg = readJson('packages/proxy/package.json');
 if (!proxyPkg || !proxyPkg.version) {
   console.error('❌ Missing or unparseable packages/proxy/package.json');
+  console.error('🔧 Fix hint: Ensure packages/proxy/package.json exists with a valid "version" field.');
   process.exit(1);
 }
 
@@ -35,11 +43,12 @@ console.log(`📦 packages/proxy/package.json version: ${proxyVersion}`);
 // 2. Check packages/proxy/package-lock.json (Fail closed if missing)
 const proxyLock = readJson('packages/proxy/package-lock.json');
 if (!proxyLock) {
-  console.error('❌ Missing or unparseable packages/proxy/package-lock.json');
-  hasErrors = true;
+  recordError('Missing or unparseable packages/proxy/package-lock.json', 'Run `npm --prefix packages/proxy install --package-lock-only` to generate lockfile.');
 } else if (proxyLock.version !== proxyVersion) {
-  console.error(`❌ Mismatch: packages/proxy/package-lock.json version (${proxyLock.version}) does not match package.json (${proxyVersion})`);
-  hasErrors = true;
+  recordError(
+    `Mismatch: packages/proxy/package-lock.json version (${proxyLock.version}) does not match package.json (${proxyVersion})`,
+    `Run \`npm --prefix packages/proxy version ${proxyVersion} --no-git-tag-version\` or \`npm --prefix packages/proxy install --package-lock-only\` to sync lockfile.`
+  );
 } else {
   console.log(`✅ packages/proxy/package-lock.json version matches (${proxyLock.version})`);
 }
@@ -47,8 +56,7 @@ if (!proxyLock) {
 // 3. Check root package.json dependency on supercompress-proxy (Fail closed if missing)
 const rootPkg = readJson('package.json');
 if (!rootPkg || !rootPkg.dependencies || !rootPkg.dependencies['supercompress-proxy']) {
-  console.error('❌ Missing root package.json or missing supercompress-proxy dependency in root package.json');
-  hasErrors = true;
+  recordError('Missing root package.json or missing supercompress-proxy dependency in root package.json', 'Add `"supercompress-proxy": "^' + proxyVersion + '"` to root package.json dependencies.');
 } else {
   const rootDepRange = rootPkg.dependencies['supercompress-proxy'];
   console.log(`📌 Root package.json supercompress-proxy dependency: ${rootDepRange}`);
@@ -57,13 +65,14 @@ if (!rootPkg || !rootPkg.dependencies || !rootPkg.dependencies['supercompress-pr
   const match = rootDepRange.match(/(\d+\.\d+)/);
   
   if (!match) {
-    console.error(`❌ Root package.json supercompress-proxy dependency range '${rootDepRange}' is not parseable`);
-    hasErrors = true;
+    recordError(`Root package.json supercompress-proxy dependency range '${rootDepRange}' is not parseable`, 'Update root package.json supercompress-proxy dependency to `"^' + proxyVersion + '"`.');
   } else {
     const rootDepMajorMinor = match[1];
     if (rootDepMajorMinor !== proxyMajorMinor) {
-      console.error(`❌ Mismatch: Root package.json pins supercompress-proxy to '${rootDepRange}' (major.minor ${rootDepMajorMinor}) but packages/proxy is at '${proxyVersion}' (major.minor ${proxyMajorMinor})`);
-      hasErrors = true;
+      recordError(
+        `Mismatch: Root package.json pins supercompress-proxy to '${rootDepRange}' (major.minor ${rootDepMajorMinor}) but packages/proxy is at '${proxyVersion}' (major.minor ${proxyMajorMinor})`,
+        `Update root package.json: set "supercompress-proxy": "^${proxyVersion}" then run \`npm install --package-lock-only\`.`
+      );
     } else {
       console.log(`✅ Root package.json dependency range matches proxy major.minor (${proxyMajorMinor})`);
     }
@@ -73,34 +82,34 @@ if (!rootPkg || !rootPkg.dependencies || !rootPkg.dependencies['supercompress-pr
 // 4. Check root package-lock.json (Fail closed if missing or mismatched resolved URL)
 const rootLock = readJson('package-lock.json');
 if (!rootLock) {
-  console.error('❌ Missing or unparseable root package-lock.json');
-  hasErrors = true;
+  recordError('Missing or unparseable root package-lock.json', 'Run `npm install --package-lock-only` to generate root package-lock.json.');
 } else if (!rootLock.packages || !rootLock.packages['node_modules/supercompress-proxy']) {
-  console.error('❌ Missing node_modules/supercompress-proxy entry in root package-lock.json');
-  hasErrors = true;
+  recordError('Missing node_modules/supercompress-proxy entry in root package-lock.json', 'Run `npm install --package-lock-only` to sync root dependencies.');
 } else {
   const lockedDep = rootLock.packages['node_modules/supercompress-proxy'];
   if (!lockedDep.version || lockedDep.version !== proxyVersion) {
-    console.error(`❌ Mismatch: Root package-lock.json has supercompress-proxy locked to version ${lockedDep.version || 'unknown'}, expected ${proxyVersion}`);
-    hasErrors = true;
+    recordError(
+      `Mismatch: Root package-lock.json has supercompress-proxy locked to version ${lockedDep.version || 'unknown'}, expected ${proxyVersion}`,
+      `Run \`npm install supercompress-proxy@${proxyVersion} --package-lock-only\` to sync root lockfile.`
+    );
   } else {
     console.log(`✅ Root package-lock.json has supercompress-proxy locked to version ${proxyVersion}`);
   }
 
   // Verify resolved tarball URL matches current version
   if (!lockedDep.resolved) {
-    console.error('❌ Missing resolved artifact URL for supercompress-proxy in root package-lock.json');
-    hasErrors = true;
+    recordError('Missing resolved artifact URL for supercompress-proxy in root package-lock.json', 'Run `npm install --package-lock-only` to populate resolved URLs.');
   } else if (!lockedDep.resolved.includes(`-${proxyVersion}.tgz`)) {
-    console.error(`❌ Mismatch: Root package-lock.json supercompress-proxy resolved URL (${lockedDep.resolved}) does not match current version ${proxyVersion}`);
-    hasErrors = true;
+    recordError(
+      `Mismatch: Root package-lock.json supercompress-proxy resolved URL (${lockedDep.resolved}) does not match current version ${proxyVersion}`,
+      `Run \`npm install supercompress-proxy@${proxyVersion} --package-lock-only\` to update resolved artifact URL.`
+    );
   } else {
     console.log(`✅ Root package-lock.json supercompress-proxy resolved artifact matches ${proxyVersion}`);
   }
 
   if (!lockedDep.integrity) {
-    console.error('❌ Missing integrity digest for supercompress-proxy in root package-lock.json');
-    hasErrors = true;
+    recordError('Missing integrity digest for supercompress-proxy in root package-lock.json', 'Run `npm install --package-lock-only` to refresh integrity checksums.');
   } else {
     console.log('✅ Root package-lock.json supercompress-proxy integrity present');
   }
@@ -108,24 +117,25 @@ if (!rootLock) {
 
 // 5. Public site / docs pins must match proxy version (OSS-facing surfaces)
 const publicPins = [
-  { file: 'web/docs/coding-agents.html', needle: `v${proxyVersion}` },
-  { file: 'web/docs/coding-agents.html', needle: `# → ${proxyVersion}` },
-  { file: 'web/index.html', needle: `"softwareVersion": "${proxyVersion}"` },
-  { file: 'web/ai-search.json', needle: `supercompress-proxy@${proxyVersion}` },
-  { file: 'web/llms.txt', needle: `supercompress-proxy@${proxyVersion}` },
+  { file: 'web/docs/coding-agents.html', needle: `v${proxyVersion}`, label: 'version kicker' },
+  { file: 'web/docs/coding-agents.html', needle: `# → ${proxyVersion}`, label: 'CLI version output' },
+  { file: 'web/index.html', needle: `"softwareVersion": "${proxyVersion}"`, label: 'schema softwareVersion' },
+  { file: 'web/ai-search.json', needle: `supercompress-proxy@${proxyVersion}`, label: 'ai-search dependency pin' },
+  { file: 'web/llms.txt', needle: `supercompress-proxy@${proxyVersion}`, label: 'llms.txt install pin' },
 ];
 
-for (const { file, needle } of publicPins) {
+for (const { file, needle, label } of publicPins) {
   const fullPath = path.join(repoRoot, file);
   if (!fs.existsSync(fullPath)) {
-    console.error(`❌ Missing public pin file: ${file}`);
-    hasErrors = true;
+    recordError(`Missing public pin file: ${file}`, `Ensure file ${file} exists in repo.`);
     continue;
   }
   const text = fs.readFileSync(fullPath, 'utf8');
   if (!text.includes(needle)) {
-    console.error(`❌ Mismatch: ${file} missing pin '${needle}' (expected proxy ${proxyVersion})`);
-    hasErrors = true;
+    recordError(
+      `Mismatch: ${file} missing ${label || 'pin'} '${needle}' (expected proxy ${proxyVersion})`,
+      `Update ${file} to reference version '${proxyVersion}'.`
+    );
   } else {
     console.log(`✅ ${file} pin matches '${needle}'`);
   }
@@ -133,6 +143,13 @@ for (const { file, needle } of publicPins) {
 
 if (hasErrors) {
   console.error('\n❌ Version consistency check failed!');
+  if (remediationHints.length > 0) {
+    console.error('\n🔧 Suggested Remediation:');
+    remediationHints.forEach(({ error, hint }, i) => {
+      console.error(`  ${i + 1}. [${error}]`);
+      console.error(`     👉 Fix: ${hint}`);
+    });
+  }
   process.exit(1);
 } else {
   console.log('\n🎉 All version consistency checks passed successfully!');


### PR DESCRIPTION
Fixes #133

### Summary
Enhances `scripts/check-versions.js` to collect actionable remediation hints across all fail-closed checks (lockfiles, root dependency pins, resolved tarball URLs, integrity digests, and public documentation pins). When version checks fail, it outputs a clean, structured remediation list with the exact commands needed to re-sync.

---

### 🔍 Changes Made
1. **Remediation Collector**:
   - Replaced raw `console.error` calls with a `recordError(msg, hint)` helper that associates each failure with a concrete remediation command.
2. **Actionable Fix Hints**:
   - **Proxy Lockfile mismatch**: Provides `npm --prefix packages/proxy install --package-lock-only` or `npm version` command.
   - **Root package.json / package-lock.json mismatch**: Provides exact `npm install supercompress-proxy@<version> --package-lock-only` command.
   - **Public doc pins (HTML / JSON / llms.txt)**: Identifies the exact file and pin label needing update.
3. **Remediation Summary**:
   - If `hasErrors` is true, prints a numbered `🔧 Suggested Remediation:` block detailing every required fix before exiting with code 1.

---

### ✅ Verification
- `npm run check:version` ➔ **All version consistency checks passed successfully**
- Tested intentional version mismatch ➔ Correctly surfaced failures with numbered remediation block and exited with code 1.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes version-check error reporting and adds a numbered remediation summary for lockfile, dependency, artifact, integrity, and public-documentation failures.
- Introduces a shared `recordError` collector for failures and remediation hints.
- Adds targeted synchronization commands and file-update guidance.
- Labels public documentation pins to make mismatch output more specific.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, though the ineffective `npm version` remediation should be removed or corrected.

Error detection and exit behavior remain intact, but the first command suggested for a proxy lockfile mismatch cannot perform the advertised repair under default npm configuration.

**Files Needing Attention:** scripts/check-versions.js

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/check-versions.js | Adds structured remediation output, but one suggested proxy lockfile command is rejected by npm because it requests the package's existing version. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: surface version-check failures with ..."](https://github.com/supercompress/supercompress/commit/f391592a6a6429d44c169eac839d859fd7936893) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55496774)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->