### PR TITLE
fix(engine): keep distinct ids when deduping severe log lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
         run: node api/stats.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
+      - name: Compress engine log-dedup unit tests
+        run: node web/assets/js/compress-engine.test.js
       - name: Proxy package tests
         run: |
           cd packages/proxy

--- a/packages/proxy/src/assets/compress-engine.js
+++ b/packages/proxy/src/assets/compress-engine.js
@@ -237,6 +237,8 @@
     void question;
     const result = [];
     const seenFingerprints = new Map();
+    // fingerprint -> index in `result` of the line that carries its marker.
+    const repeatMarkers = new Map();
     const traceAccum = [];
 
     function flushTrace() {
@@ -272,9 +274,15 @@
         continue;
       }
 
+      // Severity decides how aggressively two lines may be treated as the same.
+      // Digit-blind fingerprinting is what makes INFO/DEBUG noise collapse, but
+      // on WARN/ERROR/FATAL the digits ARE the evidence: order ids, amounts,
+      // ports and status codes differ only in their digits, so folding them
+      // together deletes the answer the query is asking for.
+      const severe = /\b(WARN|WARNING|ERROR|FATAL|SEVERE|CRIT|CRITICAL)\b/i.test(trimmed);
       const fingerprint = trimmed
         .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?/g, "T")
-        .replace(/\d+/g, "#")
+        .replace(severe ? /(?!)/g : /\d+/g, "#")
         .replace(/\s+/g, " ")
         .trim();
 
@@ -284,9 +292,13 @@
         if (count <= 2) {
           result.push(line);
         } else if (count === 3) {
-          result.push(line + `  [repeated ${count - 1}x]`);
+          // Placeholder: the real suppressed count is only known once the whole
+          // input has been walked, so it is back-filled after the loop.
+          repeatMarkers.set(fingerprint, result.length);
+          result.push(line);
         }
-        // Further identical lines are collapsed (structural), not keyword-dropped.
+        // Further lines with this fingerprint are collapsed (structural), not
+        // keyword-dropped. They are counted so the marker can report how many.
       } else {
         seenFingerprints.set(fingerprint, 1);
         result.push(line);
@@ -294,6 +306,17 @@
     }
 
     flushTrace();
+
+    // Back-fill each marker with the number of lines actually suppressed, so
+    // the count is the real one rather than a fixed "2x". A group of exactly
+    // three occurrences suppresses none and keeps its line unmarked.
+    for (const [fingerprint, idx] of repeatMarkers) {
+      const suppressed = (seenFingerprints.get(fingerprint) || 0) - 3;
+      if (suppressed > 0 && result[idx] !== undefined) {
+        result[idx] = `${result[idx]}  [+${suppressed} more suppressed]`;
+      }
+    }
+
     const collapsed = [];
     let blankRun = 0;
     for (const line of result) {

--- a/web/assets/js/compress-engine.js
+++ b/web/assets/js/compress-engine.js
@@ -237,6 +237,8 @@
     void question;
     const result = [];
     const seenFingerprints = new Map();
+    // fingerprint -> index in `result` of the line that carries its marker.
+    const repeatMarkers = new Map();
     const traceAccum = [];
 
     function flushTrace() {
@@ -272,9 +274,15 @@
         continue;
       }
 
+      // Severity decides how aggressively two lines may be treated as the same.
+      // Digit-blind fingerprinting is what makes INFO/DEBUG noise collapse, but
+      // on WARN/ERROR/FATAL the digits ARE the evidence: order ids, amounts,
+      // ports and status codes differ only in their digits, so folding them
+      // together deletes the answer the query is asking for.
+      const severe = /\b(WARN|WARNING|ERROR|FATAL|SEVERE|CRIT|CRITICAL)\b/i.test(trimmed);
       const fingerprint = trimmed
         .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?/g, "T")
-        .replace(/\d+/g, "#")
+        .replace(severe ? /(?!)/g : /\d+/g, "#")
         .replace(/\s+/g, " ")
         .trim();
 
@@ -284,9 +292,13 @@
         if (count <= 2) {
           result.push(line);
         } else if (count === 3) {
-          result.push(line + `  [repeated ${count - 1}x]`);
+          // Placeholder: the real suppressed count is only known once the whole
+          // input has been walked, so it is back-filled after the loop.
+          repeatMarkers.set(fingerprint, result.length);
+          result.push(line);
         }
-        // Further identical lines are collapsed (structural), not keyword-dropped.
+        // Further lines with this fingerprint are collapsed (structural), not
+        // keyword-dropped. They are counted so the marker can report how many.
       } else {
         seenFingerprints.set(fingerprint, 1);
         result.push(line);
@@ -294,6 +306,17 @@
     }
 
     flushTrace();
+
+    // Back-fill each marker with the number of lines actually suppressed, so
+    // the count is the real one rather than a fixed "2x". A group of exactly
+    // three occurrences suppresses none and keeps its line unmarked.
+    for (const [fingerprint, idx] of repeatMarkers) {
+      const suppressed = (seenFingerprints.get(fingerprint) || 0) - 3;
+      if (suppressed > 0 && result[idx] !== undefined) {
+        result[idx] = `${result[idx]}  [+${suppressed} more suppressed]`;
+      }
+    }
+
     const collapsed = [];
     let blankRun = 0;
     for (const line of result) {

--- a/web/assets/js/compress-engine.test.js
+++ b/web/assets/js/compress-engine.test.js
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the log preprocessor's dedup step.
+ * Run: node web/assets/js/compress-engine.test.js
+ *
+ * Regression cover for the case where lines differing only in their digits
+ * were folded into one another, silently dropping distinct ids.
+ */
+const assert = require("assert");
+
+require("./compress-engine.js");
+const E = globalThis.SuperCompressEngine;
+const model = require("../data/model.json");
+
+const compress = (ctx, q) =>
+  E.compressAdaptive(ctx, q, model, { includeAnnotations: false }).compressed_text;
+
+// ── Distinct ids on severe lines must all survive ──────────────────────────
+// Every line here differs only in the order id, so a digit-blind fingerprint
+// treats all twenty as repeats of the first and keeps three.
+const ids = Array.from({ length: 20 }, (_, i) => `ORD-${10000 + i * 137}`);
+const declined = compress(
+  ids.map((id) => `2026-03-01T09:00:00Z ERROR payment declined for order ${id} code=51`).join("\n"),
+  "which orders were declined?"
+);
+for (const id of ids) {
+  assert.ok(declined.includes(id), `ERROR line for ${id} must survive dedup`);
+}
+
+// The same holds for the other severities that carry evidence.
+for (const level of ["WARN", "FATAL", "CRITICAL"]) {
+  const out = compress(
+    [1, 2, 3, 4, 5]
+      .map((n) => `2026-03-01T09:00:0${n}Z ${level} disk usage at ${80 + n}% on /dev/sda${n}`)
+      .join("\n"),
+    "which disk is nearly full?"
+  );
+  for (const n of [1, 2, 3, 4, 5]) {
+    assert.ok(out.includes(`/dev/sda${n}`), `${level}: /dev/sda${n} must survive dedup`);
+  }
+}
+
+// ── Low-severity noise must still collapse ────────────────────────────────
+// This is what the dedup exists for, and the fix must not cost it.
+const noise = Array.from(
+  { length: 200 },
+  (_, i) => `2026-03-01T09:00:00Z INFO processed request ${i} in ${10 + (i % 5)}ms`
+).join("\n");
+const collapsed = compress(noise, "any errors?");
+assert.ok(
+  collapsed.split("\n").length <= 5,
+  `INFO noise must still collapse, got ${collapsed.split("\n").length} lines`
+);
+
+// ── The marker reports the real number of suppressed lines ────────────────
+// 200 occurrences, three kept, so 197 are suppressed.
+const marker = collapsed.match(/\[\+(\d+) more suppressed\]/);
+assert.ok(marker, "a collapsed group must carry a marker");
+assert.strictEqual(Number(marker[1]), 197, "marker must count the lines actually suppressed");
+
+// Exactly three occurrences suppress nothing, so no marker is emitted.
+const exactlyThree = compress(
+  Array.from({ length: 3 }, () => "2026-03-01T09:00:00Z INFO cache warmed").join("\n"),
+  "was the cache warmed?"
+);
+assert.ok(
+  !/more suppressed/.test(exactlyThree),
+  "three occurrences suppress nothing and must not be marked"
+);
+
+// ── Ids that mix letters into digits were never affected; keep it that way ──
+const traceIds = ["7f3a91", "8b2c04", "9d5e17"];
+const traces = compress(
+  traceIds
+    .map((id, i) => `2026-04-0${i + 1}T11:0${i}:00Z ERROR upstream call failed trace_id=${id}`)
+    .join("\n"),
+  "which trace ids failed?"
+);
+for (const id of traceIds) {
+  assert.ok(traces.includes(id), `trace_id=${id} must survive`);
+}
+
+console.log("compress-engine.test.js: ok");


### PR DESCRIPTION
Fixes #149.

## Problem

The log preprocessor fingerprints a line by replacing every digit run with `#`, so lines that differ *only* in their numbers count as repeats of one another and everything past the third occurrence is dropped:

```
2026-03-01T09:00:00Z ERROR payment declined for order ORD-10000 code=51
2026-03-01T09:00:00Z ERROR payment declined for order ORD-10137 code=51
2026-03-01T09:00:00Z ERROR payment declined for order ORD-10274 code=51  [repeated 2x]
```

Twenty distinct declined orders go in, three come out. A model reading that answers *"three orders were declined"* with full confidence, and nothing in the output signals the other seventeen. That is the failure the README attributes to summarization — *"IDs, stack traces, and exact errors get soft"* — happening inside the compiler path that is sold as keeping evidence verbatim.

## Change

Severity decides how far two lines may be folded together:

- **INFO / DEBUG / TRACE** keep the digit-blind fingerprint. This is where the compression actually comes from and it is untouched.
- **WARN / ERROR / FATAL / SEVERE / CRIT** require literal equality, because there the digits *are* the evidence: order ids, amounts, percentages, ports and status codes differ only in their digits.

The marker is fixed separately. It reported `[repeated 2x]` regardless of the real number, emitted once at the third occurrence and never updated, so three collapsed lines and three thousand printed the same text. It now back-fills the count of lines actually suppressed once the walk is complete, and a group of exactly three suppresses nothing and stays unmarked:

```
2026-03-01T09:00:00Z INFO processed request 2 in 12ms  [+197 more suppressed]
```

## Measurements

1000-line log at a realistic 95% INFO / 5% distinct ERROR mix, query *"which orders were declined?"*:

| | tokens | saved | distinct ERROR ids kept |
|---|---:|---:|---:|
| before | 28196 → 190 | 99.3% | 3 / 50 |
| after | 28196 → 1783 | 93.7% | 50 / 50 |

Pure-INFO noise compresses identically before and after (200 lines → 3 lines, 5490 → 86 tokens), so the saving the dedup exists to produce is not affected, and 93.7% is still well clear of the ~65% headline.

## Tests

Adds `web/assets/js/compress-engine.test.js` — the first coverage of this path — and wires it into CI next to the other `web/assets/js` unit tests. It fails on the unpatched engine:

```
$ node web/assets/js/compress-engine.test.js
AssertionError [ERR_ASSERTION]: ERROR line for ORD-10411 must survive dedup
```

and passes on the patched one. It pins the distinct-id case across WARN/ERROR/FATAL/CRITICAL, asserts INFO noise still collapses, checks the marker reports the true count, checks that exactly three occurrences emit no marker, and keeps the alphanumeric-id case (`trace_id=7f3a91`) that was never affected.

Both tracked engine copies are updated through `node scripts/sync-compress-assets.js`, so the sync gate stays green.

## Note on scope

Which lines you are willing to lose is a product call, so treat this as a concrete proposal rather than the only shape. If you would rather keep folding severe lines and instead list the distinct values, or cap the group differently, say so and I will rework it — the test is worth keeping either way.

Two pre-existing local failures are unrelated to this change and fail identically on a clean `main`: `api/_lib/billing-ledger.test.js` and `web/assets/js/analytics-data.test.js` both need `firebase-admin`, which CI installs and my sandbox did not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log compression so severe log entries with different numeric values remain distinguishable.
  - Suppression markers now accurately report the number of hidden repeated lines.
  - Groups with exactly three identical entries are preserved without unnecessary markers.
  - Non-severe repetitive logs continue to be condensed while preserving meaningful trace identifiers.

- **Tests**
  - Added coverage for severity-aware deduplication, suppression counts, and repeated-log handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves numeric distinctions when deduplicating severe log records and reports the actual number of suppressed low-severity records.
- Selects literal fingerprints for severe lines while retaining digit-blind fingerprints for routine noise.
- Back-fills suppression annotations after counting the complete duplicate group.
- Adds regression coverage and wires it into CI.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking compression regression when low-severity message text contains a severe-level keyword.

The evidence-preservation and suppression-count changes are consistently propagated, but severity is inferred from the whole line, which can disable intended low-severity deduplication.

**Files Needing Attention:** web/assets/js/compress-engine.js and packages/proxy/src/assets/compress-engine.js

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| web/assets/js/compress-engine.js | Implements severity-sensitive fingerprints and accurate suppression markers, but the severity search can classify low-severity messages by payload words. |
| packages/proxy/src/assets/compress-engine.js | Synchronized proxy copy of the web engine, including the same overly broad severity classification. |
| web/assets/js/compress-engine.test.js | Adds focused regression coverage for distinct severe IDs, low-severity deduplication, and suppression counts. |
| .github/workflows/ci.yml | Adds the new compress-engine regression test to CI. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Input log line] --> B{Recognized as log?}
  B -- No --> C[Keep verbatim]
  B -- Yes --> D{Severe regex matches anywhere?}
  D -- Yes --> E[Literal fingerprint]
  D -- No --> F[Normalize digit runs]
  E --> G[Keep first three occurrences]
  F --> G
  G --> H{More than three?}
  H -- Yes --> I[Suppress remainder and back-fill count]
  H -- No --> J[Emit without marker]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(engine): keep distinct ids when dedu..."](https://github.com/supercompress/supercompress/commit/fc5d79ad9b88afa1f696c0c94410499e0209e704) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61025289)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->