### PR TITLE
fix(web): credits hint matches $1/1M

### DIFF
--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -1083,7 +1083,7 @@ npm exec supercompress setup</pre>
         <span class="dash-credits-currency" aria-hidden="true">$</span>
         <input class="dash-field-input dash-credits-amount" id="credits-amount" type="number" inputmode="decimal" min="10" max="1000" step="1" value="10" />
       </div>
-      <p class="dash-credits-hint" id="credits-hint">About 33M tokens · $10 minimum</p>
+      <p class="dash-credits-hint" id="credits-hint">About 10M tokens · $10 minimum</p>
       <label class="dash-credits-auto">
         <input type="checkbox" id="credits-auto-recharge" checked />
         <span>Auto-recharge this amount when balance hits $0</span>


### PR DESCRIPTION
Follow-up to #143: dashboard credits hint still said ~33M.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the dashboard’s default credits hint to match the current $1-per-million-token pricing.
- Changes the $10 estimate from about 33M tokens to about 10M tokens.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The revised dashboard hint correctly represents the current $1-per-million-token rate, and the existing dynamic rendering path remains consistent with that value.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| web/dashboard.html | Corrects the static credits estimate to align with the current billing rate; no actionable issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): credits hint matches $1/1M ($1..."](https://github.com/supercompress/supercompress/commit/0e9338ae7932a9886a48e641a3c865883605e282) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58482837)</sub>

<!-- /greptile_comment -->