### PR TITLE
chore: ignore local kaggle/launch blobs in Vercel uploads

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -54,3 +54,23 @@ scripts/drain_weekly_emails.py
 scripts/dev.supercompress.welcome-drain.plist
 scripts/outreach_suppression.py
 .env.*
+
+# Local / non-prod blobs (SEO deploy hygiene)
+kaggle
+kaggle/**
+launch
+launch/**
+graphify-out
+graphify-out/**
+checkpoints/**
+.local
+.local/**
+LAUNCH_TODAY.md
+docs/goals
+docs/goals/**
+brand
+brand/**
+brand-pack
+brand-pack/**
+games
+games/**


### PR DESCRIPTION
## Summary
- Extends `.vercelignore` so local `kaggle/`, `launch/`, and similar blobs never upload during prod deploys (was attempting ~2.9GB).

## Test plan
- [x] Production SEO URLs return 200 after deploy
- [x] `POST api.supercompress.dev/compress` returns 401 (not 3xx)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to exclude local and non-production files, including generated outputs, checkpoints, local state, notes, documentation, branding assets, and game-related files.
  * These files will no longer be included in Vercel deployments, helping keep published builds focused on production content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents local, generated, and non-production blobs from being included in Vercel deployment uploads.
- Adds `.vercelignore` entries for Kaggle data, launch artifacts, checkpoints, local state, planning documents, brand assets, and games.
- Preserves the configured production build inputs and `web/` deployment output.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the newly ignored paths are not required by the configured production build or runtime.

Vercel builds from the existing `web/` and `api/` inputs, while the added patterns cover local, generated, training, and non-production artifacts with no reachable deployment dependency.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .vercelignore | Adds deployment exclusions for local and generated artifacts without excluding any configured production build input. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: ignore local kaggle/launch blobs ..."](https://github.com/supercompress/supercompress/commit/61835d3f83e17c13bf389f50edb69757d8c12369) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60871584)</sub>

<!-- /greptile_comment -->