### PR TITLE
ci: add remediation guidance to version consistency failures

### DIFF
--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -132,6 +132,10 @@ for (const { file, needle } of publicPins) {
 }
 
 if (hasErrors) {
+  console.error('\nRemediation:');
+  console.error('  1. Align packages/proxy/package.json with packages/proxy/package-lock.json.');
+  console.error('  2. Update package.json and package-lock.json to the same supercompress-proxy version.');
+  console.error('  3. Update the public version pins reported above, then rerun: npm run check:version');
   console.error('\n❌ Version consistency check failed!');
   process.exit(1);
 } else {


### PR DESCRIPTION
## Summary
- show concise remediation steps when the version consistency check fails
- point contributors to the package, lockfile, and public version pins to reconcile

## Validation
- npm run check:version
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves version-consistency failure output with concise remediation guidance.
- Directs contributors to align the proxy package manifest and lockfile.
- Calls out root dependency metadata and public version pins.
- Preserves the existing failure status and successful-check behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change only adds guidance to the established failure branch, and the instructions match the version relationships enforced by the script.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/check-versions.js | Adds accurate remediation messages to the existing error path without changing validation logic or exit behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add version check remediation guidan..."](https://github.com/supercompress/supercompress/commit/35b3fac627ef75bc415cfb9319e6884f876f8944) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58020534)</sub>

**Context used:**

- Knowledge Base — [Automation, release, and validation](https://app.greptile.com/supercompress/-/custom-context/knowledge-base/supercompress/supercompress/-/docs/automation-release-and-validation.md)

<!-- /greptile_comment -->