### PR TITLE
fix(ccr): refuse a colliding storage key instead of returning the wrong original

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
         run: node api/stats.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
+      - name: CCR storage-key collision tests
+        run: node web/assets/js/compress-engine-ccr.test.js
       - name: Proxy package tests
         run: |
           cd packages/proxy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
           node packages/proxy/test/sse-stream.js
           node packages/proxy/test/protocol-safety.js
           node packages/proxy/test/uninstall-clean.js
+      - name: CCR storage-key collision tests
+        run: node web/assets/js/compress-engine-ccr.test.js
       - name: Billing ledger unit tests
         run: node api/_lib/billing-ledger.test.js
       - name: Credit amount helpers
@@ -92,8 +94,6 @@ jobs:
         run: node api/stats.test.js
       - name: Analytics aggregation unit tests
         run: node web/assets/js/analytics-data.test.js
-      - name: CCR storage-key collision tests
-        run: node web/assets/js/compress-engine-ccr.test.js
       - name: Proxy package tests
         run: |
           cd packages/proxy

--- a/api/_lib/engine.js
+++ b/api/_lib/engine.js
@@ -134,7 +134,23 @@ async function ccrStoreFirestore(hash, originalText, meta = {}) {
       token_count: originalText.split(/\s+/).length,
     };
     // Owner-scoped path (canonical). Never write a shared flat ccr/{hash} — that leaked across tenants.
-    await admin.firestore().doc(ccrOwnerDocPath(ownerUid, hash)).set(payload);
+    //
+    // simpleHash is a 32-bit rolling hash through Math.abs (~31 bits of key
+    // space), so two different originals of the same length can land on one
+    // key. A blind .set() then replaces a live block with unrelated content and
+    // retrieve hands the caller a well-formed block that is not the one its
+    // marker pointed at. Refuse the write instead: a miss is recoverable, a
+    // silent substitution is not.
+    const ref = admin.firestore().doc(ccrOwnerDocPath(ownerUid, hash));
+    const existing = await ref.get();
+    if (existing.exists) {
+      const prior = existing.data() || {};
+      if (typeof prior.original === "string" && prior.original !== originalText) {
+        console.warn("CCR store refused: key collision on", hash);
+        return false;
+      }
+    }
+    await ref.set(payload);
     return true;
   } catch (err) {
     console.warn("CCR store failed:", err.message);

--- a/api/v1/compress.js
+++ b/api/v1/compress.js
@@ -394,13 +394,18 @@ module.exports = async (req, res) => {
             );
             if (stored) {
               storedOk = true;
+              // `hash` is null when the whole-context key collided with a
+              // different original, so the engine refused to claim it. Only
+              // advertise a retrieve_url for a key we actually own.
               ccrInfo = {
-                hash: result.ccr.hash,
+                hash: result.ccr.hash || null,
                 marker_hashes: result.ccr.marker_hashes || [],
                 markers_count: result.ccr.markers_count || 0,
                 stored_hashes,
                 full_stored,
-                retrieve_url: `/retrieve?hash=${result.ccr.hash}`,
+                ...(result.ccr.hash
+                  ? { retrieve_url: `/retrieve?hash=${result.ccr.hash}` }
+                  : {}),
               };
             }
           } else {
@@ -439,7 +444,7 @@ module.exports = async (req, res) => {
 
     // CacheAligner: optionally wrap compressed text for provider prompt/prefix
     // caching. SuperCompress does not operate inside model KV cache.
-    const rawText = ccrInfo && ccrInfo.markers_count === 0
+    const rawText = ccrInfo && ccrInfo.markers_count === 0 && ccrInfo.hash
       ? compressedText + `\n[SC-Retrieve: ${ccrInfo.hash}]\n`
       : compressedText;
     const finalText = cache_prefix

--- a/packages/proxy/src/assets/compress-engine.js
+++ b/packages/proxy/src/assets/compress-engine.js
@@ -3871,9 +3871,18 @@
   const CCR_MAX_ENTRIES = 500;
   const CCR_TTL_MS = 48 * 60 * 60 * 1000;
 
+  // Returns the storage key, or null when the key is already taken by DIFFERENT
+  // content. simpleHash is a 32-bit rolling hash passed through Math.abs, so
+  // roughly 31 bits of key space: two different texts of the same length do
+  // collide, and a collision used to hand back a key whose stored content was
+  // somebody else's block. Refusing the key is the honest outcome — the caller
+  // then omits the marker, so retrieval can miss but never returns the wrong
+  // original.
   function ccrStore(original) {
     const hash = simpleHash(original);
     const now = Date.now();
+    const existing = contentCache.get(hash);
+    if (existing && existing.original !== original) return null;
     if (!contentCache.has(hash)) {
       if (contentCache.size >= CCR_MAX_ENTRIES) {
         // Proper LRU: evict least recently accessed (and any expired)
@@ -3991,7 +4000,9 @@
         if (blockStart !== -1 && blockTokens > 10) {
           const blockText = lines.slice(blockStart, i).join("\n");
           const blockHash = ccrStore(blockText);
-          markerLines.push({ lineIndex: i, hash: blockHash, tokens: blockTokens });
+          // null = the key collided with different content. Emitting a marker
+          // anyway would point the reader at somebody else's block.
+          if (blockHash) markerLines.push({ lineIndex: i, hash: blockHash, tokens: blockTokens });
         }
         blockStart = -1;
         blockTokens = 0;
@@ -4001,11 +4012,13 @@
     if (blockStart !== -1 && blockTokens > 10) {
       const blockText = lines.slice(blockStart).join("\n");
       const blockHash = ccrStore(blockText);
-      markerLines.push({
-        lineIndex: lines.length,
-        hash: blockHash,
-        tokens: blockTokens,
-      });
+      if (blockHash) {
+        markerLines.push({
+          lineIndex: lines.length,
+          hash: blockHash,
+          tokens: blockTokens,
+        });
+      }
     }
 
     // Build compressed text with markers interspersed at correct positions

--- a/web/assets/js/compress-engine-ccr.test.js
+++ b/web/assets/js/compress-engine-ccr.test.js
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for CCR storage-key safety.
+ * Run: node web/assets/js/compress-engine-ccr.test.js
+ *
+ * simpleHash is a 32-bit rolling hash passed through Math.abs, so roughly 31
+ * bits of key space: two different texts of the same length do collide. The
+ * invariant these tests pin is that a collision may cause a MISS, but must
+ * never hand back an original that does not belong to the key asked for.
+ */
+const assert = require("assert");
+
+require("./compress-engine.js");
+const E = globalThis.SuperCompressEngine;
+const model = require("../data/model.json");
+
+// A known colliding pair, found by scanning a fixed-width numeric field.
+// Both are 42 characters and both key to 16eb65e4_2a.
+const A = "ERROR checksum mismatch on shard 003499399";
+const B = "ERROR checksum mismatch on shard 004051035";
+
+assert.strictEqual(A.length, B.length, "the pair must be equal length");
+assert.notStrictEqual(A, B, "the pair must be different texts");
+assert.strictEqual(
+  E.simpleHash(A),
+  E.simpleHash(B),
+  "this pair is the regression fixture: it must still collide"
+);
+
+const ccr = (text) =>
+  E.compressCCR(text, "which shard is corrupt?", model, {
+    enableMarkers: true,
+    includeAnnotations: false,
+  });
+
+// Store A first, then B under the same key.
+const first = ccr(A);
+const second = ccr(B);
+
+// The key belongs to whoever stored it first; the loser gets no key at all
+// rather than a key pointing at someone else's content.
+assert.ok(first.ccr, "first compression must produce a ccr envelope");
+assert.strictEqual(first.ccr.hash, E.simpleHash(A), "first writer owns the key");
+assert.strictEqual(
+  second.ccr.hash,
+  null,
+  "a colliding second writer must not be handed the key it does not own"
+);
+
+// The invariant that matters: whatever comes back under a key must actually
+// hash to that key. Before the fix, retrieving B's key returned A's text.
+for (const key of [E.simpleHash(A), E.simpleHash(B)]) {
+  const got = E.ccrRetrieve(key);
+  if (got !== null) {
+    assert.strictEqual(
+      E.simpleHash(got),
+      key,
+      "retrieved original must hash back to the key it was fetched with"
+    );
+    assert.strictEqual(got, A, "the stored original is the first writer's");
+  }
+}
+
+// A marker is only emitted for a block the engine actually owns, so no
+// retrieve_url can point at content belonging to a different original.
+for (const hash of second.ccr.marker_hashes || []) {
+  const got = E.ccrRetrieve(hash);
+  if (got !== null) {
+    assert.strictEqual(E.simpleHash(got), hash, "every emitted marker must resolve to its own content");
+  }
+}
+
+// Re-storing identical content is not a collision and must keep working.
+const again = ccr(A);
+assert.strictEqual(again.ccr.hash, E.simpleHash(A), "identical content keeps its key");
+assert.strictEqual(E.ccrRetrieve(E.simpleHash(A)), A, "identical content still retrievable");
+
+console.log("compress-engine-ccr.test.js: ok");

--- a/web/assets/js/compress-engine.js
+++ b/web/assets/js/compress-engine.js
@@ -3871,9 +3871,18 @@
   const CCR_MAX_ENTRIES = 500;
   const CCR_TTL_MS = 48 * 60 * 60 * 1000;
 
+  // Returns the storage key, or null when the key is already taken by DIFFERENT
+  // content. simpleHash is a 32-bit rolling hash passed through Math.abs, so
+  // roughly 31 bits of key space: two different texts of the same length do
+  // collide, and a collision used to hand back a key whose stored content was
+  // somebody else's block. Refusing the key is the honest outcome — the caller
+  // then omits the marker, so retrieval can miss but never returns the wrong
+  // original.
   function ccrStore(original) {
     const hash = simpleHash(original);
     const now = Date.now();
+    const existing = contentCache.get(hash);
+    if (existing && existing.original !== original) return null;
     if (!contentCache.has(hash)) {
       if (contentCache.size >= CCR_MAX_ENTRIES) {
         // Proper LRU: evict least recently accessed (and any expired)
@@ -3991,7 +4000,9 @@
         if (blockStart !== -1 && blockTokens > 10) {
           const blockText = lines.slice(blockStart, i).join("\n");
           const blockHash = ccrStore(blockText);
-          markerLines.push({ lineIndex: i, hash: blockHash, tokens: blockTokens });
+          // null = the key collided with different content. Emitting a marker
+          // anyway would point the reader at somebody else's block.
+          if (blockHash) markerLines.push({ lineIndex: i, hash: blockHash, tokens: blockTokens });
         }
         blockStart = -1;
         blockTokens = 0;
@@ -4001,11 +4012,13 @@
     if (blockStart !== -1 && blockTokens > 10) {
       const blockText = lines.slice(blockStart).join("\n");
       const blockHash = ccrStore(blockText);
-      markerLines.push({
-        lineIndex: lines.length,
-        hash: blockHash,
-        tokens: blockTokens,
-      });
+      if (blockHash) {
+        markerLines.push({
+          lineIndex: lines.length,
+          hash: blockHash,
+          tokens: blockTokens,
+        });
+      }
     }
 
     // Build compressed text with markers interspersed at correct positions


### PR DESCRIPTION
Fixes #150.

## Problem

CCR addresses stored originals by `simpleHash`, a 32-bit rolling hash passed through `Math.abs`, leaving roughly 31 bits of key space. Two different texts of the same length collide readily — I found a pair by scanning a fixed-width numeric field and stopping at the first repeat, about four million tries:

```
"ERROR checksum mismatch on shard 003499399"
"ERROR checksum mismatch on shard 004051035"
```

Both key to `16eb65e4_2a`.

On a collision both storage paths lost data, in opposite directions:

- **In process** — `ccrStore` returned the taken key anyway while keeping the **first** block, so `ccrRetrieve` handed back someone else's content.
- **Server** — `ccrStoreFirestore` wrote with `.set()`, so the **last** writer overwrote a live block and a marker minted earlier resolved to unrelated text.

Either way the caller got a well-formed, plausible block that was not the one its marker pointed at, with no error and no way to detect the substitution. That breaks the one guarantee CCR exists to provide.

## Change

This deliberately does **not** change the key format. Moving to a cryptographic digest is the better long-term answer, but it drags a TTL migration behind it (`isValidHash()` in `api/retrieve.js` would need to accept both shapes for 48 hours), and that is your call rather than mine. This makes a collision fail loudly instead:

- `ccrStore` returns `null` when the key is held by different content, and `compressCCR` omits that block's marker rather than minting one that resolves to the wrong original.
- `ccrStoreFirestore` reads before writing and refuses to replace a document whose `original` differs.
- The API only advertises a `retrieve_url` for a key it actually owns, and the trailing `[SC-Retrieve: …]` marker is only appended when there is a real hash behind it.

A miss is recoverable; a silent substitution is not.

## Tests

Adds `web/assets/js/compress-engine-ccr.test.js` and wires it into CI. It pins the colliding pair as a fixture, so the test still means something if the hash function is later replaced, and asserts the invariant that actually matters: **anything returned under a key must hash back to that key**.

On the unpatched engine:

```
$ node web/assets/js/compress-engine-ccr.test.js
AssertionError [ERR_ASSERTION]: a colliding second writer must not be handed the key it does not own
```

It also checks that re-storing identical content is not treated as a collision, which is the common case and must keep working.

## Notes

Both tracked engine copies are updated through `node scripts/sync-compress-assets.js`, so the sync gate stays green.

This touches `web/assets/js/compress-engine.js` in a different region from #151, so the two should merge independently, but I am happy to rebase whichever lands second.

Two pre-existing local failures are unrelated and fail identically on a clean `main`: `api/_lib/billing-ledger.test.js` and `web/assets/js/analytics-data.test.js` both need `firebase-admin`, which CI installs and my sandbox did not.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented compressed content from being overwritten or incorrectly retrieved when different content produces the same storage key.
  - Retrieval links are now provided only when valid content ownership can be confirmed.
  - Retrieval markers are no longer emitted when content cannot be safely stored or verified.
  - Re-saving identical content continues to preserve its existing key and remain retrievable.

- **Tests**
  - Added coverage for storage-key collisions, retrieval integrity, and marker correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes CCR collision handling so process-local and Firestore storage refuse keys already associated with different content, and it avoids advertising unavailable retrieval hashes.
- Adds a regression test using a known `simpleHash` collision and runs it in CI.
- Updates the browser and proxy engine copies to suppress retrieval markers for rejected keys.
- Adjusts the compression API to publish retrieval metadata only for successfully owned hashes.

<h3>Confidence Score: 3/5</h3>

The PR does not appear safe to merge because concurrent Firestore writers can still cause wrong-content retrieval, while rejected block collisions can still make removed content unrecoverable.

The separate Firestore read and write leave the reported collision race intact, and marker suppression still removes colliding dropped blocks without preserving their original content elsewhere.

**Files Needing Attention:** api/_lib/engine.js and web/assets/js/compress-engine.js

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/_lib/engine.js | Adds a Firestore read-before-write collision check and returns failure when an existing string-valued original differs. |
| api/v1/compress.js | Makes full-context retrieval metadata and trailing markers conditional on a non-null owned hash. |
| web/assets/js/compress-engine.js | Makes process-local CCR storage reject colliding content and suppresses markers for rejected block hashes. |
| packages/proxy/src/assets/compress-engine.js | Mirrors the browser engine's process-local collision refusal and marker suppression. |
| web/assets/js/compress-engine-ccr.test.js | Adds deterministic coverage for sequential process-local collisions and identical-content re-storage. |
| .github/workflows/ci.yml | Runs the new CCR storage-key collision regression test in CI. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Compression caller
  participant E as CCR engine
  participant S as CCR storage
  participant R as Retrieve API
  C->>E: Compress original text
  E->>S: Store by simpleHash
  S-->>E: Owned hash or collision refusal
  alt Hash owned
    E-->>C: Compressed text and retrieval marker
    C->>R: Retrieve owned hash
    R-->>C: Stored original
  else Collision refused
    E-->>C: Compressed text without rejected hash
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: move the CCR test step so it does no..."](https://github.com/supercompress/supercompress/commit/4fad9b4773e93349ac6aec858573443e56d5611b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61025947)</sub>

<!-- /greptile_comment -->